### PR TITLE
CI: bind LLM review job to llm-pr-review environment

### DIFF
--- a/.github/workflows/llm-pr-review.yml
+++ b/.github/workflows/llm-pr-review.yml
@@ -16,6 +16,7 @@ jobs:
   review:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    environment: llm-pr-review
     timeout-minutes: 15
     steps:
       - name: Check out trusted base revision


### PR DESCRIPTION
## What
Add `environment: llm-pr-review` to the `review` job in `.github/workflows/llm-pr-review.yml`.

## Why
The review config lives under the **`llm-pr-review` environment**:
- var `LLM_REVIEW_BASE_URL`
- var `LLM_REVIEW_MODEL`
- secret `LLM_REVIEW_API_KEY`

But the job never declared that environment, so `${{ vars.* }}` / `${{ secrets.* }}` resolved against repository scope (empty). The review script then aborted with:

```
RuntimeError: required environment variable is missing: LLM_REVIEW_BASE_URL
```

Environment-scoped vars/secrets are only injected when the job opts into the environment. This one-line change wires them in.

## Safety
The `llm-pr-review` environment's only protection is a branch policy (protected branches). `pull_request_target` executes in the base branch (`main`) context, which is protected, so the policy is satisfied — no manual-approval gate is introduced. Opened from a fork so the `pull_request_target` path is exercised end-to-end.
