### PR TITLE
Fix Harbor analyzer runtime model configuration

### DIFF
--- a/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
+++ b/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the Harbor Analyzer entrypoint that launches Pi + GLM-5.2."""
+"""Run the Harbor Analyzer entrypoint that launches Pi."""
 
 from __future__ import annotations
 
@@ -29,7 +29,7 @@ def _default_base_url() -> str:
 
 
 def _default_model() -> str:
-    return os.environ.get("HARBOR_ANALYZER_MODEL") or os.environ.get("MODEL") or "glm5.2"
+    return os.environ.get("HARBOR_ANALYZER_MODEL") or os.environ.get("MODEL") or ""
 
 
 def _ensure_analyzer_env_defaults() -> None:

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
@@ -1,4 +1,4 @@
-"""Launch an isolated read-only Pi process pinned to the GLM-5.2 analyzer model."""
+"""Launch an isolated read-only Pi process for the configured analyzer model."""
 
 from __future__ import annotations
 
@@ -101,6 +101,7 @@ def _models_config(
                 "baseUrl": base_url,
                 "api": "openai-completions",
                 "apiKey": f"${api_key_env}",
+                "authHeader": True,
                 "compat": {
                     "supportsDeveloperRole": False,
                     "supportsReasoningEffort": False,
@@ -347,6 +348,8 @@ def dispatch_to_child(
         return DispatchResult(None, provenance, "pi_binary_not_found", "")
     if not provider.strip():
         return DispatchResult(None, provenance, "pi_provider_not_configured", "")
+    if not model.strip():
+        return DispatchResult(None, provenance, "pi_model_not_configured", "")
     if not ENV_NAME_RE.fullmatch(api_key_env):
         return DispatchResult(None, provenance, "analyzer_api_key_env_invalid", "")
     if not os.environ.get(api_key_env):

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/prompt.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/prompt.py
@@ -1,4 +1,4 @@
-"""Build fixed prompts used to launch Pi/GLM analyzer subagents."""
+"""Build fixed prompts used to launch Pi analyzer subagents."""
 
 from __future__ import annotations
 

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
@@ -1,4 +1,4 @@
-"""Run per-task Pi/GLM Analyzer subagents and persist aggregate outputs."""
+"""Run per-task Pi Analyzer subagents and persist aggregate outputs."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ class AnalyzerConfig:
     run_id: str | None = None
     pi_bin: str = "pi"
     provider: str = "harbor-analyzer"
-    model: str = "glm5.2"
+    model: str = ""
     base_url: str = ""
     api_key_env: str = "HARBOR_ANALYZER_API_KEY"
     timeout_seconds: int = 900

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -18,6 +18,7 @@ if str(SCRIPT_DIR) not in sys.path:
 
 from Agents.utils.common.Harbor.scripts.analyzer_subagent import (
     FOLLOW_MAX_FAILURE_ATTEMPTS,
+    _default_model,
     _pending_handovers,
     _record_follow_failure,
 )
@@ -29,6 +30,7 @@ from Agents.utils.common.Harbor.scripts.harbor_analyzer.runner import (
     _write_outputs,
     run_handover,
 )
+from Agents.utils.common.Harbor.scripts.harbor_analyzer.pi import _models_config, dispatch_to_child
 from Agents.utils.common.Harbor.scripts.harbor_monitor.contracts import build_analyzer_handover
 
 
@@ -154,6 +156,49 @@ def write_outputs_process(root: str, marker: str) -> None:
 
 
 class HarborAnalyzerRuntimeTest(unittest.TestCase):
+    def test_analyzer_model_has_no_glm_default(self) -> None:
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(_default_model(), "")
+            self.assertEqual(
+                AnalyzerConfig(
+                    run_dir=Path("/tmp/run"),
+                    queue_dir=None,
+                    output_dir=Path("/tmp/out"),
+                ).model,
+                "",
+            )
+
+    def test_dispatch_requires_configured_model(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            result = dispatch_to_child(
+                prompt="{}",
+                analysis_id="sha256-" + ("1" * 64),
+                output_dir=Path(root),
+                pi_bin=sys.executable,
+                provider="harbor-analyzer",
+                model="",
+                base_url="https://example.test/v1",
+                api_key_env="HARBOR_ANALYZER_API_KEY",
+                agent_name="harbor_analyzer_pi_subagent",
+                timeout_seconds=1,
+            )
+
+        self.assertIsNone(result.report)
+        self.assertEqual(result.block_reason, "pi_model_not_configured")
+
+    def test_models_config_uses_bearer_auth_header_for_custom_provider(self) -> None:
+        config = _models_config(
+            provider="harbor-analyzer",
+            model="glm-5.2-fp8",
+            base_url="https://example.test/v1",
+            api_key_env="HARBOR_ANALYZER_API_KEY",
+        )
+
+        provider = config["providers"]["harbor-analyzer"]
+        self.assertEqual(provider["api"], "openai-completions")
+        self.assertEqual(provider["apiKey"], "$HARBOR_ANALYZER_API_KEY")
+        self.assertTrue(provider["authHeader"])
+
     def test_task_slug_uses_safe_basename_for_untrusted_task_index(self) -> None:
         slug = _task_slug(task(task_index="/tmp/pr83-escape"))
 


### PR DESCRIPTION
## Why the change?

The analyzer runtime should use the model configured by the user instead of silently defaulting to a GLM model. It should also fail fast when no analyzer model is configured, and custom OpenAI-compatible providers need bearer auth enabled.

This PR migrates sii-system/sii-agent-fleet#102 to sii-system/agent-fleet.

## Summary of the change

- Remove hard-coded GLM model defaults from analyzer runtime configuration.
- Return a clear pi_model_not_configured block reason when no model is provided.
- Add authHeader to the analyzer Pi provider config.
- Update Pi analyzer module descriptions to avoid implying a fixed model.

## Validation

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test*.py'`\n- `git diff --cached --check`