### PR TITLE
Sandbox draft and fork PR checks on the self-hosted runner

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes jq \
+    && rm -rf /var/lib/apt/lists/*

--- a/.github/scripts/tests/test_pr_ci_workflow.py
+++ b/.github/scripts/tests/test_pr_ci_workflow.py
@@ -5,18 +5,21 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = ROOT / ".github" / "workflows" / "pr-ci.yml"
+SANDBOX_DOCKERFILE = ROOT / ".github" / "ci" / "Dockerfile"
 
 
 class PrCiWorkflowContractTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        cls.sandbox_dockerfile = SANDBOX_DOCKERFILE.read_text(encoding="utf-8")
 
-    def test_uses_safe_pull_request_event(self):
-        self.assertIn('"on":\n  pull_request:', self.workflow)
-        self.assertNotIn("pull_request_target", self.workflow)
-        self.assertIn(
-            "github.event.pull_request.head.repo.full_name == github.repository",
+    def test_runs_for_draft_and_fork_pull_requests(self):
+        self.assertIn('"on":\n  pull_request_target:', self.workflow)
+        self.assertIn("converted_to_draft", self.workflow)
+        self.assertNotIn("pull_request.draft", self.workflow)
+        self.assertNotIn(
+            "head.repo.full_name == github.repository",
             self.workflow,
         )
 
@@ -29,13 +32,53 @@ class PrCiWorkflowContractTest(unittest.TestCase):
     def test_uses_least_privilege_and_pinned_checkout(self):
         self.assertIn("permissions:\n  contents: read", self.workflow)
         self.assertNotIn("secrets.", self.workflow)
-        self.assertIn("persist-credentials: false", self.workflow)
-        self.assertRegex(
-            self.workflow,
-            re.compile(r"uses: actions/checkout@[0-9a-f]{40}"),
+        self.assertEqual(self.workflow.count("persist-credentials: false"), 2)
+        self.assertEqual(
+            len(re.findall(r"uses: actions/checkout@[0-9a-f]{40}", self.workflow)),
+            2,
         )
 
-    def test_runs_the_fast_test_suites(self):
+    def test_builds_the_sandbox_from_the_trusted_base(self):
+        self.assertIn(
+            "ref: ${{ github.event.pull_request.base.sha }}",
+            self.workflow,
+        )
+        self.assertIn(
+            'trusted-${{ github.run_id }}/.github/ci/Dockerfile',
+            self.workflow,
+        )
+        self.assertRegex(
+            self.sandbox_dockerfile,
+            re.compile(r"\AFROM python:3\.11-slim@sha256:[0-9a-f]{64}\n"),
+        )
+
+    def test_checks_out_the_candidate_without_executing_it_on_the_host(self):
+        self.assertIn(
+            "repository: ${{ github.event.pull_request.head.repo.full_name }}",
+            self.workflow,
+        )
+        self.assertIn(
+            "ref: ${{ github.event.pull_request.head.sha }}",
+            self.workflow,
+        )
+        self.assertIn(
+            'candidate-${{ github.run_id }}:/src:ro',
+            self.workflow,
+        )
+
+    def test_locks_down_untrusted_code_in_a_container(self):
+        for option in (
+            "--network none",
+            "--read-only",
+            "--cap-drop ALL",
+            "--security-opt no-new-privileges",
+            "--user 65534:65534",
+        ):
+            with self.subTest(option=option):
+                self.assertIn(option, self.workflow)
+        self.assertNotIn("/var/run/docker.sock", self.workflow)
+
+    def test_runs_the_fast_test_suites_in_the_sandbox(self):
         for suite in ("tests", "scripts/tests", ".github/scripts/tests"):
             with self.subTest(suite=suite):
                 self.assertIn(

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,8 +1,8 @@
 name: PR Quick CI
 
 "on":
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
 
 permissions:
   contents: read
@@ -14,33 +14,71 @@ concurrency:
 jobs:
   quick-checks:
     name: Quick checks
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
+    # Candidate files are checked out on the host but are only executed inside
+    # the restricted container below. Keep every host-side command base-trusted.
     steps:
-      - name: Check out pull request
+      - name: Check out trusted CI definition
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-${{ github.run_id }}
           persist-credentials: false
 
-      - name: Show runtime versions
+      - name: Build trusted test sandbox
         run: |
           set -euo pipefail
-          python3 --version
-          bash --version | head -n 1
+          docker build \
+            --file "$GITHUB_WORKSPACE/trusted-${{ github.run_id }}/.github/ci/Dockerfile" \
+            --tag "agent-fleet-pr-ci:${{ github.run_id }}" \
+            "$GITHUB_WORKSPACE/trusted-${{ github.run_id }}/.github/ci"
 
-      - name: Validate shell syntax
-        run: |
-          set -euo pipefail
-          while IFS= read -r -d '' script; do
-            bash -n "$script"
-          done < <(git ls-files -z '*.sh')
+      - name: Check out candidate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate-${{ github.run_id }}
+          persist-credentials: false
 
-      - name: Run quick unit tests
+      - name: Run isolated quick checks
         run: |
           set -euo pipefail
-          python3 -m unittest discover -s tests -v
-          python3 -m unittest discover -s scripts/tests -v
-          bash scripts/tests/test_dind_run.sh
-          python3 -m unittest discover -s .github/scripts/tests -v
+          docker run --rm \
+            --network none \
+            --read-only \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 2g \
+            --cpus 2 \
+            --user 65534:65534 \
+            --env HOME=/tmp/home \
+            --tmpfs /tmp:rw,nosuid,nodev,exec,size=2g,mode=1777 \
+            --volume "$GITHUB_WORKSPACE/candidate-${{ github.run_id }}:/src:ro" \
+            "agent-fleet-pr-ci:${{ github.run_id }}" \
+            bash -lc '
+              set -euo pipefail
+              mkdir -p /tmp/home /tmp/work
+              cp -R /src/. /tmp/work
+              cd /tmp/work
+              find . -type f -name "*.sh" -not -path "./.git/*" -print0 |
+                while IFS= read -r -d "" script; do
+                  bash -n "$script"
+                done
+              python3 -m unittest discover -s tests -v
+              python3 -m unittest discover -s scripts/tests -v
+              bash scripts/tests/test_dind_run.sh
+              python3 -m unittest discover -s .github/scripts/tests -v
+            '
+
+      - name: Clean up sandbox
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          docker image rm --force "agent-fleet-pr-ci:${{ github.run_id }}" || true
+          rm -rf -- \
+            "$GITHUB_WORKSPACE/trusted-${{ github.run_id }}" \
+            "$GITHUB_WORKSPACE/candidate-${{ github.run_id }}"


### PR DESCRIPTION
## 1. Why the change?

`PR Quick CI` currently skips draft pull requests and every pull request opened from a fork. The self-hosted runner should validate both cases without directly executing untrusted candidate code in its host environment.

## 2. Summary of the change

- Trigger the controller with `pull_request_target`, including `converted_to_draft`, so draft and fork PR activity is covered.
- Keep the host-side workflow and sandbox Dockerfile pinned to the trusted base revision.
- Check out the candidate SHA without persisted credentials, but execute its files only inside a dedicated Docker container.
- Lock the container down with no network, a read-only root filesystem, no Linux capabilities, `no-new-privileges`, a non-root UID, no Docker socket, and CPU, memory, and process limits.
- Mount candidate source read-only, copy it into an ephemeral tmpfs, run shell validation and all quick test suites there, then remove per-run checkout directories and the tagged sandbox image.
- Pin the Python sandbox base image by digest and add contract tests for the event, trust boundary, checkout settings, and isolation controls.

## 3. Other details

### Test plan / Verification

- `docker run --rm --volume "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color`
- `docker build --check --file .github/ci/Dockerfile .github/ci`
- Build `.github/ci/Dockerfile` locally.
- Run the complete quick-check sequence in the container with the same network, filesystem, capability, UID, resource, tmpfs, and read-only bind-mount restrictions used by the workflow.
- `python3 -m unittest discover -s .github/scripts/tests -v`
- `git diff --check`

The isolated test sequence completes in about 13 seconds on `cpu-nat-093` after the sandbox image is available.

### Residual risk

Container isolation substantially reduces exposure but does not make a persistent self-hosted runner equivalent to an ephemeral GitHub-hosted runner; a container-runtime or kernel escape remains possible. GitHub explicitly warns that untrusted fork code on self-hosted infrastructure is risky: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories