### PR TITLE
Migrate control-plane workflows from Claude Code to Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Claude Code.
 ### 2. Clone the repository
 
 ```bash
-git clone --recurse-submodules https://github.com/sii-system/sii-agent-fleet.git
-cd sii-agent-fleet
+git clone --recurse-submodules https://github.com/sii-system/agent-fleet.git
+cd agent-fleet
 ```
 
 ### 3. Configure and set up

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ REPO_DIR="$PWD" ./scripts/setup.sh
 ```
 
 `REPO_DIR="$PWD"` points setup at this checkout instead of its default
-`$HOME/sii-agent-fleet` clone.
+`$HOME/agent-fleet` clone.
 
 ### 4. Run one benchmark
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ evaluating Claude Code, OpenCode, and OpenClaw.
 
 Install tmux with your package manager and install Zellij from its
 [releases page](https://github.com/zellij-org/zellij/releases). `setup.sh`
-below installs Node.js and Claude Code for you.
+below installs Node.js and Pi for the control-plane Prompt workflow. Harbor
+task containers still install and run the selected benchmark agent, including
+Claude Code.
 
 ### 2. Clone the repository
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 | Script | Purpose |
 | --- | --- |
-| `setup.sh` | One-shot environment bootstrap: installs Node, Claude Code, and the pinned host Harbor runner; writes config and installs skills |
+| `setup.sh` | One-shot control-plane bootstrap: installs Node, Pi, and the pinned host Harbor runner; writes config and installs the Pi skills |
 | `run_fleet.sh` | Routes tasksets to the existing Harbor or OpenClaw runner |
 | `fleet_spec.sh` | Internal dispatcher for validated single- and multi-run spec inputs |
 | `fleet_batch.sh` | Internal concurrent launcher for normalized multi-run inputs |
@@ -30,7 +30,9 @@ MODEL=glm-5.1-fp8 \
 ./scripts/setup.sh
 ```
 
-**Prerequisites**: Manually install `git` / `curl` / `jq` / `docker` / `python3`. Node and Claude Code do not need to be pre-installed.
+**Prerequisites**: Manually install `git` / `curl` / `jq` / `docker` /
+`python3`. Node and Pi do not need to be pre-installed. Claude Code remains a
+Harbor task-container dependency and is prepared separately by the runner.
 
 ### Details
 
@@ -39,14 +41,15 @@ MODEL=glm-5.1-fp8 \
 
 1. Gather model endpoint config (interactive prompt or env vars)
 2. Check base dependencies (git / curl / jq / docker / python3)
-3. Install Node.js via nvm (if missing or < 18)
-4. Install Claude Code (pinned to 2.1.90)
-5. Write env vars to `~/.bashrc`
-6. Clone the repo
-7. Create or validate the pinned Harbor/Opik runner environment
-8. Install the skills plugin
-9. Write `config.local.env`
-10. Check Docker permissions
+3. Install Node.js via nvm (if missing or < 22.19)
+4. Install Pi (pinned to 0.81.1)
+5. Merge the `sii-gateway` Pi provider and default model
+6. Write control-plane env vars to `~/.bashrc`
+7. Clone the repo
+8. Create or validate the pinned Harbor/Opik runner environment
+9. Install the Pi skills
+10. Write `config.local.env`
+11. Check Docker permissions
 
 </details>
 
@@ -54,7 +57,9 @@ MODEL=glm-5.1-fp8 \
 <summary>Idempotency notes</summary>
 
 - `~/.bashrc`: wrapped in a marker block `# >>> sii-agent-fleet env >>>`, the whole block is replaced each run
-- `~/.claude/settings.json`: managed keys are merged, user customizations preserved
+- `~/.pi/agent/settings.json`: the managed provider/model defaults are merged; unrelated settings are preserved
+- `~/.pi/agent/models.json`: only the managed `sii-gateway` provider is replaced; unrelated providers and top-level fields are preserved
+- Existing user-managed Claude Code installations and `~/.claude` data are not removed or modified
 - `config.local.env`: only managed keys (`BASE_URL` / `API_KEY` / `MODEL`, plus `TRACE_TO_OPIK` and `OPIK_*` when set) are updated; comments and other keys are preserved
 - Host Harbor runner: exact direct dependencies come from `runner-requirements.txt`; a valid environment is reused
 - A backup is taken before each modification (`*.bak.sii-agent-fleet`)
@@ -235,11 +240,12 @@ own any resulting resource conflicts and failures.
 
 ### Prompt execution
 
-Prompt mode uses the configured model only to translate natural language into
-one or more FleetSpecs. After local validation succeeds, every result uses the
-same `--spec` path, which automatically selects single- or multi-run execution.
-The model never receives tools and never constructs or executes the runner
-command.
+Prompt mode runs Pi in the control plane and uses the configured model only to
+translate natural language into one or more FleetSpecs. After local validation
+succeeds, every result uses the same `--spec` path, which automatically selects
+single- or multi-run execution. Pi runs with an isolated configuration and no
+tools, sessions, extensions, skills, templates, themes, context files, or
+project trust. It never constructs or executes the runner command.
 
 ```bash
 # Translate, validate, and run immediately.
@@ -287,9 +293,12 @@ unsupported instead of producing a spec that would fail after Harbor starts. A
 Prompt batch may contain at most one OpenClaw run because those runners share
 one fleet; additional OpenClaw runs are rejected before display or output.
 
-Prompt mode never creates or overwrites an output file, and never starts a
-runner, when translation, structured-output validation, FleetSpec validation,
-or clarification fails.
+Prompt mode validates Pi's JSONL session, agent, and turn lifecycle, provider
+errors, final stop reason, and final assistant message. It then treats that
+message as untrusted JSON and applies the existing FleetSpec validation. It
+never creates or overwrites an output file, and never starts a runner, when
+translation, lifecycle validation, FleetSpec validation, or clarification
+fails.
 
 Prompt mode exit codes: `0` — the runner or dry-run succeeded; `2` — invalid CLI
 usage; `3` — the prompt needs clarification or requests an unsupported feature
@@ -426,7 +435,7 @@ When invoked inside a container, the launcher warns and delegates directly to
    (`TRACE_TO_OPIK`, `OPIK_URL`, `OPIK_API_KEY`, `OPIK_WORKSPACE`,
    `OPIK_PROJECT_NAME`), local Claude package paths, and package mirrors.
 7. Run `scripts/setup.sh` inside DinD per `DIND_BOOTSTRAP` (`always` every
-   time, `missing` only when Claude Code or the skills plugin is absent,
+   time, `missing` only when Pi provider configuration or the Pi skills are absent,
    `skip` never).
 8. Run `scripts/run_fleet.sh` inside DinD with the same arguments.
 
@@ -445,7 +454,7 @@ When invoked inside a container, the launcher warns and delegates directly to
 | `DIND_BASE_IMAGE` | pinned Debian 12 slim digest | glibc base image used when building the default image |
 | `DIND_UV_IMAGE` | DaoCloud mirror of `ghcr.io/astral-sh/uv:0.11.28` | Pinned uv image used to install the Harbor runner environment at build time |
 | `DIND_DOCKER_VOLUME` | `<DIND_NAME>-docker` | Persistent `/var/lib/docker` volume for nested image/build cache reuse |
-| `DIND_HOME_VOLUME` | `<DIND_NAME>-home` | Persistent benchmark-user home volume for Claude/plugin setup |
+| `DIND_HOME_VOLUME` | `<DIND_NAME>-home` | Persistent benchmark-user home volume for Pi control-plane configuration and skills |
 | `DIND_USER` | `sii` | Unprivileged user that runs `run_fleet.sh`; must exist in `DIND_IMAGE` |
 | `DIND_HOME_DIR` | `/home/<DIND_USER>` | Home path mounted from `DIND_HOME_VOLUME` |
 | `DIND_USER_UID` / `DIND_USER_GID` | caller's UID / GID | IDs assigned to `DIND_USER` so the mounted checkout stays writable without host-side `chown` |
@@ -458,11 +467,12 @@ When invoked inside a container, the launcher warns and delegates directly to
 ### Caveats
 
 - Requires privileged Docker on the host.
-- The launcher runs as the image's unprivileged `sii` user so Claude Code can
-  use bypass-permissions mode. Setup installs global packages as root, then
-  transfers the benchmark home directory to that user. The wrapper maps that
-  user's UID/GID to the calling host user so it can write result files to the
-  mounted checkout without changing host file ownership.
+- The launcher runs as the image's unprivileged `sii` user. Setup installs Pi
+  globally as root, then transfers the controller home directory to that user.
+  The wrapper maps that user's UID/GID to the calling host user so it can write
+  result files to the mounted checkout without changing host file ownership.
+  Nested Harbor task containers continue to install and run Claude Code when
+  `agent=claude-code` is selected.
 - The default image uses the pinned Debian 12 slim base and bakes in Docker
   Engine plus the Harbor runner environment. Its fingerprint changes
   with the Dockerfile, entrypoint, dependency manifest, or build image references.
@@ -497,7 +507,11 @@ When invoked inside a container, the launcher warns and delegates directly to
 - **Run setup.sh before run_fleet.sh**: setup installs the environment, run_fleet launches the fleet. Skipping setup will almost certainly fail.
 - **Harbor before OpenClaw**: harbor is lighter (single container); openclaw needs 10 containers.
 - **Verify the endpoint after switching models**: after changing `MODEL`, first `curl` the gateway to confirm it responds, then launch the fleet.
-- **Intranet / offline hosts**: setup.sh installs Node.js via nvm and Claude Code via npm, both reaching the public internet. On a network without public access, install Node.js >= 18 manually first. Benchmark containers also pull Claude Code from `downloads.claude.ai` by default; provide a local Claude package at setup time:
+- **Intranet / offline hosts**: setup.sh installs Node.js via nvm and Pi via npm,
+  both reaching the public internet. On a network without public access,
+  install Node.js >= 22.19 and the pinned Pi package manually first. Benchmark
+  containers still pull Claude Code by default; provide a local Claude package
+  at setup time:
   ```bash
   CLAUDE_TGZ_SOURCE=/path/to/claude-code.tgz \
   CLAUDE_WHEEL_DIR_SOURCE=/path/to/wheels/ \

--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -403,7 +403,10 @@ case "$DIND_BOOTSTRAP" in
     run_setup=1
     ;;
   missing)
-    if ! docker_exec sh -c 'command -v pi >/dev/null 2>&1 && pi --version 2>/dev/null | grep -Fqx "$3" && test -f "$1" && test -d "$2"' \
+    # Extract the version number instead of matching the whole output line:
+    # setup.sh does the same, and an exact-line match would re-run setup on
+    # every invocation if `pi --version` ever prints more than the bare version.
+    if ! docker_exec sh -c 'command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$3" ] && test -f "$1" && test -d "$2"' \
       sh "$DIND_HOME_DIR/.pi/agent/models.json" \
       "$DIND_HOME_DIR/.pi/agent/skills/harbor-benchmark-runner" \
       "${PI_VERSION:-0.81.1}"; then

--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -375,7 +375,7 @@ declare -a run_env=(
   "HOME=$DIND_HOME_DIR"
 )
 run_env+=("${proxy_env[@]}")
-for optional in TRACE_TO_OPIK OPIK_URL OPIK_API_KEY OPIK_WORKSPACE OPIK_PROJECT_NAME CLAUDE_TGZ_SOURCE CLAUDE_WHEEL_DIR_SOURCE TB_CC_CLAUDE_TGZ_SOURCE TB_CC_PY_WHEEL_DIR_SOURCE; do
+for optional in PI_VERSION TRACE_TO_OPIK OPIK_URL OPIK_API_KEY OPIK_WORKSPACE OPIK_PROJECT_NAME CLAUDE_TGZ_SOURCE CLAUDE_WHEEL_DIR_SOURCE TB_CC_CLAUDE_TGZ_SOURCE TB_CC_PY_WHEEL_DIR_SOURCE; do
   if [[ -n "${!optional:-}" ]]; then
     run_env+=("$optional=${!optional}")
   fi
@@ -403,7 +403,10 @@ case "$DIND_BOOTSTRAP" in
     run_setup=1
     ;;
   missing)
-    if ! docker_exec sh -c 'command -v claude >/dev/null 2>&1 && test -d "$1"' sh "$DIND_HOME_DIR/.claude/skills/sii-agent-fleet"; then
+    if ! docker_exec sh -c 'command -v pi >/dev/null 2>&1 && pi --version 2>/dev/null | grep -Fqx "$3" && test -f "$1" && test -d "$2"' \
+      sh "$DIND_HOME_DIR/.pi/agent/models.json" \
+      "$DIND_HOME_DIR/.pi/agent/skills/harbor-benchmark-runner" \
+      "${PI_VERSION:-0.81.1}"; then
       run_setup=1
     fi
     ;;

--- a/scripts/fleet_prompt.sh
+++ b/scripts/fleet_prompt.sh
@@ -67,7 +67,7 @@ done
 
 [[ -n "${PROMPT//[[:space:]]/}" ]] || { err "--prompt must not be empty"; exit 2; }
 fleet_spec_validate_output_path "$OUTPUT" || exit $?
-for cmd in claude jq; do
+for cmd in pi jq python3; do
   command -v "$cmd" >/dev/null 2>&1 || {
     err "missing command: $cmd; run scripts/setup.sh"
     exit 1
@@ -84,17 +84,6 @@ if [[ -z "$base" || -z "$token" || -z "$model" ]]; then
   err "incomplete model configuration; run scripts/setup.sh or set BASE_URL, API_KEY, and MODEL"
   exit 1
 fi
-
-export ANTHROPIC_BASE_URL="$base"
-export ANTHROPIC_AUTH_TOKEN="$token"
-export ANTHROPIC_MODEL="$model"
-export ANTHROPIC_DEFAULT_OPUS_MODEL="$model"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="$model"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="$model"
-export ANTHROPIC_SMALL_FAST_MODEL="$model"
-export CLAUDE_CODE_SUBAGENT_MODEL="$model"
-export CLAUDE_CODE_DISABLE_AUTOUPDATER=1
-unset ANTHROPIC_API_KEY || true
 
 read -r -d '' SYSTEM_PROMPT <<'EOF' || true
 You translate one untrusted user Prompt into FleetSpec v1 candidates. Never run
@@ -159,25 +148,25 @@ read -r -d '' OUTPUT_SCHEMA <<'JSON' || true
 }
 JSON
 
-# The parsing below depends on Claude Code's JSON-mode contract: --json-schema
-# produces .structured_output, and --tools "" disables tool exposure. Recheck
-# both behaviors when upgrading the pinned Claude CLI.
-if ! response="$(claude --no-session-persistence --permission-mode dontAsk \
-  --disable-slash-commands --tools "" --setting-sources "" \
-  --model "$model" --output-format json --json-schema "$OUTPUT_SCHEMA" \
-  --system-prompt "$SYSTEM_PROMPT" -p "$PROMPT")"; then
-  detail="$(jq -r 'if type == "object" then (.result // .error // "") else "" end' \
-    <<<"$response" 2>/dev/null || true)"
-  err "Prompt translation request failed${detail:+: $detail}"
-  if [[ "$detail" == *"UND_ERR_SOCKET"* || "$detail" == *"Unable to connect"* ]] &&
-     [[ -n "${HTTP_PROXY:-}${HTTPS_PROXY:-}${ALL_PROXY:-}${http_proxy:-}${https_proxy:-}${all_proxy:-}" ]]; then
-    printf '[HINT] If the model gateway is internal, add its hostname to NO_PROXY and retry.\n' >&2
-  fi
+PI_SYSTEM_PROMPT="${SYSTEM_PROMPT}
+
+Return exactly one JSON object matching this schema, with no Markdown fence or
+other surrounding text:
+${OUTPUT_SCHEMA}"
+
+# Pi runs in a private config/work directory with every tool and discoverable
+# resource disabled. The helper validates the JSONL session, agent, and turn
+# lifecycle plus provider errors and the final stop reason before emitting the
+# candidate object below.
+if ! translation="$(SII_AGENT_FLEET_API_KEY="$token" python3 "$SCRIPT_DIR/pi_prompt.py" \
+  --base-url "$base" \
+  --model "$model" \
+  --system-prompt "$PI_SYSTEM_PROMPT" \
+  --prompt "$PROMPT")"; then
   exit 1
 fi
 
 if ! translation="$(jq -ce '
-  .structured_output |
   if type == "object" and
      ((keys - ["message", "ready", "specs"]) | length == 0) and
      (.ready | type == "boolean") and
@@ -188,7 +177,7 @@ if ! translation="$(jq -ce '
       else (.message | length > 0) and (.specs | length == 0)
       end)
   then . else error("invalid translation") end
-' <<<"$response" 2>/dev/null)"; then
+' <<<"$translation" 2>/dev/null)"; then
   err "model returned no valid structured Prompt translation"
   exit 1
 fi

--- a/scripts/pi_prompt.py
+++ b/scripts/pi_prompt.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Run the control-plane Pi translator and emit its final JSON object."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+PROVIDER = "sii-gateway"
+API_KEY_ENV = "SII_AGENT_FLEET_API_KEY"
+
+
+class PromptFailure(RuntimeError):
+    """A safe, user-facing Prompt translation failure."""
+
+
+def normalized_base_url(value: str) -> str:
+    base_url = value.strip().rstrip("/")
+    if base_url and not base_url.endswith("/v1"):
+        base_url = f"{base_url}/v1"
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise PromptFailure("invalid BASE_URL for Pi provider")
+    return base_url
+
+
+def models_config(
+    base_url: str,
+    model: str,
+    *,
+    display_name: str = "SII Agent Fleet Prompt Translator",
+) -> dict[str, Any]:
+    """Keep this provider contract aligned with the merged Pi analyzer."""
+
+    return {
+        "providers": {
+            PROVIDER: {
+                "baseUrl": base_url,
+                "api": "openai-completions",
+                "apiKey": f"${API_KEY_ENV}",
+                "compat": {
+                    "supportsDeveloperRole": False,
+                    "supportsReasoningEffort": False,
+                    "supportsUsageInStreaming": True,
+                    "maxTokensField": "max_tokens",
+                    "thinkingFormat": "zai",
+                },
+                "models": [
+                    {
+                        "id": model,
+                        "name": display_name,
+                        "reasoning": True,
+                        "input": ["text"],
+                        "contextWindow": 204800,
+                        "maxTokens": 32768,
+                        "cost": {
+                            "input": 0,
+                            "output": 0,
+                            "cacheRead": 0,
+                            "cacheWrite": 0,
+                        },
+                    }
+                ],
+            }
+        }
+    }
+
+
+def minimal_environment(runtime_dir: Path, api_key: str) -> dict[str, str]:
+    environment: dict[str, str] = {}
+    passthrough = {
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "NODE_EXTRA_CA_CERTS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "all_proxy",
+    }
+    for key in passthrough:
+        value = os.environ.get(key)
+        if value:
+            environment[key] = value
+    environment.setdefault("PATH", os.defpath)
+    environment["HOME"] = str(runtime_dir)
+    environment["PI_CODING_AGENT_DIR"] = str(runtime_dir)
+    environment["PI_OFFLINE"] = "1"
+    environment[API_KEY_ENV] = api_key
+    return environment
+
+
+def parse_jsonl(raw: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise PromptFailure("Pi returned invalid JSONL") from exc
+        if not isinstance(event, dict):
+            raise PromptFailure("Pi returned a non-object JSONL event")
+        events.append(event)
+    if not events:
+        raise PromptFailure("Pi returned no JSONL events")
+    return events
+
+
+def message_text(message: Any) -> str:
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") not in {"text", "output_text"}:
+            continue
+        text = block.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def final_assistant_message(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    candidate: dict[str, Any] | None = None
+    for event in events:
+        if event.get("type") not in {"message_end", "turn_end"}:
+            continue
+        message = event.get("message")
+        if isinstance(message, dict) and message.get("role") == "assistant":
+            candidate = message
+    return candidate
+
+
+def provider_error(events: list[dict[str, Any]]) -> str:
+    retry_errors = [
+        str(event.get("finalError") or "")
+        for event in events
+        if event.get("type") == "auto_retry_end"
+    ]
+    retry_errors = [message for message in retry_errors if message]
+    if retry_errors:
+        return retry_errors[-1]
+    message_errors = [
+        str((event.get("message") or {}).get("errorMessage") or "")
+        for event in events
+        if isinstance(event.get("message"), dict)
+    ]
+    message_errors = [message for message in message_errors if message]
+    return message_errors[-1] if message_errors else ""
+
+
+def validate_event_stream(events: list[dict[str, Any]]) -> dict[str, Any]:
+    session_ids = [
+        str(event.get("id"))
+        for event in events
+        if event.get("type") == "session" and event.get("id")
+    ]
+    if len(session_ids) != 1:
+        raise PromptFailure("Pi session lifecycle was not observed exactly once")
+
+    agent_start = sum(event.get("type") == "agent_start" for event in events)
+    agent_end = sum(event.get("type") == "agent_end" for event in events)
+    if agent_start < 1 or agent_start != agent_end:
+        raise PromptFailure("Pi agent lifecycle is incomplete")
+
+    turn_start = sum(event.get("type") == "turn_start" for event in events)
+    turn_end = sum(event.get("type") == "turn_end" for event in events)
+    if turn_start < 1 or turn_start != turn_end:
+        raise PromptFailure("Pi turn lifecycle is incomplete")
+
+    error = provider_error(events)
+    if error:
+        raise PromptFailure(f"Pi provider request failed: {error}")
+
+    message = final_assistant_message(events)
+    if message is None:
+        raise PromptFailure("Pi returned no final assistant message")
+    stop_reason = str(message.get("stopReason") or "")
+    if not stop_reason:
+        raise PromptFailure("Pi final assistant message has no stop reason")
+    if stop_reason != "stop":
+        raise PromptFailure(f"Pi final assistant message stopped with {stop_reason}")
+
+    text = message_text(message)
+    if not text:
+        raise PromptFailure("Pi returned an empty final assistant message")
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PromptFailure("Pi final assistant message is not a JSON object") from exc
+    if not isinstance(value, dict):
+        raise PromptFailure("Pi final assistant message is not a JSON object")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pi-bin", default="pi")
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--system-prompt", required=True)
+    parser.add_argument("--prompt", required=True)
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    pi_binary = shutil.which(args.pi_bin)
+    if pi_binary is None:
+        raise PromptFailure(f"missing command: {args.pi_bin}; run scripts/setup.sh")
+    base_url = normalized_base_url(args.base_url)
+    model = args.model.strip()
+    if not model:
+        raise PromptFailure("MODEL is empty")
+    api_key = os.environ.get(API_KEY_ENV, "")
+    if not api_key:
+        raise PromptFailure(f"missing API key environment: {API_KEY_ENV}")
+
+    with tempfile.TemporaryDirectory(prefix="sii-fleet-prompt-") as temporary:
+        root = Path(temporary)
+        runtime_dir = root / "pi-agent"
+        work_dir = root / "work"
+        runtime_dir.mkdir()
+        work_dir.mkdir()
+        (runtime_dir / "models.json").write_text(
+            json.dumps(models_config(base_url, model), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        command = [
+            pi_binary,
+            "--mode",
+            "json",
+            "--print",
+            "--provider",
+            PROVIDER,
+            "--model",
+            model,
+            "--no-session",
+            "--no-tools",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--no-context-files",
+            "--no-approve",
+            "--system-prompt",
+            args.system_prompt,
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=work_dir,
+                env=minimal_environment(runtime_dir, api_key),
+                input=args.prompt,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
+                check=False,
+            )
+        except OSError as exc:
+            raise PromptFailure(f"could not launch Pi: {exc}") from exc
+
+        if completed.returncode != 0:
+            detail = (completed.stderr or "").strip().splitlines()
+            suffix = f": {detail[-1]}" if detail else ""
+            raise PromptFailure(f"Pi exited with code {completed.returncode}{suffix}")
+        events = parse_jsonl(completed.stdout or "")
+        return validate_event_stream(events)
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        result = run(args)
+    except PromptFailure as exc:
+        message = str(exc)
+        print(f"[ERROR] Prompt translation request failed: {message}", file=sys.stderr)
+        if (
+            ("UND_ERR_SOCKET" in message or "Unable to connect" in message)
+            and any(
+                os.environ.get(name)
+                for name in (
+                    "HTTP_PROXY",
+                    "HTTPS_PROXY",
+                    "ALL_PROXY",
+                    "http_proxy",
+                    "https_proxy",
+                    "all_proxy",
+                )
+            )
+        ):
+            print(
+                "[HINT] If the model gateway is internal, add its hostname to NO_PROXY and retry.",
+                file=sys.stderr,
+            )
+        return 1
+    print(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi_prompt.py
+++ b/scripts/pi_prompt.py
@@ -265,13 +265,16 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "--no-approve",
             "--system-prompt",
             args.system_prompt,
+            # Pi print mode reads the user message from the trailing
+            # positional argument, not stdin, like the Harbor analyzer.
+            args.prompt,
         ]
         try:
             completed = subprocess.run(
                 command,
                 cwd=work_dir,
                 env=minimal_environment(runtime_dir, api_key),
-                input=args.prompt,
+                stdin=subprocess.DEVNULL,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,7 +19,7 @@ SOURCE_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # ---- Hardcoded versions (override via env if needed) ----
 NODE_VERSION="${NODE_VERSION:-24}"
 PI_VERSION="${PI_VERSION:-0.81.1}"
-REPO_URL="${REPO_URL:-https://github.com/sii-system/sii-agent-fleet.git}"
+REPO_URL="${REPO_URL:-https://github.com/sii-system/agent-fleet.git}"
 REPO_DIR="${REPO_DIR:-$HOME/sii-agent-fleet}"
 
 # ---- 1. Gather config (env vars first, then interactive prompt) ----

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,7 +20,7 @@ SOURCE_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 NODE_VERSION="${NODE_VERSION:-24}"
 PI_VERSION="${PI_VERSION:-0.81.1}"
 REPO_URL="${REPO_URL:-https://github.com/sii-system/agent-fleet.git}"
-REPO_DIR="${REPO_DIR:-$HOME/sii-agent-fleet}"
+REPO_DIR="${REPO_DIR:-$HOME/agent-fleet}"
 
 # ---- 1. Gather config (env vars first, then interactive prompt) ----
 # Credentials: BASE_URL / MODEL come from env vars, or are prompted

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ SOURCE_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ---- Hardcoded versions (override via env if needed) ----
 NODE_VERSION="${NODE_VERSION:-24}"
-CLAUDE_CODE_VERSION="${CLAUDE_CODE_VERSION:-2.1.90}"
+PI_VERSION="${PI_VERSION:-0.81.1}"
 REPO_URL="${REPO_URL:-https://github.com/sii-system/sii-agent-fleet.git}"
 REPO_DIR="${REPO_DIR:-$HOME/sii-agent-fleet}"
 
@@ -78,8 +78,14 @@ if [[ ${#MISSING[@]} -gt 0 ]]; then
 fi
 ok "Base dependencies present (git / curl / jq / docker / python3)"
 
-# ---- 3. Ensure Node >=18 (via nvm if needed) ----
-node_major() { node -v 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/' || echo 0; }
+# ---- 3. Ensure Node >=22.19 (via nvm if needed) ----
+node_version_ok() {
+  local version major minor
+  version="${1#v}"
+  IFS=. read -r major minor _ <<<"$version"
+  [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+  (( major > 22 || (major == 22 && minor >= 19) ))
+}
 load_nvm() {
   export NVM_DIR="$HOME/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
@@ -92,9 +98,9 @@ load_nvm() {
 load_nvm
 NEED_NODE=1
 if command -v node >/dev/null 2>&1; then
-  CUR_MAJOR="$(node_major)"
-  if [[ "$CUR_MAJOR" -ge 18 ]]; then
-    ok "Node $(node -v) OK (>=18)"
+  CUR_NODE_VERSION="$(node -v 2>/dev/null || true)"
+  if node_version_ok "$CUR_NODE_VERSION"; then
+    ok "Node $CUR_NODE_VERSION OK (>=22.19)"
     NEED_NODE=0
   else
     warn "Node $(node -v) too old, will install Node $NODE_VERSION via nvm"
@@ -110,18 +116,18 @@ if [[ "$NEED_NODE" == "1" ]]; then
     load_nvm
   fi
   if ! command -v nvm >/dev/null 2>&1; then
-    err "nvm install/load failed. Please install Node >=18 manually and re-run."
+    err "nvm install/load failed. Please install Node >=22.19 manually and re-run."
     exit 1
   fi
   info "Installing Node $NODE_VERSION via nvm..."
   nvm install "$NODE_VERSION"
   nvm use "$NODE_VERSION"
   nvm alias default "$NODE_VERSION" || true
-  CUR_MAJOR="$(node_major)"
-  if [[ "$CUR_MAJOR" -ge 18 ]]; then
-    ok "Node $(node -v) ready"
+  CUR_NODE_VERSION="$(node -v 2>/dev/null || true)"
+  if node_version_ok "$CUR_NODE_VERSION"; then
+    ok "Node $CUR_NODE_VERSION ready"
   else
-    err "Node still <18 after install, aborting."
+    err "Node still <22.19 after install, aborting."
     exit 1
   fi
 fi
@@ -131,62 +137,96 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-# ---- 4. Install Claude Code ----
-info "Checking Claude Code version..."
-export CLAUDE_CODE_DISABLE_AUTOUPDATER=1
+# ---- 4. Install Pi for control-plane use ----
+info "Checking Pi version..."
 NEED_INSTALL=1
-if command -v claude >/dev/null 2>&1; then
-  CUR_VER="$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
-  if [[ "$CUR_VER" == "$CLAUDE_CODE_VERSION" ]]; then
-    ok "Claude Code already at target version $CLAUDE_CODE_VERSION"
+if command -v pi >/dev/null 2>&1; then
+  CUR_VER="$(pi --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  if [[ "$CUR_VER" == "$PI_VERSION" ]]; then
+    ok "Pi already at target version $PI_VERSION"
     NEED_INSTALL=0
   else
-    warn "Current version ${CUR_VER:-unknown}, switching to $CLAUDE_CODE_VERSION"
+    warn "Current Pi version ${CUR_VER:-unknown}, switching to $PI_VERSION"
   fi
 else
-  warn "Claude Code not found, installing $CLAUDE_CODE_VERSION"
+  warn "Pi not found, installing $PI_VERSION"
 fi
 if [[ "$NEED_INSTALL" == "1" ]]; then
-  info "Installing Claude Code @${CLAUDE_CODE_VERSION}..."
-  npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" --force
+  info "Installing Pi @${PI_VERSION}..."
+  npm install -g --ignore-scripts "@earendil-works/pi-coding-agent@${PI_VERSION}" --force
   hash -r
-  ok "Claude Code ${CLAUDE_CODE_VERSION} installed"
-  info "Override pinned version via CLAUDE_CODE_VERSION env var if a newer release is required"
+  CUR_VER="$(pi --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  if [[ "$CUR_VER" != "$PI_VERSION" ]]; then
+    err "Pi install did not provide target version $PI_VERSION (got ${CUR_VER:-unknown})"
+    exit 1
+  fi
+  ok "Pi ${PI_VERSION} installed"
+  info "Override pinned version via PI_VERSION only after verifying compatibility"
 fi
 
-# ---- 5. Merge managed keys into ~/.claude/settings.json ----
-info "Merging managed keys into ~/.claude/settings.json..."
-mkdir -p "$HOME/.claude"
-SETTINGS="$HOME/.claude/settings.json"
-cp -f "$SETTINGS" "$SETTINGS.bak.sii-agent-fleet" 2>/dev/null || true
-python3 - "$SETTINGS" "$MODEL" <<'PY'
+# ---- 5. Merge the managed Pi provider and settings ----
+info "Merging managed Pi configuration..."
+PI_AGENT_DIR="$HOME/.pi/agent"
+mkdir -p "$PI_AGENT_DIR"
+PI_SETTINGS="$PI_AGENT_DIR/settings.json"
+PI_MODELS="$PI_AGENT_DIR/models.json"
+cp -f "$PI_SETTINGS" "$PI_SETTINGS.bak.sii-agent-fleet" 2>/dev/null || true
+cp -f "$PI_MODELS" "$PI_MODELS.bak.sii-agent-fleet" 2>/dev/null || true
+python3 - "$PI_SETTINGS" "$PI_MODELS" "$BASE_URL" "$MODEL" "$SCRIPT_DIR" <<'PY'
 import json, sys
-path, model = sys.argv[1], sys.argv[2]
+settings_path, models_path, base_url, model, script_dir = sys.argv[1:]
+sys.path.insert(0, script_dir)
+from pi_prompt import PromptFailure, models_config, normalized_base_url
+
+def load_object(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            value = json.load(f)
+        if isinstance(value, dict):
+            return value
+    except FileNotFoundError:
+        pass
+    except json.JSONDecodeError:
+        print(
+            f"\033[1;33m[WARN]\033[0m existing {path} could not be parsed; "
+            f"backed up at {path}.bak.sii-agent-fleet, writing fresh",
+            file=sys.stderr,
+        )
+    return {}
+
+settings = load_object(settings_path)
+settings["defaultProvider"] = "sii-gateway"
+settings["defaultModel"] = model
+settings.setdefault("defaultThinkingLevel", "high")
+settings.setdefault("theme", "dark")
+settings.setdefault("enableInstallTelemetry", False)
+
+models = load_object(models_path)
+providers = models.get("providers")
+if not isinstance(providers, dict):
+    providers = {}
+    models["providers"] = providers
 try:
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    if not isinstance(data, dict):
-        data = {}
-except FileNotFoundError:
-    data = {}
-except json.JSONDecodeError:
-    print(f"\033[1;33m[WARN]\033[0m existing settings.json could not be parsed; backed up at {path}.bak.sii-agent-fleet, writing fresh", file=sys.stderr)
-    data = {}
-data["model"] = model
-data.setdefault("effortLevel", "high")
-data.setdefault("theme", "dark")
-with open(path, "w", encoding="utf-8") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
+    normalized_url = normalized_base_url(base_url)
+except PromptFailure as exc:
+    print(f"\033[1;31m[FAIL]\033[0m {exc}", file=sys.stderr)
+    raise SystemExit(1) from exc
+providers["sii-gateway"] = models_config(
+    normalized_url, model, display_name="SII Agent Fleet"
+)["providers"]["sii-gateway"]
+
+for path, value in ((settings_path, settings), (models_path, models)):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(value, f, indent=2)
+        f.write("\n")
 PY
-ok "settings.json merged (model=${MODEL}); backup at ${SETTINGS}.bak.sii-agent-fleet"
+ok "Pi configuration merged (provider=sii-gateway, model=${MODEL})"
 
 # ---- 6. Write env vars + nvm init to ~/.bashrc (idempotent) ----
 # Uses Python to replace the managed block portably (GNU/BSD sed differ).
 info "Writing env vars to ~/.bashrc..."
 BASHRC="$HOME/.bashrc"
 cp -f "$BASHRC" "$BASHRC.bak.sii-agent-fleet" 2>/dev/null || true
-BASE_URL="$BASE_URL" \
 AUTH_TOKEN="$AUTH_TOKEN" \
 CLAUDE_TGZ_SOURCE="$CLAUDE_TGZ_SOURCE" \
 CLAUDE_WHEEL_DIR_SOURCE="$CLAUDE_WHEEL_DIR_SOURCE" \
@@ -196,7 +236,6 @@ import os, shlex
 from pathlib import Path
 
 bashrc = Path(os.environ["BASHRC"])
-base_url = os.environ["BASE_URL"]
 auth_token = os.environ["AUTH_TOKEN"]
 tgz = os.environ.get("CLAUDE_TGZ_SOURCE", "").strip()
 wheel = os.environ.get("CLAUDE_WHEEL_DIR_SOURCE", "").strip()
@@ -228,10 +267,8 @@ block = [
     BEGIN,
     'export NVM_DIR="$HOME/.nvm"',
     '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
-    "export CLAUDE_CODE_DISABLE_AUTOUPDATER=1",
-    f"export ANTHROPIC_BASE_URL={q(base_url)}",
-    f"export ANTHROPIC_AUTH_TOKEN={q(auth_token)}",
-    "unset ANTHROPIC_API_KEY",
+    "export PI_OFFLINE=1",
+    f"export SII_AGENT_FLEET_API_KEY={q(auth_token)}",
 ]
 if tgz and wheel:
     block += [
@@ -246,9 +283,8 @@ bashrc.write_text("\n".join(out) + "\n", encoding="utf-8")
 PY
 ok "Env vars written to ~/.bashrc (idempotent); backup at ${BASHRC}.bak.sii-agent-fleet"
 
-export ANTHROPIC_BASE_URL="${BASE_URL}"
-export ANTHROPIC_AUTH_TOKEN="${AUTH_TOKEN}"
-unset ANTHROPIC_API_KEY || true
+export PI_OFFLINE=1
+export SII_AGENT_FLEET_API_KEY="${AUTH_TOKEN}"
 if [[ -n "${CLAUDE_TGZ_SOURCE:-}" && -n "${CLAUDE_WHEEL_DIR_SOURCE:-}" ]]; then
   export TB_CC_OPIK_ENABLE_HOOK=1
   export TB_CC_CLAUDE_TGZ_SOURCE="${CLAUDE_TGZ_SOURCE}"
@@ -286,10 +322,10 @@ case "${HARBOR_RUNNER_SETUP:-1}" in
     ;;
 esac
 
-# ---- 9. Install skills plugin ----
-info "Installing skills plugin..."
-CLAUDE_PLUGIN_DIR="$HOME/.claude/skills/sii-agent-fleet"
-mkdir -p "$CLAUDE_PLUGIN_DIR/.claude-plugin"
+# ---- 9. Install Pi skills ----
+info "Installing Pi skills..."
+PI_SKILLS_DIR="$PI_AGENT_DIR/skills"
+mkdir -p "$PI_SKILLS_DIR"
 SKILLS=(
   harbor-benchmark-runner
   openclaw-fleet-operations
@@ -297,25 +333,12 @@ SKILLS=(
 )
 for skill in "${SKILLS[@]}"; do
   if [[ -d "$REPO_DIR/skills/$skill" ]]; then
-    ln -sfn "$REPO_DIR/skills/$skill" "$CLAUDE_PLUGIN_DIR/$skill"
+    ln -sfn "$REPO_DIR/skills/$skill" "$PI_SKILLS_DIR/$skill"
   else
     warn "skill dir not found: $REPO_DIR/skills/$skill"
   fi
 done
-cat > "$CLAUDE_PLUGIN_DIR/.claude-plugin/plugin.json" <<'JSON'
-{
-  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
-  "name": "sii-agent-fleet",
-  "version": "0.1.0",
-  "description": "SII Agent Fleet operation skills for Harbor, OpenClaw, and benchmarks.",
-  "skills": [
-    "./harbor-benchmark-runner",
-    "./openclaw-fleet-operations",
-    "./openclaw-benchmark-runners"
-  ]
-}
-JSON
-ok "Skills plugin installed to $CLAUDE_PLUGIN_DIR"
+ok "Pi skills installed to $PI_SKILLS_DIR"
 
 # ---- 10. Merge managed keys into config.local.env ----
 # Update only the keys setup.sh manages (BASE_URL/API_KEY/MODEL + tracing/Opik),

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -11,9 +11,20 @@ mkdir -p \
   "$PROJECT_DIR/Agents/utils/common/Harbor" \
   "$TMP_DIR/bin"
 cp "$REPO_ROOT/scripts/dind-run.sh" "$PROJECT_DIR/scripts/dind-run.sh"
-sed -i \
-  '0,/if running_in_container; then/s//if [[ "${DIND_TEST_ASSUME_HOST:-0}" != "1" ]] \&\& running_in_container; then/' \
-  "$PROJECT_DIR/scripts/dind-run.sh"
+# First-occurrence rewrite via python: GNU sed's -i and 0,/re/ addressing
+# are unavailable in the BSD sed shipped on macOS.
+python3 - "$PROJECT_DIR/scripts/dind-run.sh" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+old = "if running_in_container; then"
+new = 'if [[ "${DIND_TEST_ASSUME_HOST:-0}" != "1" ]] && running_in_container; then'
+if old not in text:
+    sys.exit("test guard patch point not found in dind-run.sh")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
 cp "$REPO_ROOT/scripts/dind/dockerd-entrypoint.sh" "$PROJECT_DIR/scripts/dind/dockerd-entrypoint.sh"
 cp "$REPO_ROOT/scripts/run_fleet.sh" "$PROJECT_DIR/scripts/run_fleet.sh"
 cp "$REPO_ROOT/scripts/fleet_spec_io.sh" "$PROJECT_DIR/scripts/fleet_spec_io.sh"

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -152,6 +152,26 @@ if grep -q -- '^volume rm ' "$DOCKER_ACTION_LOG"; then
   exit 1
 fi
 
+PATH="$TMP_DIR/bin:$PATH" \
+DIND_BOOTSTRAP=missing \
+PI_VERSION=0.81.1 \
+"$PROJECT_DIR/scripts/dind-run.sh" --taskset terminalbench21 --agent claude-code --workers 1 > "$LOG"
+
+grep -q -- '<sh> <-c> <command -v pi >/dev/null 2>&1 && pi --version 2>/dev/null | grep -Fqx "$3" && test -f "$1" && test -d "$2">' "$LOG"
+grep -q -- '</home/sii/.pi/agent/models.json>' "$LOG"
+grep -q -- '</home/sii/.pi/agent/skills/harbor-benchmark-runner>' "$LOG"
+grep -q -- '<0.81.1>' "$LOG"
+grep -q -- '<PI_VERSION=0.81.1>' "$LOG"
+if grep -q -- 'command -v claude' "$LOG"; then
+  echo "dind-run.sh still checks the controller for Claude Code" >&2
+  exit 1
+fi
+if grep -q -- '<./scripts/setup.sh>' "$LOG"; then
+  echo "dind-run.sh bootstrapped despite a complete Pi controller setup" >&2
+  exit 1
+fi
+grep -q -- '<./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>' "$LOG"
+
 FALLBACK_LOG="$TMP_DIR/fallback.log"
 PATH="$TMP_DIR/bin:$PATH" \
 container=docker \

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -157,7 +157,7 @@ DIND_BOOTSTRAP=missing \
 PI_VERSION=0.81.1 \
 "$PROJECT_DIR/scripts/dind-run.sh" --taskset terminalbench21 --agent claude-code --workers 1 > "$LOG"
 
-grep -q -- '<sh> <-c> <command -v pi >/dev/null 2>&1 && pi --version 2>/dev/null | grep -Fqx "$3" && test -f "$1" && test -d "$2">' "$LOG"
+grep -qF -- '<sh> <-c> <command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$3" ] && test -f "$1" && test -d "$2">' "$LOG"
 grep -q -- '</home/sii/.pi/agent/models.json>' "$LOG"
 grep -q -- '</home/sii/.pi/agent/skills/harbor-benchmark-runner>' "$LOG"
 grep -q -- '<0.81.1>' "$LOG"

--- a/scripts/tests/test_fleet_prompt.py
+++ b/scripts/tests/test_fleet_prompt.py
@@ -44,13 +44,15 @@ if [[ "${1:-}" == "--version" ]]; then
   exit 0
 fi
 stub_dir="$(cd "$(dirname "$0")" && pwd)"
-prompt="$(cat)"
+prompt="${@: -1}"
+stdin_data="$(cat)"
 {
   printf 'home=%s\\n' "${HOME:-}"
   printf 'pi_dir=%s\\n' "${PI_CODING_AGENT_DIR:-}"
   printf 'offline=%s\\n' "${PI_OFFLINE:-}"
   printf 'token=%s\\n' "${SII_AGENT_FLEET_API_KEY:-}"
   printf 'prompt=<%s>\\n' "$prompt"
+  printf 'stdin=<%s>\\n' "$stdin_data"
   printf 'arg=<%s>\\n' "$@"
   printf 'models=\n'
   cat "$PI_CODING_AGENT_DIR/models.json"
@@ -222,7 +224,7 @@ exit "${STUB_EXIT:-0}"
             result.stderr,
         )
 
-    def test_caller_config_wins_and_prompt_is_literal_stdin(self):
+    def test_caller_config_wins_and_prompt_is_final_positional_argument(self):
         capture = self.pi_capture
         goal = '{"request":"run terminal-bench/terminal-bench-2"}'
         result = self.run_goal(
@@ -246,7 +248,15 @@ exit "${STUB_EXIT:-0}"
         self.assertIn('"apiKey": "$SII_AGENT_FLEET_API_KEY"', captured)
         self.assertIn('"id": "caller-model"', captured)
         self.assertNotIn("stale", captured)
+        # Pi print mode consumes the user message as the trailing positional
+        # argument and must receive nothing on stdin; a stub that read the
+        # prompt from stdin previously masked a broken real invocation.
         self.assertIn(f"prompt=<{goal}>", captured)
+        self.assertIn("stdin=<>", captured)
+        arg_lines = [
+            line for line in captured.splitlines() if line.startswith("arg=<")
+        ]
+        self.assertEqual(arg_lines[-1], f"arg=<{goal}>")
         self.assertIn("arg=<--provider>", captured)
         self.assertIn("arg=<sii-gateway>", captured)
         self.assertIn("arg=<--no-tools>", captured)

--- a/scripts/tests/test_fleet_prompt.py
+++ b/scripts/tests/test_fleet_prompt.py
@@ -20,6 +20,7 @@ class FleetGoalTest(unittest.TestCase):
         self.bin_dir = self.root / "bin"
         self.repo.mkdir()
         self.bin_dir.mkdir()
+        self.pi_capture = self.bin_dir / "pi-capture.txt"
 
         (self.repo / "config.env").write_text(
             "BASE_URL=https://public.example.invalid\n"
@@ -34,26 +35,33 @@ class FleetGoalTest(unittest.TestCase):
             encoding="utf-8",
         )
 
-        claude = self.bin_dir / "claude"
-        claude.write_text(
+        pi = self.bin_dir / "pi"
+        pi.write_text(
             """#!/usr/bin/env bash
 set -euo pipefail
-if [[ -n "${CLAUDE_STUB_CAPTURE:-}" ]]; then
-  {
-    printf 'base=%s\\n' "${ANTHROPIC_BASE_URL:-}"
-    printf 'token=%s\\n' "${ANTHROPIC_AUTH_TOKEN:-}"
-    printf 'model=%s\\n' "${ANTHROPIC_MODEL:-}"
-    printf 'haiku=%s\\n' "${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}"
-    printf 'fast=%s\\n' "${ANTHROPIC_SMALL_FAST_MODEL:-}"
-    printf 'arg=<%s>\\n' "$@"
-  } >"$CLAUDE_STUB_CAPTURE"
+if [[ "${1:-}" == "--version" ]]; then
+  printf '%s\n' '0.81.1'
+  exit 0
 fi
-printf '%s\\n' "$CLAUDE_STUB_RESPONSE"
-exit "${CLAUDE_STUB_EXIT:-0}"
+stub_dir="$(cd "$(dirname "$0")" && pwd)"
+prompt="$(cat)"
+{
+  printf 'home=%s\\n' "${HOME:-}"
+  printf 'pi_dir=%s\\n' "${PI_CODING_AGENT_DIR:-}"
+  printf 'offline=%s\\n' "${PI_OFFLINE:-}"
+  printf 'token=%s\\n' "${SII_AGENT_FLEET_API_KEY:-}"
+  printf 'prompt=<%s>\\n' "$prompt"
+  printf 'arg=<%s>\\n' "$@"
+  printf 'models=\n'
+  cat "$PI_CODING_AGENT_DIR/models.json"
+} >"$stub_dir/pi-capture.txt"
+cat "$stub_dir/pi-stderr.txt" >&2
+cat "$stub_dir/pi-response.jsonl"
+exit "$(cat "$stub_dir/pi-exit.txt")"
 """,
             encoding="utf-8",
         )
-        claude.chmod(0o755)
+        pi.chmod(0o755)
 
         harbor = self.repo / "Agents/utils/common/Harbor/start.sh"
         harbor.parent.mkdir(parents=True)
@@ -103,7 +111,7 @@ exit "${STUB_EXIT:-0}"
         self.temp_dir.cleanup()
 
     @staticmethod
-    def response(*, ready=True, message="", spec=None, specs=None):
+    def response(*, ready=True, message="", spec=None, specs=None, stop_reason="stop"):
         if specs is None and ready:
             specs = [spec or {
                 "schema_version": 1,
@@ -113,29 +121,32 @@ exit "${STUB_EXIT:-0}"
             }]
         elif specs is None:
             specs = []
-        return json.dumps(
-            {
-                "type": "result",
-                "structured_output": {
-                    "ready": ready,
-                    "message": message,
-                    "specs": specs,
-                },
-            }
+        translation = json.dumps(
+            {"ready": ready, "message": message, "specs": specs},
+            separators=(",", ":"),
         )
+        assistant = {
+            "role": "assistant",
+            "content": [{"type": "text", "text": translation}],
+            "stopReason": stop_reason,
+        }
+        events = [
+            {"type": "session", "id": "session-1"},
+            {"type": "agent_start"},
+            {"type": "turn_start"},
+            {"type": "message_end", "message": assistant},
+            {"type": "turn_end", "message": assistant},
+            {"type": "agent_end"},
+        ]
+        return "\n".join(json.dumps(event) for event in events)
 
     def goal_env(self, response=None, extra_env=None):
         env = os.environ.copy()
+        extra_env = dict(extra_env or {})
         for name in (
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_AUTH_TOKEN",
-            "ANTHROPIC_BASE_URL",
-            "ANTHROPIC_MODEL",
-            "ANTHROPIC_DEFAULT_OPUS_MODEL",
-            "ANTHROPIC_DEFAULT_SONNET_MODEL",
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-            "ANTHROPIC_SMALL_FAST_MODEL",
-            "CLAUDE_CODE_SUBAGENT_MODEL",
+            "PI_CODING_AGENT_DIR",
+            "PI_OFFLINE",
+            "SII_AGENT_FLEET_API_KEY",
             "API_KEY",
             "BASE_URL",
             "MODEL",
@@ -145,10 +156,19 @@ exit "${STUB_EXIT:-0}"
             {
                 "PATH": f"{self.bin_dir}{os.pathsep}{env['PATH']}",
                 "REPO_DIR": str(self.repo),
-                "CLAUDE_STUB_RESPONSE": response or self.response(),
             }
         )
-        env.update(extra_env or {})
+        (self.bin_dir / "pi-response.jsonl").write_text(
+            response or self.response(), encoding="utf-8"
+        )
+        (self.bin_dir / "pi-exit.txt").write_text(
+            str(extra_env.pop("PI_STUB_EXIT", "0")), encoding="utf-8"
+        )
+        (self.bin_dir / "pi-stderr.txt").write_text(
+            extra_env.pop("PI_STUB_STDERR", ""), encoding="utf-8"
+        )
+        self.pi_capture.unlink(missing_ok=True)
+        env.update(extra_env)
         return env
 
     def run_goal(self, *args, response=None, extra_env=None, stdin=None):
@@ -202,8 +222,8 @@ exit "${STUB_EXIT:-0}"
             result.stderr,
         )
 
-    def test_caller_config_wins_and_goal_is_one_literal_argument(self):
-        capture = self.root / "claude-capture.txt"
+    def test_caller_config_wins_and_prompt_is_literal_stdin(self):
+        capture = self.pi_capture
         goal = '{"request":"run terminal-bench/terminal-bench-2"}'
         result = self.run_goal(
             "--prompt",
@@ -212,22 +232,28 @@ exit "${STUB_EXIT:-0}"
                 "BASE_URL": "https://caller.example.invalid/v1/",
                 "API_KEY": "fake-caller-token",
                 "MODEL": "caller-model",
-                "ANTHROPIC_BASE_URL": "https://stale.example.invalid",
-                "ANTHROPIC_AUTH_TOKEN": "fake-stale-token",
-                "ANTHROPIC_MODEL": "stale-model",
-                "CLAUDE_STUB_CAPTURE": str(capture),
+                "PI_CODING_AGENT_DIR": "/tmp/stale-pi-dir",
+                "SII_AGENT_FLEET_API_KEY": "fake-stale-token",
             },
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
         captured = capture.read_text(encoding="utf-8")
-        self.assertIn("base=https://caller.example.invalid", captured)
         self.assertIn("token=fake-caller-token", captured)
-        self.assertIn("model=caller-model", captured)
-        self.assertIn("haiku=caller-model", captured)
-        self.assertIn("fast=caller-model", captured)
+        self.assertIn("offline=1", captured)
+        self.assertIn('"baseUrl": "https://caller.example.invalid/v1"', captured)
+        self.assertIn('"api": "openai-completions"', captured)
+        self.assertIn('"apiKey": "$SII_AGENT_FLEET_API_KEY"', captured)
+        self.assertIn('"id": "caller-model"', captured)
         self.assertNotIn("stale", captured)
-        self.assertIn(f"arg=<{goal}>", captured)
+        self.assertIn(f"prompt=<{goal}>", captured)
+        self.assertIn("arg=<--provider>", captured)
+        self.assertIn("arg=<sii-gateway>", captured)
+        self.assertIn("arg=<--no-tools>", captured)
+        self.assertIn("arg=<--no-extensions>", captured)
+        self.assertIn("arg=<--no-skills>", captured)
+        self.assertIn("arg=<--no-context-files>", captured)
+        self.assertIn("arg=<--no-approve>", captured)
         self.assertIn("Terminus-2", captured)
         self.assertIn("return ready=false", captured)
         self.assertIn('"specs"', captured)
@@ -449,11 +475,10 @@ exit "${STUB_EXIT:-0}"
     def test_missing_config_fails_before_calling_the_model(self):
         (self.repo / "config.env").unlink()
         (self.repo / "config.local.env").unlink()
-        capture = self.root / "claude-capture.txt"
+        capture = self.pi_capture
         result = self.run_goal(
             "--prompt",
             "Run pinchbench",
-            extra_env={"CLAUDE_STUB_CAPTURE": str(capture)},
         )
 
         self.assertEqual(result.returncode, 1)
@@ -465,9 +490,9 @@ exit "${STUB_EXIT:-0}"
         result = self.run_goal(
             "--prompt",
             "Run pinchbench",
-            response=json.dumps({"result": "API Error: UND_ERR_SOCKET"}),
             extra_env={
-                "CLAUDE_STUB_EXIT": "1",
+                "PI_STUB_EXIT": "1",
+                "PI_STUB_STDERR": "API Error: UND_ERR_SOCKET\n",
                 "HTTPS_PROXY": "http://proxy.example.invalid:8080",
             },
         )
@@ -475,6 +500,70 @@ exit "${STUB_EXIT:-0}"
         self.assertEqual(result.returncode, 1)
         self.assertIn("UND_ERR_SOCKET", result.stderr)
         self.assertIn("add its hostname to NO_PROXY", result.stderr)
+        self.assertNotIn("runner=", result.stdout)
+
+    def test_prompt_rejects_invalid_pi_jsonl(self):
+        result = self.run_goal(
+            "--prompt",
+            "Run pinchbench",
+            response="not-jsonl\n",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Pi returned invalid JSONL", result.stderr)
+        self.assertNotIn("runner=", result.stdout)
+
+    def test_prompt_rejects_incomplete_pi_lifecycle(self):
+        events = [json.loads(line) for line in self.response().splitlines()]
+        events = [event for event in events if event["type"] != "agent_end"]
+        result = self.run_goal(
+            "--prompt",
+            "Run pinchbench",
+            response="\n".join(json.dumps(event) for event in events),
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Pi agent lifecycle is incomplete", result.stderr)
+        self.assertNotIn("runner=", result.stdout)
+
+    def test_prompt_rejects_pi_provider_error(self):
+        events = [json.loads(line) for line in self.response().splitlines()]
+        events.insert(-1, {"type": "auto_retry_end", "finalError": "gateway unavailable"})
+        result = self.run_goal(
+            "--prompt",
+            "Run pinchbench",
+            response="\n".join(json.dumps(event) for event in events),
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Pi provider request failed: gateway unavailable", result.stderr)
+        self.assertNotIn("runner=", result.stdout)
+
+    def test_prompt_rejects_aborted_pi_final_message(self):
+        result = self.run_goal(
+            "--prompt",
+            "Run pinchbench",
+            response=self.response(stop_reason="aborted"),
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("stopped with aborted", result.stderr)
+        self.assertNotIn("runner=", result.stdout)
+
+    def test_prompt_rejects_markdown_wrapped_pi_json(self):
+        events = [json.loads(line) for line in self.response().splitlines()]
+        for event in events:
+            message = event.get("message")
+            if message:
+                message["content"][0]["text"] = '```json\n{"ready":true}\n```'
+        result = self.run_goal(
+            "--prompt",
+            "Run pinchbench",
+            response="\n".join(json.dumps(event) for event in events),
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("final assistant message is not a JSON object", result.stderr)
         self.assertNotIn("runner=", result.stdout)
 
     def test_goal_requires_nonempty_text(self):
@@ -518,13 +607,12 @@ exit "${STUB_EXIT:-0}"
         self.assertIn("runner=harbor", result.stdout)
 
     def test_prompt_output_requires_a_file_path_before_model_call(self):
-        capture = self.root / "claude-capture.txt"
+        capture = self.pi_capture
         result = self.run_goal(
             "--prompt",
             "Run pinchbench",
             "--output",
             "-",
-            extra_env={"CLAUDE_STUB_CAPTURE": str(capture)},
         )
 
         self.assertEqual(result.returncode, 2)
@@ -533,13 +621,12 @@ exit "${STUB_EXIT:-0}"
         self.assertNotIn("runner=", result.stdout)
 
     def test_prompt_output_rejects_empty_path_before_model_call(self):
-        capture = self.root / "claude-capture.txt"
+        capture = self.pi_capture
         result = self.run_goal(
             "--prompt",
             "Run pinchbench",
             "--output",
             "",
-            extra_env={"CLAUDE_STUB_CAPTURE": str(capture)},
         )
 
         self.assertEqual(result.returncode, 2)
@@ -548,13 +635,12 @@ exit "${STUB_EXIT:-0}"
         self.assertNotIn("runner=", result.stdout)
 
     def test_prompt_output_rejects_mistyped_option_token_before_model_call(self):
-        capture = self.root / "claude-capture.txt"
+        capture = self.pi_capture
         result = self.run_goal(
             "--prompt",
             "Run pinchbench",
             "--output",
             "--dryrn",
-            extra_env={"CLAUDE_STUB_CAPTURE": str(capture)},
         )
 
         self.assertEqual(result.returncode, 2)
@@ -565,13 +651,12 @@ exit "${STUB_EXIT:-0}"
     def test_prompt_output_rejects_option_token_before_model_call(self):
         # `--output --dry-run` is a mangled preview command; consuming the
         # token as a filename silently turned it into a live benchmark run.
-        capture = self.root / "claude-capture.txt"
+        capture = self.pi_capture
         result = self.run_goal(
             "--prompt",
             "Run pinchbench",
             "--output",
             "--dry-run",
-            extra_env={"CLAUDE_STUB_CAPTURE": str(capture)},
         )
 
         self.assertEqual(result.returncode, 2)

--- a/scripts/tests/test_setup.py
+++ b/scripts/tests/test_setup.py
@@ -1,0 +1,218 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SETUP = Path(__file__).resolve().parents[1] / "setup.sh"
+
+
+class SetupTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.home = self.root / "home"
+        self.repo = self.root / "repo"
+        self.bin_dir = self.root / "bin"
+        self.state = self.root / "state"
+        for path in (self.home, self.repo / ".git", self.bin_dir, self.state):
+            path.mkdir(parents=True)
+
+        for skill in (
+            "harbor-benchmark-runner",
+            "openclaw-fleet-operations",
+            "openclaw-benchmark-runners",
+        ):
+            skill_dir = self.repo / "skills" / skill
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(f"# {skill}\n", encoding="utf-8")
+
+        (self.state / "node-version").write_text("v22.18.0\n", encoding="utf-8")
+        (self.state / "pi-version").write_text("0.80.0\n", encoding="utf-8")
+        self.write_executable(
+            "node",
+            """#!/usr/bin/env bash
+cat "$SETUP_TEST_STATE/node-version"
+""",
+        )
+        self.write_executable(
+            "nvm",
+            """#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$SETUP_TEST_STATE/nvm.log"
+if [[ "${1:-}" == "install" ]]; then
+  printf 'v24.0.0\n' >"$SETUP_TEST_STATE/node-version"
+fi
+""",
+        )
+        self.write_executable(
+            "npm",
+            """#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$SETUP_TEST_STATE/npm.log"
+printf '0.81.1\n' >"$SETUP_TEST_STATE/pi-version"
+""",
+        )
+        self.write_executable(
+            "pi",
+            """#!/usr/bin/env bash
+cat "$SETUP_TEST_STATE/pi-version"
+""",
+        )
+        self.write_executable(
+            "git",
+            """#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$SETUP_TEST_STATE/git.log"
+""",
+        )
+        for command in ("curl", "jq", "docker"):
+            self.write_executable(command, "#!/usr/bin/env bash\nexit 0\n")
+
+        pi_dir = self.home / ".pi" / "agent"
+        pi_dir.mkdir(parents=True)
+        (pi_dir / "settings.json").write_text(
+            json.dumps(
+                {
+                    "theme": "light",
+                    "customSetting": True,
+                    "enableInstallTelemetry": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (pi_dir / "models.json").write_text(
+            json.dumps(
+                {
+                    "customRoot": "preserve-me",
+                    "providers": {
+                        "other-provider": {
+                            "baseUrl": "https://other.invalid/v1",
+                            "api": "openai-completions",
+                            "apiKey": "other",
+                            "models": [{"id": "other-model"}],
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        claude_dir = self.home / ".claude"
+        claude_dir.mkdir()
+        self.claude_sentinel = claude_dir / "settings.json"
+        self.claude_sentinel.write_text('{"keep":"unchanged"}\n', encoding="utf-8")
+
+        (self.home / ".bashrc").write_text(
+            "export KEEP_ME=yes\n"
+            "# >>> sii-agent-fleet env >>>\n"
+            "export ANTHROPIC_AUTH_TOKEN=old-secret\n"
+            "# <<< sii-agent-fleet env <<<\n",
+            encoding="utf-8",
+        )
+        (self.repo / "config.local.env").write_text(
+            "# keep comment\nKEEP_SETTING=yes\nBASE_URL=https://old.invalid\n",
+            encoding="utf-8",
+        )
+
+        self.claude_tgz = self.root / "claude-code.tgz"
+        self.claude_tgz.write_text("fixture", encoding="utf-8")
+        self.wheel_dir = self.root / "wheels"
+        (self.wheel_dir / "npm-cache").mkdir(parents=True)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def write_executable(self, name: str, content: str) -> None:
+        path = self.bin_dir / name
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+
+    def test_setup_installs_pi_and_preserves_task_container_claude_artifacts(self):
+        env = os.environ.copy()
+        for name in (
+            "AUTH_TOKEN",
+            "TB_CC_CLAUDE_TGZ_SOURCE",
+            "TB_CC_PY_WHEEL_DIR_SOURCE",
+        ):
+            env.pop(name, None)
+        env.update(
+            {
+                "PATH": f"{self.bin_dir}{os.pathsep}{env['PATH']}",
+                "HOME": str(self.home),
+                "REPO_DIR": str(self.repo),
+                "BASE_URL": "https://gateway.example.invalid",
+                "API_KEY": "fake-setup-secret",
+                "MODEL": "test-model",
+                "TRACE_TO_OPIK": "false",
+                "CLAUDE_TGZ_SOURCE": str(self.claude_tgz),
+                "CLAUDE_WHEEL_DIR_SOURCE": str(self.wheel_dir),
+                "SETUP_TEST_STATE": str(self.state),
+            }
+        )
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("install 24", (self.state / "nvm.log").read_text(encoding="utf-8"))
+        npm_log = (self.state / "npm.log").read_text(encoding="utf-8")
+        self.assertIn(
+            "install -g --ignore-scripts @earendil-works/pi-coding-agent@0.81.1 --force",
+            npm_log,
+        )
+        self.assertNotIn("anthropic-ai", npm_log)
+
+        pi_dir = self.home / ".pi" / "agent"
+        settings = json.loads((pi_dir / "settings.json").read_text(encoding="utf-8"))
+        self.assertEqual(settings["defaultProvider"], "sii-gateway")
+        self.assertEqual(settings["defaultModel"], "test-model")
+        self.assertEqual(settings["theme"], "light")
+        self.assertTrue(settings["customSetting"])
+        self.assertTrue(settings["enableInstallTelemetry"])
+
+        models = json.loads((pi_dir / "models.json").read_text(encoding="utf-8"))
+        self.assertEqual(models["customRoot"], "preserve-me")
+        self.assertIn("other-provider", models["providers"])
+        provider = models["providers"]["sii-gateway"]
+        self.assertEqual(provider["baseUrl"], "https://gateway.example.invalid/v1")
+        self.assertEqual(provider["api"], "openai-completions")
+        self.assertEqual(provider["apiKey"], "$SII_AGENT_FLEET_API_KEY")
+        self.assertEqual(provider["models"][0]["id"], "test-model")
+        self.assertNotIn("fake-setup-secret", (pi_dir / "models.json").read_text())
+
+        bashrc = (self.home / ".bashrc").read_text(encoding="utf-8")
+        self.assertIn("export KEEP_ME=yes", bashrc)
+        self.assertIn("export PI_OFFLINE=1", bashrc)
+        self.assertIn("export SII_AGENT_FLEET_API_KEY=fake-setup-secret", bashrc)
+        self.assertIn(f"export TB_CC_CLAUDE_TGZ_SOURCE={self.claude_tgz}", bashrc)
+        self.assertIn(f"export TB_CC_PY_WHEEL_DIR_SOURCE={self.wheel_dir}", bashrc)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", bashrc)
+
+        for skill in (
+            "harbor-benchmark-runner",
+            "openclaw-fleet-operations",
+            "openclaw-benchmark-runners",
+        ):
+            skill_link = pi_dir / "skills" / skill
+            self.assertTrue(skill_link.is_symlink())
+            self.assertEqual(skill_link.resolve(), (self.repo / "skills" / skill).resolve())
+
+        self.assertEqual(
+            self.claude_sentinel.read_text(encoding="utf-8"),
+            '{"keep":"unchanged"}\n',
+        )
+        config = (self.repo / "config.local.env").read_text(encoding="utf-8")
+        self.assertIn("KEEP_SETTING=yes", config)
+        self.assertIn("BASE_URL=https://gateway.example.invalid", config)
+        self.assertIn("API_KEY=fake-setup-secret", config)
+        self.assertIn("MODEL=test-model", config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_setup.py
+++ b/scripts/tests/test_setup.py
@@ -144,6 +144,7 @@ printf '%s\n' "$*" >>"$SETUP_TEST_STATE/git.log"
                 "API_KEY": "fake-setup-secret",
                 "MODEL": "test-model",
                 "TRACE_TO_OPIK": "false",
+                "HARBOR_RUNNER_SETUP": "0",
                 "CLAUDE_TGZ_SOURCE": str(self.claude_tgz),
                 "CLAUDE_WHEEL_DIR_SOURCE": str(self.wheel_dir),
                 "SETUP_TEST_STATE": str(self.state),


### PR DESCRIPTION
## 1. Why the change?

The repository currently requires Claude Code in the host or DinD controller to translate user prompts into FleetSpec. Replace that control-plane dependency with Pi while retaining the existing Claude Code benchmark agent inside Harbor task containers.

Supersedes #3, resubmitted from a fork branch as required by the contribution workflow. Closes sii-system/sii-agent-fleet#92.

## 2. Summary of the change

- Install and pin `@earendil-works/pi-coding-agent@0.81.1` for control-plane use and enforce its Node.js minimum.
- Merge the managed Pi gateway provider, settings, and repository skills without overwriting unrelated Pi or existing Claude configuration.
- Run Prompt-to-FleetSpec translation through an isolated, tool-free Pi JSONL process with lifecycle, provider-error, stop-reason, and final-output validation.
- Update DinD bootstrap checks to verify Pi in the controller while preserving Claude Code artifacts and `agent=claude-code` dispatch for nested Harbor containers.
- Add focused setup, Prompt JSONL, and DinD regression coverage and update active documentation.

## 3. Review follow-up from #3

All four review comments from @LongHanyu on #3 are addressed in the head commit:

- The Prompt translation is now passed to Pi as the trailing positional message with stdin closed, matching the Harbor analyzer invocation contract, instead of being written to stdin.
- The `pi` test stub records argv and stdin separately, and the regression test asserts the prompt arrives as the final positional argument with nothing on stdin.
- `setup.sh` now defaults `REPO_DIR` to `$HOME/agent-fleet` to match the renamed repository; the root README's mention of the default is updated too.
- Extracting a shared Pi runtime module for `pi_prompt.py` and the Harbor analyzer is tracked in #7 as a follow-up, as suggested.

Additionally, `scripts/tests/test_dind_run.sh` no longer uses GNU-only `sed -i`/`0,/re/` addressing, so the DinD regression suite also runs on macOS (BSD sed).

## 4. Other details

The Harbor Claude adapter, FleetSpec agent semantics, Opik hooks, worker behavior, RL paths, and pinned task-container Claude Code version remain unchanged.

Validation on this branch:

- `python3 -m unittest discover -s scripts/tests` — 90 tests, 1 pre-existing failure (`test_run_fleet.py::test_explicit_local_taskset_maps_only_path_inputs`, also fails on clean `main` on macOS; untouched here).
- `bash scripts/tests/test_dind_run.sh` — passes, including on macOS after the portability fix.
- Shell syntax checks, Python compilation checks, and `git diff --check`.
- A real Prompt run previously used Pi to generate `agent=claude-code`, launched Harbor, installed Claude Code 2.1.90 inside the task container, and completed the verifier path.

## Porting notes

Ported from sii-system/sii-agent-fleet#104 onto this repository's history. Two adaptations:

- `test_setup.py` no longer expects the retired `tui-dashboard-deployment` skill; main removed that subsystem, and `setup.sh` here installs the remaining three skills.
- The skill-symlink assertion resolves both sides, so the test also passes on macOS where the tmpdir path traverses the `/var -> /private/var` symlink.
