### PR TITLE
CI: bump actions/checkout to v7.0.1 (Node 24)

### DIFF
--- a/.github/workflows/llm-pr-review.yml
+++ b/.github/workflows/llm-pr-review.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out trusted base revision
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false


### PR DESCRIPTION
## What
Bump `actions/checkout` in the LLM PR review workflow (`.github/workflows/llm-pr-review.yml`) from v4.3.1 (SHA `34e1148`) to v7.0.1 (SHA `3d3c42e`).

## Why
v4.3.1 ships the Node 20 runtime, which GitHub deprecated and now force-runs on Node 24, emitting a deprecation warning on every review run. v7.0.1 targets Node 24 natively, clearing the warning.

## Safety note
The step checks out the trusted `base.sha`, so v7's refusal to check out **fork PR head** code under `pull_request_target` (added in v7.0.0, refined in v7.0.1) does not apply here — and adds defense-in-depth on this trigger.

This PR is intentionally opened from a fork (`qiyuangong/agent-fleet`) so the `pull_request_target` review workflow runs the new checkout against a real fork PR.
