### PR TITLE
LLM review: handle empty reasoning-model responses

### DIFF
--- a/.github/scripts/llm_pr_review.py
+++ b/.github/scripts/llm_pr_review.py
@@ -263,7 +263,7 @@ class LlmClient:
                 if not isinstance(content, str):
                     raise ModelResponseError("model content must be text")
                 if not content.strip():
-                    return {"findings": []}
+                    return {"findings": [], "incomplete": True}
                 return extract_json(content)
             except HTTPError as exc:
                 if exc.code not in RETRYABLE_STATUS or attempt == 2:
@@ -407,8 +407,11 @@ def build_summary(
     rejected: int,
     skipped: list[tuple[str, str]],
     truncated: bool,
+    incomplete_chunks: int,
 ) -> str:
-    coverage = "Partial" if skipped or truncated else "Complete"
+    coverage = (
+        "Partial" if skipped or truncated or incomplete_chunks else "Complete"
+    )
     headline = (
         f"Automated review found {len(findings)} actionable finding(s)."
         if findings
@@ -435,6 +438,14 @@ def build_summary(
         lines.extend(
             ["", "- Additional diff content exceeded the total review budget."]
         )
+    if incomplete_chunks:
+        lines.extend(
+            [
+                "",
+                f"- {incomplete_chunks} diff chunk(s) returned an empty model "
+                "response and were not reviewed.",
+            ]
+        )
     return "\n".join(lines)
 
 
@@ -457,8 +468,11 @@ def run_review(
     chunks, truncated = build_chunks(files)
     findings: list[Finding] = []
     rejected = 0
+    incomplete_chunks = 0
     for chunk in chunks:
         payload = llm.review(prompt, build_model_input(pull, chunk))
+        if payload.get("incomplete"):
+            incomplete_chunks += 1
         chunk_findings, chunk_rejected = validate_findings(payload, by_path)
         findings.extend(chunk_findings)
         rejected += chunk_rejected
@@ -471,7 +485,9 @@ def run_review(
     if current["head"]["sha"] != head_sha:
         return "stale"
 
-    summary = build_summary(head_sha, findings, rejected, skipped, truncated)
+    summary = build_summary(
+        head_sha, findings, rejected, skipped, truncated, incomplete_chunks
+    )
     github.create_review(pull_number, head_sha, summary, findings)
     return "published"
 

--- a/.github/scripts/llm_pr_review.py
+++ b/.github/scripts/llm_pr_review.py
@@ -136,13 +136,6 @@ def build_chunks(
     return chunks, cursor < len(source)
 
 
-def _first_nonempty_text(*candidates: Any) -> str | None:
-    for candidate in candidates:
-        if isinstance(candidate, str) and candidate.strip():
-            return candidate
-    return None
-
-
 def extract_json(content: str) -> dict[str, Any]:
     text = content.strip()
     opening, separator, fenced = text.partition("\n")
@@ -266,13 +259,10 @@ class LlmClient:
         for attempt in range(3):
             try:
                 response = _json_request(request, opener=self.opener)
-                message = response["choices"][0]["message"]
-                text = _first_nonempty_text(
-                    message.get("content"), message.get("reasoning_content")
-                )
-                if text is None:
+                content = response["choices"][0]["message"].get("content")
+                if not isinstance(content, str) or not content.strip():
                     return {"findings": []}
-                return extract_json(text)
+                return extract_json(content)
             except HTTPError as exc:
                 if exc.code not in RETRYABLE_STATUS or attempt == 2:
                     raise

--- a/.github/scripts/llm_pr_review.py
+++ b/.github/scripts/llm_pr_review.py
@@ -26,6 +26,7 @@ MAX_CHUNK_CHARS = 50_000
 MAX_TOTAL_CHARS = 200_000
 MAX_COMMENTS = 20
 MAX_FIELD_CHARS = 2_000
+MAX_RESPONSE_TOKENS = 12_000
 SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
 API_VERSION = "2022-11-28"
 REQUEST_TIMEOUT_SECONDS = 90
@@ -133,6 +134,13 @@ def build_chunks(
         output_chars += len(chunk)
 
     return chunks, cursor < len(source)
+
+
+def _first_nonempty_text(*candidates: Any) -> str | None:
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+    return None
 
 
 def extract_json(content: str) -> dict[str, Any]:
@@ -243,7 +251,7 @@ class LlmClient:
                 {"role": "user", "content": diff_chunk},
             ],
             "temperature": 0.1,
-            "max_tokens": 4_000,
+            "max_tokens": MAX_RESPONSE_TOKENS,
         }
         request = Request(
             self.base_url,
@@ -258,15 +266,18 @@ class LlmClient:
         for attempt in range(3):
             try:
                 response = _json_request(request, opener=self.opener)
-                content = response["choices"][0]["message"]["content"]
-                if not isinstance(content, str):
-                    raise ModelResponseError("model content must be text")
-                return extract_json(content)
+                message = response["choices"][0]["message"]
+                text = _first_nonempty_text(
+                    message.get("content"), message.get("reasoning_content")
+                )
+                if text is None:
+                    return {"findings": []}
+                return extract_json(text)
             except HTTPError as exc:
                 if exc.code not in RETRYABLE_STATUS or attempt == 2:
                     raise
                 self.sleeper(attempt + 1)
-            except (KeyError, IndexError, TypeError) as exc:
+            except (KeyError, IndexError, TypeError, AttributeError) as exc:
                 raise ModelResponseError(
                     "unexpected chat completion response"
                 ) from exc

--- a/.github/scripts/llm_pr_review.py
+++ b/.github/scripts/llm_pr_review.py
@@ -260,7 +260,9 @@ class LlmClient:
             try:
                 response = _json_request(request, opener=self.opener)
                 content = response["choices"][0]["message"].get("content")
-                if not isinstance(content, str) or not content.strip():
+                if not isinstance(content, str):
+                    raise ModelResponseError("model content must be text")
+                if not content.strip():
                     return {"findings": []}
                 return extract_json(content)
             except HTTPError as exc:

--- a/.github/scripts/tests/test_llm_pr_review.py
+++ b/.github/scripts/tests/test_llm_pr_review.py
@@ -282,7 +282,7 @@ class ApiClientTest(unittest.TestCase):
         with self.assertRaises(review.ModelResponseError):
             client.review("system", "diff")
 
-    def test_falls_back_to_reasoning_content_when_content_empty(self) -> None:
+    def test_empty_content_ignores_reasoning_prose(self) -> None:
         opener = mock.Mock(
             return_value=FakeResponse(
                 {
@@ -290,7 +290,7 @@ class ApiClientTest(unittest.TestCase):
                         {
                             "message": {
                                 "content": "",
-                                "reasoning_content": '{"findings": []}',
+                                "reasoning_content": "Let me analyze this diff...",
                             }
                         }
                     ]

--- a/.github/scripts/tests/test_llm_pr_review.py
+++ b/.github/scripts/tests/test_llm_pr_review.py
@@ -261,7 +261,7 @@ class ApiClientTest(unittest.TestCase):
 
         self.assertEqual(client.review("system", "diff"), {"findings": []})
 
-    def test_missing_content_key_is_treated_as_no_findings(self) -> None:
+    def test_missing_content_key_raises_model_response_error(self) -> None:
         opener = mock.Mock(
             return_value=FakeResponse({"choices": [{"message": {}}]})
         )
@@ -269,7 +269,8 @@ class ApiClientTest(unittest.TestCase):
             "https://example.invalid", "key", "model", opener, mock.Mock()
         )
 
-        self.assertEqual(client.review("system", "diff"), {"findings": []})
+        with self.assertRaises(review.ModelResponseError):
+            client.review("system", "diff")
 
     def test_malformed_message_raises_model_response_error(self) -> None:
         opener = mock.Mock(

--- a/.github/scripts/tests/test_llm_pr_review.py
+++ b/.github/scripts/tests/test_llm_pr_review.py
@@ -221,7 +221,7 @@ class ApiClientTest(unittest.TestCase):
         client = review.LlmClient(
             "https://example.invalid/v3/chat/completions",
             "secret-value",
-            "deepseek-v4-pro-202606",
+            "test-model",
             opener=opener,
             sleeper=mock.Mock(),
         )
@@ -232,8 +232,76 @@ class ApiClientTest(unittest.TestCase):
         self.assertEqual(request.get_header("Authorization"), "Bearer secret-value")
         self.assertEqual(opener.call_args.kwargs["timeout"], 90)
         body = json.loads(request.data)
-        self.assertEqual(body["model"], "deepseek-v4-pro-202606")
+        self.assertEqual(body["model"], "test-model")
         self.assertEqual(body["temperature"], 0.1)
+        self.assertEqual(body["max_tokens"], review.MAX_RESPONSE_TOKENS)
+        self.assertGreaterEqual(review.MAX_RESPONSE_TOKENS, 8_000)
+
+    def test_empty_content_is_treated_as_no_findings(self) -> None:
+        opener = mock.Mock(
+            return_value=FakeResponse(
+                {"choices": [{"message": {"content": ""}}]}
+            )
+        )
+        client = review.LlmClient(
+            "https://example.invalid", "key", "model", opener, mock.Mock()
+        )
+
+        self.assertEqual(client.review("system", "diff"), {"findings": []})
+
+    def test_whitespace_content_is_treated_as_no_findings(self) -> None:
+        opener = mock.Mock(
+            return_value=FakeResponse(
+                {"choices": [{"message": {"content": "   \n\t "}}]}
+            )
+        )
+        client = review.LlmClient(
+            "https://example.invalid", "key", "model", opener, mock.Mock()
+        )
+
+        self.assertEqual(client.review("system", "diff"), {"findings": []})
+
+    def test_missing_content_key_is_treated_as_no_findings(self) -> None:
+        opener = mock.Mock(
+            return_value=FakeResponse({"choices": [{"message": {}}]})
+        )
+        client = review.LlmClient(
+            "https://example.invalid", "key", "model", opener, mock.Mock()
+        )
+
+        self.assertEqual(client.review("system", "diff"), {"findings": []})
+
+    def test_malformed_message_raises_model_response_error(self) -> None:
+        opener = mock.Mock(
+            return_value=FakeResponse({"choices": [{"message": "oops"}]})
+        )
+        client = review.LlmClient(
+            "https://example.invalid", "key", "model", opener, mock.Mock()
+        )
+
+        with self.assertRaises(review.ModelResponseError):
+            client.review("system", "diff")
+
+    def test_falls_back_to_reasoning_content_when_content_empty(self) -> None:
+        opener = mock.Mock(
+            return_value=FakeResponse(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "",
+                                "reasoning_content": '{"findings": []}',
+                            }
+                        }
+                    ]
+                }
+            )
+        )
+        client = review.LlmClient(
+            "https://example.invalid", "key", "model", opener, mock.Mock()
+        )
+
+        self.assertEqual(client.review("system", "diff"), {"findings": []})
 
     def test_llm_client_retries_429_twice(self) -> None:
         error = HTTPError("url", 429, "rate limited", {}, None)

--- a/.github/scripts/tests/test_llm_pr_review.py
+++ b/.github/scripts/tests/test_llm_pr_review.py
@@ -237,7 +237,7 @@ class ApiClientTest(unittest.TestCase):
         self.assertEqual(body["max_tokens"], review.MAX_RESPONSE_TOKENS)
         self.assertGreaterEqual(review.MAX_RESPONSE_TOKENS, 8_000)
 
-    def test_empty_content_is_treated_as_no_findings(self) -> None:
+    def test_empty_content_is_flagged_incomplete(self) -> None:
         opener = mock.Mock(
             return_value=FakeResponse(
                 {"choices": [{"message": {"content": ""}}]}
@@ -247,9 +247,12 @@ class ApiClientTest(unittest.TestCase):
             "https://example.invalid", "key", "model", opener, mock.Mock()
         )
 
-        self.assertEqual(client.review("system", "diff"), {"findings": []})
+        self.assertEqual(
+            client.review("system", "diff"),
+            {"findings": [], "incomplete": True},
+        )
 
-    def test_whitespace_content_is_treated_as_no_findings(self) -> None:
+    def test_whitespace_content_is_flagged_incomplete(self) -> None:
         opener = mock.Mock(
             return_value=FakeResponse(
                 {"choices": [{"message": {"content": "   \n\t "}}]}
@@ -259,7 +262,10 @@ class ApiClientTest(unittest.TestCase):
             "https://example.invalid", "key", "model", opener, mock.Mock()
         )
 
-        self.assertEqual(client.review("system", "diff"), {"findings": []})
+        self.assertEqual(
+            client.review("system", "diff"),
+            {"findings": [], "incomplete": True},
+        )
 
     def test_missing_content_key_raises_model_response_error(self) -> None:
         opener = mock.Mock(
@@ -302,7 +308,10 @@ class ApiClientTest(unittest.TestCase):
             "https://example.invalid", "key", "model", opener, mock.Mock()
         )
 
-        self.assertEqual(client.review("system", "diff"), {"findings": []})
+        self.assertEqual(
+            client.review("system", "diff"),
+            {"findings": [], "incomplete": True},
+        )
 
     def test_llm_client_retries_429_twice(self) -> None:
         error = HTTPError("url", 429, "rate limited", {}, None)
@@ -538,11 +547,33 @@ class OrchestrationTest(unittest.TestCase):
     def test_summary_caps_the_skipped_path_list(self) -> None:
         skipped = [(f"generated/{index}.map", "generated") for index in range(55)]
 
-        summary = review.build_summary("head-1", [], 0, skipped, False)
+        summary = review.build_summary("head-1", [], 0, skipped, False, 0)
 
         self.assertIn("`generated/49.map`", summary)
         self.assertNotIn("`generated/50.map`", summary)
         self.assertIn("5 additional skipped file(s)", summary)
+
+    def test_summary_reports_partial_when_a_chunk_is_incomplete(self) -> None:
+        summary = review.build_summary("head-1", [], 0, [], False, 1)
+
+        self.assertIn("Coverage: Partial", summary)
+        self.assertIn("empty model response", summary)
+
+    def test_summary_reports_complete_when_no_chunk_is_incomplete(self) -> None:
+        summary = review.build_summary("head-1", [], 0, [], False, 0)
+
+        self.assertIn("Coverage: Complete", summary)
+        self.assertNotIn("empty model response", summary)
+
+    def test_run_review_reports_partial_on_empty_model_response(self) -> None:
+        github = FakeGitHub()
+        llm = mock.Mock()
+        llm.review.return_value = {"findings": [], "incomplete": True}
+
+        review.run_review(github, llm, 7, "prompt")
+
+        self.assertIn("Coverage: Partial", github.created[0][2])
+        self.assertIn("empty model response", github.created[0][2])
 
 
 class WorkflowContractTest(unittest.TestCase):


### PR DESCRIPTION
## 1. Why the change?

The `LLM PR Review` workflow was failing on non-trivial PRs with:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
→ ModelResponseError: model response is not valid JSON
```

Root cause: model `deepseek-v4-pro-202606` (Tencent TokenHub) is a **reasoning model with thinking mode enabled by default**. Chain-of-thought goes to `message.reasoning_content` and counts against `max_tokens`. With the previous 4000-token budget, larger diffs exhausted the budget during reasoning and returned an **empty** `message.content`, so `json.loads("")` failed at char 0.

The traceback confirms this: the code read `choices[0].message.content` and passed the `isinstance(content, str)` check, failing only at JSON parsing — the signature of empty (not missing/malformed) content. Run history corroborates it: small PRs succeeded, larger PRs failed, deterministically (both retry attempts failed identically).

Failing run: https://github.com/sii-system/agent-fleet/actions/runs/30016480733/job/89372301614

## 2. Summary of the change

- Raise `max_tokens` to a new `MAX_RESPONSE_TOKENS = 12000` constant so reasoning + the JSON answer both fit.
- In `LlmClient.review()`, base the decision on `content` alone: missing/non-string `content` raises `ModelResponseError` (fails loudly); an empty/whitespace `content` string returns `{"findings": [], "incomplete": True}` — the reasoning-exhaustion signal — and `reasoning_content` is never parsed as the answer.
- Surface exhaustion honestly instead of silently passing the gate: `run_review()` counts incomplete chunks and `build_summary()` reports `Coverage: Partial` with an explicit note (`- N diff chunk(s) returned an empty model response and were not reviewed.`). Findings from other chunks are preserved.
- Catch `AttributeError` so a malformed `message` still yields a clean `ModelResponseError`.
- Replace the real model name in the pass-through unit test with a neutral placeholder (`test-model`); production still reads the model from the `LLM_REVIEW_MODEL` env/repo variable.

## 3. Other details

### Test plan / Verification

- `python3 -m unittest discover -s .github/scripts/tests` — 36 tests pass.

If failures ever recur on very large diffs, the next lever is adding `"thinking": {"type": "disabled"}` to the request payload to route the answer straight to `content`.
