### PR TITLE
Add self-hosted PR quick checks

### DIFF
--- a/.github/scripts/tests/test_pr_ci_workflow.py
+++ b/.github/scripts/tests/test_pr_ci_workflow.py
@@ -42,6 +42,7 @@ class PrCiWorkflowContractTest(unittest.TestCase):
                     f"python3 -m unittest discover -s {suite} -v",
                     self.workflow,
                 )
+        self.assertIn("bash scripts/tests/test_dind_run.sh", self.workflow)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_pr_ci_workflow.py
+++ b/.github/scripts/tests/test_pr_ci_workflow.py
@@ -1,0 +1,48 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "pr-ci.yml"
+
+
+class PrCiWorkflowContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_uses_safe_pull_request_event(self):
+        self.assertIn('"on":\n  pull_request:', self.workflow)
+        self.assertNotIn("pull_request_target", self.workflow)
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            self.workflow,
+        )
+
+    def test_targets_the_self_hosted_linux_runner(self):
+        self.assertIn(
+            "runs-on: [self-hosted, Linux, X64]",
+            self.workflow,
+        )
+
+    def test_uses_least_privilege_and_pinned_checkout(self):
+        self.assertIn("permissions:\n  contents: read", self.workflow)
+        self.assertNotIn("secrets.", self.workflow)
+        self.assertIn("persist-credentials: false", self.workflow)
+        self.assertRegex(
+            self.workflow,
+            re.compile(r"uses: actions/checkout@[0-9a-f]{40}"),
+        )
+
+    def test_runs_the_fast_test_suites(self):
+        for suite in ("tests", "scripts/tests", ".github/scripts/tests"):
+            with self.subTest(suite=suite):
+                self.assertIn(
+                    f"python3 -m unittest discover -s {suite} -v",
+                    self.workflow,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,45 @@
+name: PR Quick CI
+
+"on":
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-quick-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  quick-checks:
+    name: Quick checks
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Show runtime versions
+        run: |
+          set -euo pipefail
+          python3 --version
+          bash --version | head -n 1
+
+      - name: Validate shell syntax
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' script; do
+            bash -n "$script"
+          done < <(git ls-files -z '*.sh')
+
+      - name: Run quick unit tests
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s tests -v
+          python3 -m unittest discover -s scripts/tests -v
+          python3 -m unittest discover -s .github/scripts/tests -v

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -42,4 +42,5 @@ jobs:
           set -euo pipefail
           python3 -m unittest discover -s tests -v
           python3 -m unittest discover -s scripts/tests -v
+          bash scripts/tests/test_dind_run.sh
           python3 -m unittest discover -s .github/scripts/tests -v


### PR DESCRIPTION
## 1. Why the change?

The repository now has a persistent self-hosted runner but no fast validation workflow for pull requests. Contributors need early feedback on shell syntax and the lightweight unit suites before merge.

## 2. Summary of the change

- Add a `PR Quick CI` workflow for non-draft pull requests from trusted branches in this repository.
- Run the job on the self-hosted Linux x64 runner with read-only repository permissions, a pinned checkout action, no persisted credentials, cancellation of superseded runs, and a 10-minute timeout.
- Validate every tracked shell script and run the root, control-plane, DinD, and GitHub automation test suites.
- Skip fork pull requests so untrusted code cannot execute on the persistent runner attached to this public repository.
- Add contract tests that preserve the trigger, runner, least-privilege, and test-suite requirements.

## 3. Other details

### Test plan / Verification

- `docker run --rm --volume "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color`
- Parse `.github/workflows/pr-ci.yml` with PyYAML.
- `git ls-files -z '*.sh' | xargs -0 -r -n1 bash -n`
- `python3 -m unittest discover -s tests -v`
- `python3 -m unittest discover -s scripts/tests -v`
- `bash scripts/tests/test_dind_run.sh`
- `python3 -m unittest discover -s .github/scripts/tests -v`
- `git diff --check`

The quick checks complete in about 17 seconds on the registered host. Fork PRs remain excluded because persistent self-hosted runners can be compromised by untrusted PR code: https://docs.github.com/en/actions/reference/security/secure-use