### PR TITLE
Start Harbor analyzer from run lifecycle

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -161,9 +161,11 @@ ROLLOUT=1 bash start.sh
 
 ## Harbor Monitor
 
-`start.sh` automatically starts one monitor for each Harbor benchmark run.
-Set `HARBOR_MONITOR_ENABLED=0` to disable it. The monitor reads Fleet queue
-artifacts for local datasets and Harbor job/trial results for registry datasets.
+`start.sh` automatically starts one monitor for each Harbor benchmark run,
+including detached zellij runs and command-mode runs such as
+`bash start.sh ./harboropik.sh`. Set `HARBOR_MONITOR_ENABLED=0` to disable it.
+The monitor reads Fleet queue artifacts for local datasets and Harbor job/trial
+results for registry datasets.
 
 Equivalent queue monitor command:
 
@@ -207,6 +209,28 @@ All files are refreshed on each sample. The actual action is
 | Every task has a terminal queue record | `stop` |
 
 Automatic restart is only used when tasks remain and no worker is alive.
+
+## Harbor Analyzer
+
+`start.sh` can also start the Pi-backed analyzer under the same Harbor run
+lifecycle. It is disabled by default because it may consume model calls:
+
+```bash
+HARBOR_ANALYZER_ENABLED=1 ./start.sh --detach
+```
+
+For a foreground run without zellij, pass the Harbor command to `start.sh`:
+
+```bash
+HARBOR_ANALYZER_ENABLED=1 bash start.sh ./harboropik.sh
+```
+
+The analyzer depends on the monitor. It follows
+`monitor/analyzer-handover-latest.json` and `monitor/analyzer-handoffs/`, writes
+reports under `$OUTPUT_PATH/analyzer`, and does not restart, stop, or otherwise
+control the benchmark run. Configure the model, Opik endpoint, dataset, workers,
+and task selection through `config.local.env`, `env.sh`, or environment
+overrides before starting the run.
 
 ## More Details
 

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -119,6 +119,12 @@ Typical dataset paths:
 | `TB_AGENT_SETUP_TIMEOUT_MULTIPLIER` | Agent setup timeout multiplier |
 | `HARBOR_ONLINE_ANALYSIS` | Enables console-only online analysis, default `0` |
 | `HARBOR_EARLY_STOP` | Stops the current SETA task on matching task-blocking online-analysis events when set to `1`, default `0` |
+| `HARBOR_ANALYZER_ENABLED` | Starts the Pi-backed analyzer from `start.sh` after the monitor is ready, default `0` |
+| `HARBOR_ANALYZER_MODE` | Analyzer launch mode, currently only `handover-follow` |
+| `HARBOR_ANALYZER_OUTPUT_DIR` | Analyzer output directory, defaults to `<OUTPUT_PATH>/analyzer` |
+| `HARBOR_ANALYZER_POLL_INTERVAL` | Analyzer handover polling interval in seconds, default `5` |
+| `HARBOR_ANALYZER_TIMEOUT` | Per-task analyzer Pi timeout in seconds, default `900` |
+| `HARBOR_ANALYZER_MAX_CONCURRENCY` | Maximum concurrent per-task analyzer Pi subprocesses, default `1` |
 
 ## RL Rollout Variables
 
@@ -263,3 +269,9 @@ Outputs:
 <OUTPUT_PATH>/online-analysis/environment-events.jsonl
 <OUTPUT_PATH>/online-analysis/environment-summary.json
 ```
+
+When `HARBOR_ANALYZER_ENABLED=1`, `start.sh` also starts
+`scripts/analyzer_subagent.py --follow` after the monitor has produced
+`monitor/analyzer-handover-latest.json`. The analyzer consumes that latest file
+and `monitor/analyzer-handoffs/`, writes reports under `<OUTPUT_PATH>/analyzer`,
+and remains outside the monitor's restart/stop decision logic.

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -107,6 +107,14 @@ HARBOR_ANALYZER_BASE_URL="${HARBOR_ANALYZER_BASE_URL:-${BASE_URL:+${BASE_URL}/v1
 HARBOR_ANALYZER_MODEL="${HARBOR_ANALYZER_MODEL:-$MODEL}"
 HARBOR_ANALYZER_PI_PROVIDER="${HARBOR_ANALYZER_PI_PROVIDER:-harbor-analyzer}"
 HARBOR_ANALYZER_NO_PROXY="${HARBOR_ANALYZER_NO_PROXY:-0}"
+HARBOR_ANALYZER_ENABLED="${HARBOR_ANALYZER_ENABLED:-0}"
+HARBOR_ANALYZER_MODE="${HARBOR_ANALYZER_MODE:-handover-follow}"
+HARBOR_ANALYZER_OUTPUT_DIR="${HARBOR_ANALYZER_OUTPUT_DIR:-${OUTPUT_PATH}/analyzer}"
+HARBOR_ANALYZER_PID_FILE="${HARBOR_ANALYZER_PID_FILE:-${RUNTIME_DIR}/harbor-analyzer.pid}"
+HARBOR_ANALYZER_LOG_FILE="${HARBOR_ANALYZER_LOG_FILE:-${RUNTIME_DIR}/harbor-analyzer.log}"
+HARBOR_ANALYZER_POLL_INTERVAL="${HARBOR_ANALYZER_POLL_INTERVAL:-5}"
+HARBOR_ANALYZER_TIMEOUT="${HARBOR_ANALYZER_TIMEOUT:-900}"
+HARBOR_ANALYZER_MAX_CONCURRENCY="${HARBOR_ANALYZER_MAX_CONCURRENCY:-1}"
 TRACE_TO_OPIK="${TRACE_TO_OPIK:-true}"
 # The single switch for running without Opik, shared by every script that
 # sources env.sh (harboropik.sh, run_harbor_worker.sh). Anything except an
@@ -368,7 +376,7 @@ export SCRIPT_DIR REPO_ROOT AGENTS_DIR TASKS_DIR HARBOR_CLAUDE_CODE_DIR HARBOR_O
 export HARBOR_ROOT DATASET_PATH DATASET_NAME METRIC_MODE OUTPUT_ROOT OUTPUT_PATH TASK_SOURCE_FILE TASK_FILE QUEUE_DIR RUNTIME_DIR LAYOUT_FILE JOBS_ROOT
 export HARBOR_ONLINE_ANALYSIS HARBOR_ONLINE_ANALYSIS_POLL_INTERVAL HARBOR_ONLINE_ANALYSIS_DIR HARBOR_ONLINE_ANALYSIS_PID_FILE HARBOR_ONLINE_ANALYSIS_LOG_FILE HARBOR_EARLY_STOP HARBOR_ZELLIJ_CLOSE_ON_COMPLETE
 export HARBOR_MONITOR_ENABLED HARBOR_MONITOR_DIR HARBOR_MONITOR_PID_FILE HARBOR_MONITOR_LOG_FILE HARBOR_BENCHMARK_PID_FILE HARBOR_BENCHMARK_EXIT_FILE HARBOR_JOB_DIR_FILE HARBOR_MONITOR_RESTART_CMD HARBOR_MONITOR_STOP_CMD HARBOR_MONITOR_INTERVAL HARBOR_MONITOR_STARTUP_GRACE HARBOR_MONITOR_STALL_SECONDS HARBOR_MONITOR_MAX_RETRIES HARBOR_MONITOR_CONFIGURED_TIMEOUT
-export API_KEY BASE_URL HARBOR_ANALYZER_API_KEY HARBOR_ANALYZER_BASE_URL HARBOR_ANALYZER_MODEL HARBOR_ANALYZER_PI_PROVIDER HARBOR_ANALYZER_NO_PROXY TRACE_TO_OPIK OPIK_URL OPIK_URL_OVERRIDE OPIK_BASE OPIK_MODE OPIK_PROJECT_NAME OPIK_API_KEY OPIK_WORKSPACE CC_OPIK_DEBUG
+export API_KEY BASE_URL HARBOR_ANALYZER_API_KEY HARBOR_ANALYZER_BASE_URL HARBOR_ANALYZER_MODEL HARBOR_ANALYZER_PI_PROVIDER HARBOR_ANALYZER_NO_PROXY HARBOR_ANALYZER_ENABLED HARBOR_ANALYZER_MODE HARBOR_ANALYZER_OUTPUT_DIR HARBOR_ANALYZER_PID_FILE HARBOR_ANALYZER_LOG_FILE HARBOR_ANALYZER_POLL_INTERVAL HARBOR_ANALYZER_TIMEOUT HARBOR_ANALYZER_MAX_CONCURRENCY TRACE_TO_OPIK OPIK_URL OPIK_URL_OVERRIDE OPIK_BASE OPIK_MODE OPIK_PROJECT_NAME OPIK_API_KEY OPIK_WORKSPACE CC_OPIK_DEBUG
 export CLAUDE_CODE_VERSION CLAUDE_CODE_TGZ_BASENAME LOCAL_WHEEL_DIR LOCAL_WHEEL_PORT LOCAL_WHEEL_PORT_ATTEMPTS LOCAL_WHEEL_HOST_IP
 export TB_LOCAL_WHEEL_SERVER_URL TB_LOCAL_CLAUDE_TGZ_URL TB_REMOTE_WHEEL_SERVER_URLS EFFECTIVE_WHEEL_URL_FILE EFFECTIVE_CLAUDE_TGZ_URL_FILE LOCAL_DEPS_LOG_FILE HARBOR_RUNNER_PREPARE HARBOR_OPIK_BIN HARBOR_RUNNER_PREPARE_STATUS_FILE HARBOR_RUNNER_PREPARE_LOG_FILE
 export TB_DATASET_GIT_URL TB_PATH TB_LIMIT TB_RUNS TB_AGENT TB_AGENT_IMPORT_PATH TB_MODEL INCLUDE_TASKS TB_DRY_RUN TB_MIN_TEST TB_MIN_TEST_INCLUDE_TASK
@@ -402,6 +410,18 @@ harbor_agent_is_opencode() {
 
 harbor_agent_is_claude_code() {
   [[ "$AGENT" == "claude-code" ]]
+}
+
+harbor_analyzer_pid_matches_run() {
+  local pid="$1" arg previous="" script_seen=0 run_seen=0 handover_seen=0
+  [[ "$pid" =~ ^[0-9]+$ && -r "/proc/$pid/cmdline" ]] || return 1
+  while IFS= read -r -d '' arg; do
+    [[ "$arg" == "$SCRIPT_DIR/scripts/analyzer_subagent.py" ]] && script_seen=1
+    [[ "$previous" == "--run-dir" && "$arg" == "$OUTPUT_PATH" ]] && run_seen=1
+    [[ "$previous" == "--handover" && "$arg" == "$HARBOR_MONITOR_DIR/analyzer-handover-latest.json" ]] && handover_seen=1
+    previous="$arg"
+  done < "/proc/$pid/cmdline"
+  [[ "$script_seen" == 1 && "$run_seen" == 1 && "$handover_seen" == 1 ]]
 }
 
 harbor_validate_agent() {
@@ -495,16 +515,44 @@ harbor_stop_monitor() {
 }
 
 harbor_reset_run_state() {
+  harbor_stop_analyzer
   harbor_stop_monitor
   harbor_stop_online_analysis
   rm -f "$QUEUE_DIR"/worker-*.current "$LOCK_FILE" "$WORKERS_READY_FILE" "$WORKERS_FAILED_FILE"
   rm -f "$NEXT_INDEX_FILE"
   rm -f "$OUTPUT_PATH/.monitor_state.json" "$HARBOR_MONITOR_LOG_FILE" "$HARBOR_BENCHMARK_PID_FILE" "$HARBOR_BENCHMARK_EXIT_FILE" "$HARBOR_JOB_DIR_FILE"
   rm -rf "$HARBOR_MONITOR_DIR"
+  rm -f "$HARBOR_ANALYZER_PID_FILE" "$HARBOR_ANALYZER_LOG_FILE" "$HARBOR_ANALYZER_OUTPUT_DIR/.analyzer_state.json"
   rm -f "$HARBOR_ONLINE_ANALYSIS_PID_FILE" "$HARBOR_ONLINE_ANALYSIS_LOG_FILE"
   rm -f "$HARBOR_ONLINE_ANALYSIS_DIR/environment-events.jsonl" "$HARBOR_ONLINE_ANALYSIS_DIR/environment-summary.json"
   : > "$QUEUE_DIR/done.txt"
   : > "$QUEUE_DIR/failed.txt"
+}
+
+harbor_stop_analyzer() {
+  [[ -f "$HARBOR_ANALYZER_PID_FILE" ]] || return 0
+  local pid sid signal_target
+  pid="$(cat "$HARBOR_ANALYZER_PID_FILE" 2>/dev/null || true)"
+  if [[ ! "$pid" =~ ^[0-9]+$ ]] || ! kill -0 "$pid" >/dev/null 2>&1; then
+    rm -f "$HARBOR_ANALYZER_PID_FILE"
+    return 0
+  fi
+  if ! harbor_analyzer_pid_matches_run "$pid"; then
+    echo "[ERROR] refusing to stop unrelated process from $HARBOR_ANALYZER_PID_FILE: pid=$pid" >&2
+    return 1
+  fi
+  sid="$(ps -o sid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  signal_target="$pid"
+  [[ "$sid" == "$pid" ]] && signal_target="-$pid"
+  kill -TERM -- "$signal_target" >/dev/null 2>&1 || true
+  for _ in $(seq 1 30); do
+    kill -0 "$pid" >/dev/null 2>&1 || break
+    sleep 1
+  done
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    kill -KILL -- "$signal_target" >/dev/null 2>&1 || true
+  fi
+  rm -f "$HARBOR_ANALYZER_PID_FILE"
 }
 
 harbor_generate_task_file() {

--- a/Agents/utils/common/Harbor/start.sh
+++ b/Agents/utils/common/Harbor/start.sh
@@ -143,6 +143,172 @@ harbor_start_monitor_if_enabled() {
   ) 9>"$RUNTIME_DIR/harbor-monitor.lock"
 }
 
+harbor_start_analyzer_if_enabled() {
+  [[ "$HARBOR_ANALYZER_ENABLED" == "1" ]] || return 0
+  [[ "$ROLLOUT" != "1" ]] || return 0
+  if [[ "$HARBOR_MONITOR_ENABLED" != "1" ]]; then
+    echo "[ERROR] cannot start Harbor analyzer because Harbor monitor is disabled" >&2
+    return 1
+  fi
+
+  (
+  flock 9
+  if [[ -f "$HARBOR_ANALYZER_PID_FILE" ]]; then
+    local existing_pid
+    existing_pid="$(cat "$HARBOR_ANALYZER_PID_FILE" 2>/dev/null || true)"
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" >/dev/null 2>&1; then
+      if harbor_analyzer_pid_matches_run "$existing_pid"; then
+        exit 0
+      fi
+      echo "[ERROR] refusing to replace unrelated process from $HARBOR_ANALYZER_PID_FILE: pid=$existing_pid" >&2
+      exit 1
+    fi
+    rm -f "$HARBOR_ANALYZER_PID_FILE"
+  fi
+
+  for _ in $(seq 1 50); do
+    [[ -f "$HARBOR_MONITOR_DIR/analyzer-handover-latest.json" ]] && break
+    sleep 0.1
+  done
+  if [[ ! -f "$HARBOR_MONITOR_DIR/analyzer-handover-latest.json" ]]; then
+    echo "[ERROR] cannot start Harbor analyzer before monitor handover exists" >&2
+    exit 1
+  fi
+
+  mkdir -p "$HARBOR_ANALYZER_OUTPUT_DIR" "$RUNTIME_DIR"
+  local analyzer_pid
+  case "$HARBOR_ANALYZER_MODE" in
+    handover-follow)
+      nohup setsid python3 "$SCRIPT_DIR/scripts/analyzer_subagent.py" \
+        --handover "$HARBOR_MONITOR_DIR/analyzer-handover-latest.json" \
+        --handoff-dir "$HARBOR_MONITOR_DIR/analyzer-handoffs" \
+        --run-dir "$OUTPUT_PATH" \
+        --queue-dir "$QUEUE_DIR" \
+        --agent "$AGENT" \
+        --output-dir "$HARBOR_ANALYZER_OUTPUT_DIR" \
+        --pi-provider "$HARBOR_ANALYZER_PI_PROVIDER" \
+        --pi-model "$HARBOR_ANALYZER_MODEL" \
+        --pi-base-url "$HARBOR_ANALYZER_BASE_URL" \
+        --pi-api-key-env HARBOR_ANALYZER_API_KEY \
+        --timeout "$HARBOR_ANALYZER_TIMEOUT" \
+        --max-concurrency "$HARBOR_ANALYZER_MAX_CONCURRENCY" \
+        --follow \
+        --poll-interval "$HARBOR_ANALYZER_POLL_INTERVAL" \
+        >>"$HARBOR_ANALYZER_LOG_FILE" 2>&1 &
+      analyzer_pid="$!"
+      ;;
+    *)
+      echo "[ERROR] unsupported HARBOR_ANALYZER_MODE=$HARBOR_ANALYZER_MODE" >&2
+      exit 1
+      ;;
+  esac
+  printf '%s\n' "$analyzer_pid" >"$HARBOR_ANALYZER_PID_FILE"
+  for _ in $(seq 1 50); do
+    if ! kill -0 "$analyzer_pid" >/dev/null 2>&1; then
+      rm -f "$HARBOR_ANALYZER_PID_FILE"
+      echo "[ERROR] Harbor analyzer exited during startup; see $HARBOR_ANALYZER_LOG_FILE" >&2
+      exit 1
+    fi
+    if harbor_analyzer_pid_matches_run "$analyzer_pid"; then
+      exit 0
+    fi
+    sleep 0.1
+  done
+  rm -f "$HARBOR_ANALYZER_PID_FILE"
+  echo "[ERROR] Harbor analyzer did not survive startup; see $HARBOR_ANALYZER_LOG_FILE" >&2
+  exit 1
+  ) 9>"$RUNTIME_DIR/harbor-analyzer.lock"
+}
+
+harbor_monitor_is_running_for_run() {
+  [[ "$HARBOR_MONITOR_ENABLED" == "1" && -f "$HARBOR_MONITOR_PID_FILE" ]] || return 1
+  local pid
+  pid="$(cat "$HARBOR_MONITOR_PID_FILE" 2>/dev/null || true)"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  harbor_monitor_pid_matches_run "$pid"
+}
+
+harbor_wait_for_monitor_completion() {
+  [[ "$HARBOR_MONITOR_ENABLED" == "1" && "$ROLLOUT" != "1" ]] || return 0
+  harbor_monitor_is_running_for_run || return 0
+  local timeout deadline
+  timeout="${HARBOR_ANALYZER_DRAIN_TIMEOUT:-60}"
+  deadline=$((SECONDS + timeout))
+  while (( SECONDS < deadline )); do
+    harbor_monitor_is_running_for_run || return 0
+    sleep 1
+  done
+  echo "[WARN] Harbor monitor still running after ${timeout}s analyzer shutdown wait; stopping analyzer anyway" >&2
+}
+
+harbor_analyzer_pending_drained() {
+  [[ -f "$HARBOR_MONITOR_DIR/analyzer-handover-latest.json" ]] || return 0
+  python3 - "$SCRIPT_DIR/scripts" \
+    "$HARBOR_MONITOR_DIR/analyzer-handover-latest.json" \
+    "$HARBOR_MONITOR_DIR/analyzer-handoffs" \
+    "$HARBOR_ANALYZER_OUTPUT_DIR/.analyzer_state.json" <<'PY'
+import sys
+import time
+from pathlib import Path
+
+scripts_dir = Path(sys.argv[1])
+sys.path.insert(0, str(scripts_dir))
+from analyzer_subagent import _load_follow_state, _pending_handovers  # noqa: E402
+
+latest_path = Path(sys.argv[2])
+handoff_dir = Path(sys.argv[3])
+state_path = Path(sys.argv[4])
+processed, failed = _load_follow_state(state_path)
+pending = _pending_handovers(
+    latest_path=latest_path,
+    handoff_dir=handoff_dir,
+    processed=processed,
+    failed=failed,
+    now=time.time(),
+)
+raise SystemExit(0 if not pending else 1)
+PY
+}
+
+harbor_wait_for_analyzer_drain() {
+  [[ "$HARBOR_ANALYZER_ENABLED" == "1" && "$ROLLOUT" != "1" ]] || return 0
+  [[ -f "$HARBOR_ANALYZER_PID_FILE" ]] || return 0
+  local pid timeout deadline
+  pid="$(cat "$HARBOR_ANALYZER_PID_FILE" 2>/dev/null || true)"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+  kill -0 "$pid" >/dev/null 2>&1 || return 0
+  timeout="${HARBOR_ANALYZER_DRAIN_TIMEOUT:-60}"
+  deadline=$((SECONDS + timeout))
+  while (( SECONDS < deadline )); do
+    kill -0 "$pid" >/dev/null 2>&1 || return 0
+    if harbor_analyzer_pending_drained; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "[WARN] Harbor analyzer still has pending handovers after ${timeout}s drain wait; stopping it" >&2
+}
+
+harbor_finish_analyzer_lifecycle() {
+  [[ "$HARBOR_ANALYZER_ENABLED" == "1" && "$ROLLOUT" != "1" ]] || return 0
+  harbor_wait_for_monitor_completion
+  harbor_wait_for_analyzer_drain
+  harbor_stop_analyzer || true
+}
+
+harbor_start_detached_analyzer_supervisor_if_enabled() {
+  [[ "$HARBOR_ANALYZER_ENABLED" == "1" && "$ROLLOUT" != "1" ]] || return 0
+  (
+    trap '' HUP
+    while harbor_monitor_is_running_for_run; do
+      sleep 5
+    done
+    harbor_wait_for_analyzer_drain
+    harbor_stop_analyzer || true
+  ) >>"$HARBOR_ANALYZER_LOG_FILE" 2>&1 &
+}
+
 harbor_init_run_dirs
 if [[ "$ROLLOUT" != "1" ]]; then
   harbor_validate_agent
@@ -175,8 +341,17 @@ if [[ $# -gt 0 ]]; then
   if [[ "$ROLLOUT" != "1" ]]; then
     harbor_start_online_analysis_if_enabled
     harbor_start_monitor_if_enabled
+    if ! harbor_start_analyzer_if_enabled; then
+      harbor_stop_monitor >/dev/null 2>&1 || true
+      exit 1
+    fi
   fi
-  exec "$@"
+  set +e
+  "$@"
+  command_rc="$?"
+  set -e
+  harbor_finish_analyzer_lifecycle
+  exit "$command_rc"
 fi
 
 if [[ "$ROLLOUT" != "1" ]] && ! harbor_uses_registry_dataset; then
@@ -229,10 +404,26 @@ if [[ "$DETACH_MODE" == "true" ]]; then
     zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
     exit 1
   fi
+  if ! harbor_start_analyzer_if_enabled; then
+    harbor_stop_monitor >/dev/null 2>&1 || true
+    zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+    zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+    exit 1
+  fi
+  harbor_start_detached_analyzer_supervisor_if_enabled
 
   printf '%s\n' "$ZELLIJ_SESSION_NAME"
   exit 0
 fi
 
 harbor_start_monitor_if_enabled
-exec env -u ZELLIJ_SESSION_NAME zellij --session "$ZELLIJ_SESSION_NAME" --new-session-with-layout "$LAYOUT_FILE"
+if ! harbor_start_analyzer_if_enabled; then
+  harbor_stop_monitor >/dev/null 2>&1 || true
+  exit 1
+fi
+set +e
+env -u ZELLIJ_SESSION_NAME zellij --session "$ZELLIJ_SESSION_NAME" --new-session-with-layout "$LAYOUT_FILE"
+zellij_rc="$?"
+set -e
+harbor_finish_analyzer_lifecycle
+exit "$zellij_rc"


### PR DESCRIPTION
## Why the change?

Harbor monitor already emits analyzer handovers, and the analyzer already supports follow mode, but they are not started under one run lifecycle. Users must launch the analyzer manually, which makes PID/log/reset behavior inconsistent with the monitor.

This PR migrates sii-system/sii-agent-fleet#95 to sii-system/agent-fleet.

## Summary of the change

- Add opt-in Harbor analyzer lifecycle settings in `env.sh`.
- Start the existing `analyzer_subagent.py --follow` after the monitor produces `analyzer-handover-latest.json`.
- Add run-scoped analyzer PID matching and reset cleanup.
- Drain analyzer handovers before shutdown in command and foreground zellij modes.
- Add a detached analyzer supervisor for detached zellij runs.
- Document the opt-in analyzer startup path.

## Other details

The analyzer remains disabled by default because it can consume model calls. The monitor still owns benchmark control decisions; the analyzer only consumes monitor handovers and writes reports.

Validation:
- `bash -n Agents/utils/common/Harbor/env.sh`
- `bash -n Agents/utils/common/Harbor/start.sh`
- `git diff --cached --check`

Not run:
- Harbor analyzer pytest tests because `pytest` is not installed in this environment.