### PR TITLE
docs: document TMax Harbor registry dataset

### DIFF
--- a/Tasks/README.md
+++ b/Tasks/README.md
@@ -9,6 +9,7 @@ Benchmarks, task lists, and automated task workflows.
 | [`SWE-rebench-v2/`](./SWE-rebench-v2/) | SWE-rebench-v2 Harbor Hub entrypoint. |
 | [`SWE-verify/`](./SWE-verify/) | SWE-bench Verified task list for Harbor. |
 | [`SWE-smith/`](./SWE-smith/) | SWE-Smith task list for Harbor. |
+| [`TMax/`](./TMax/) | TMax Harbor registry dataset entrypoint. |
 | [`Terminal-bench-2/`](./Terminal-bench-2/) | Terminal-Bench task lists for Harbor. |
 | [`SETA/`](./SETA/) | SETA task lists. |
 

--- a/Tasks/TMax/README.md
+++ b/Tasks/TMax/README.md
@@ -1,0 +1,21 @@
+# TMax Harbor Registry Dataset
+
+TMax is available through the published Harbor Hub registry dataset.
+
+Default source:
+
+- Harbor Hub: https://hub.harborframework.com/datasets/tmax/TMax-15K-Harbor
+
+Use the registry dataset id directly:
+
+```bash
+DATASET_NAME=tmax/TMax-15K-Harbor
+```
+
+## Unified Entry
+
+Run through the normal Harbor zellij entrypoint:
+
+```bash
+DATASET_NAME=tmax/TMax-15K-Harbor bash Agents/utils/common/Harbor/start.sh --detach
+```


### PR DESCRIPTION
## Summary

- add documentation for the published TMax Harbor registry dataset
- document the registry dataset ID:
  `tmax/TMax-15K-Harbor`
- add TMax to the task documentation index
- use the existing generic Harbor entrypoint without TMax-specific handling

## Usage

```bash
DATASET_NAME=tmax/TMax-15K-Harbor \
  bash Agents/utils/common/Harbor/start.sh --detach
```

`DATASET_NAME` selects the Harbor registry dataset. The agent model must be configured separately; `tmax` and the dataset ID are not model names.

## Validation

Validated the unversioned registry ID end to end:

- Harbor registry resolution succeeded
- task images and containers started successfully
- agents and verifiers executed
- 1-task smoke test completed with reward `1.0`
- 5 tasks completed with 0 infrastructure errors
- average reward: `0.8`

The single `0.0` reward was a verifier quality failure, not a dataset resolution, Harbor, Docker, model-routing, or runtime failure.

## Scope

Documentation only. No runtime or dataset-specific code changes are required because the existing Harbor entrypoint already supports registry dataset IDs in `org/name` format.