### PR TITLE
docs: restructure README run sections and clarify Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,10 @@ evaluating Claude Code, OpenCode, and OpenClaw.
 - `git`, `curl`, `jq`, and `openssl`
 - Linux `util-linux` (`flock`, `setsid`, and `script`) and `procps` (`pkill`)
 
-These system commands must be on `PATH`; downloading an executable without
-adding its directory to `PATH` is not sufficient. `setup.sh` installs the
-tested Zellij and uv releases, Node.js, and Pi to user-writable locations and
-records their paths for every runner. The scripts do not require tmux. Harbor
-task containers still install and run the selected benchmark agent, including
-Claude Code.
+Install these with your system package manager, which puts them on `PATH`
+automatically. Everything else — Zellij, uv, Node.js, Pi, and the benchmark
+agents themselves — is installed automatically by `setup.sh` or inside the
+Harbor task containers.
 
 ### 2. Clone the repository
 
@@ -44,10 +42,9 @@ export TRACE_TO_OPIK=false
 ./scripts/setup.sh
 ```
 
-After setup succeeds, this shell and future shells can invoke every public
-runner without manual `PATH`, Zellij, or cache overrides. Private configuration
-stays in this checkout's ignored `config.local.env`. There is no need to source
-`~/.bashrc` before running the repository scripts.
+Setup stores your credentials in the git-ignored `config.local.env` and puts
+every managed tool on `PATH`, so the runner scripts work in this and future
+shells with no manual environment changes.
 
 ### 4. Run one benchmark
 
@@ -68,6 +65,9 @@ Then start the full benchmark, with direct arguments or in natural language
 ./scripts/run_fleet.sh --prompt "Run terminalbench21 with claude-code and 10 workers"
 ```
 
+Results are written to `runs/<RUN_ID>/` in this checkout; with tracing on,
+live traces appear in your Opik dashboard.
+
 The first run is slower while Harbor downloads the taskset and Docker images.
 At launch, the runner prints the `RUN_ID`, Zellij session, output directory,
 and `summary.txt` path. A successful foreground run closes Zellij and prints
@@ -77,6 +77,11 @@ after inspection. Noninteractive foreground runs return Harbor's exit code
 without waiting for input. Rerun `setup.sh` only when configuration changes.
 
 ## FleetSpec runs
+
+A FleetSpec is a small JSON file that declares one benchmark run — taskset,
+agent, and worker count — so runs are reproducible and can be launched in
+batches. See [scripts/README.md § FleetSpec JSON](./scripts/README.md#fleetspec-json)
+for the full format.
 
 ```bash
 # One saved FleetSpec file
@@ -88,7 +93,7 @@ without waiting for input. Rerun `setup.sh` only when configuration changes.
 
 | Flag | Short | Purpose |
 | --- | --- | --- |
-| `--taskset` | `-t` | Taskset to run |
+| `--taskset` | `-t` | Taskset to run ([available tasksets](./scripts/README.md#fleet-launch-modes)) |
 | `--agent` | `-a` | `claude-code`, `opencode`, or `openclaw` |
 | `--workers` | `-n` | Concurrency |
 | `--prompt` | `-p` | Natural-language run request (AI mode) |
@@ -97,8 +102,7 @@ without waiting for input. Rerun `setup.sh` only when configuration changes.
 | `--dry-run` | — | Preview the commands without running |
 | `--detach` | `-d` | Harbor detached mode (automatic for multi-run) |
 
-See [scripts/README.md](./scripts/README.md) for the FleetSpec format,
-tasksets, and agents.
+## Docker-in-Docker runs
 
 On hosts where Docker Hub needs registry mirrors, wrap the same arguments with
 the Docker-in-Docker launcher instead:
@@ -106,6 +110,9 @@ the Docker-in-Docker launcher instead:
 ```bash
 ./scripts/dind-run.sh --taskset terminalbench21 --agent claude-code --workers 1
 ```
+
+See [scripts/README.md § dind-run.sh](./scripts/README.md#dind-runsh) for
+configuration and caveats.
 
 ## More details
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ evaluating Claude Code, OpenCode, and OpenClaw.
 - Python 3.9 or newer
 - `git`, `curl`, and `jq`
 
-Install these with your system package manager. Everything else is installed
-automatically by `setup.sh` or inside the task containers.
+Install these with your system package manager. `setup.sh` checks the few
+remaining system tools (preinstalled on most distros) and reports anything
+missing; everything else is installed automatically.
 
 ### 2. Clone the repository
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Then start the full benchmark, with direct arguments or in natural language
 ./scripts/run_fleet.sh --prompt "Run terminalbench21 with claude-code and 10 workers"
 ```
 
-Results are written to `runs/<RUN_ID>/` in this checkout; with tracing on,
-live traces appear in your Opik dashboard.
+The run opens a terminal UI that shows live progress and final results;
+with tracing on, live traces also appear in your Opik dashboard.
 
 The first run is slower while Harbor downloads the taskset and Docker images.
 At launch, the runner prints the `RUN_ID`, Zellij session, output directory,

--- a/README.md
+++ b/README.md
@@ -9,13 +9,10 @@ evaluating Claude Code, OpenCode, and OpenClaw.
 
 - Docker with Docker Compose v2
 - Python 3.9 or newer
-- `git`, `curl`, `jq`, and `openssl`
-- Linux `util-linux` (`flock`, `setsid`, and `script`) and `procps` (`pkill`)
+- `git`, `curl`, and `jq`
 
-Install these with your system package manager, which puts them on `PATH`
-automatically. Everything else — Zellij, uv, Node.js, Pi, and the benchmark
-agents themselves — is installed automatically by `setup.sh` or inside the
-Harbor task containers.
+Install these with your system package manager. Everything else is installed
+automatically by `setup.sh` or inside the task containers.
 
 ### 2. Clone the repository
 
@@ -65,16 +62,9 @@ Then start the full benchmark, with direct arguments or in natural language
 ./scripts/run_fleet.sh --prompt "Run terminalbench21 with claude-code and 10 workers"
 ```
 
-The run opens a terminal UI that shows live progress and final results;
-with tracing on, live traces also appear in your Opik dashboard.
-
-The first run is slower while Harbor downloads the taskset and Docker images.
-At launch, the runner prints the `RUN_ID`, Zellij session, output directory,
-and `summary.txt` path. A successful foreground run closes Zellij and prints
-the final counts and reward in the calling shell. A failed interactive or
-detached run keeps its Zellij pane open for diagnostics; leave it with `Ctrl-q`
-after inspection. Noninteractive foreground runs return Harbor's exit code
-without waiting for input. Rerun `setup.sh` only when configuration changes.
+The run shows live progress and final results on screen. The first run is
+slower while the taskset and Docker images download; rerun `setup.sh` only
+when configuration changes.
 
 ## FleetSpec runs
 
@@ -100,7 +90,7 @@ for the full format.
 | `--spec` | `-s` | FleetSpec file(s) |
 | `--output` | `-o` | Save the validated spec |
 | `--dry-run` | — | Preview the commands without running |
-| `--detach` | `-d` | Harbor detached mode (automatic for multi-run) |
+| `--detach` | `-d` | Detached mode (automatic for multi-run) |
 
 ## Docker-in-Docker runs
 
@@ -118,6 +108,9 @@ configuration and caveats.
 
 - Launch modes and limitations:
   [scripts/README.md](./scripts/README.md#current-limitations)
+- Tasksets: [Tasks/README.md](./Tasks/README.md)
 - Skills: [skills/README.md](./skills/README.md)
 - Repository structure: [STRUCT.md](./STRUCT.md)
+- Tips and troubleshooting:
+  [scripts/README.md](./scripts/README.md#tips--caveats)
 - Harbor runner: [Agents/utils/common/Harbor/STRUCT.md](./Agents/utils/common/Harbor/STRUCT.md)


### PR DESCRIPTION
## Why the change

The root README mixed Docker-in-Docker usage into the FleetSpec section, front-loaded setup internals a first-time reader does not need, and gave no pointer to the valid taskset values. Review feedback on #10 asked for the same direction: keep details in scripts/README.md and the README to what users act on.

## Summary of the change

- Split Docker-in-Docker runs into their own section with a link to the dind-run.sh configuration and caveats; it applies to every launch mode, not just specs.
- Open the FleetSpec section with a one-sentence definition and a deep link to the full format (`scripts/README.md#fleetspec-json`).
- Trim the prerequisite list to packages that are not preinstalled (Docker, Python, git/curl/jq) and condense the setup paragraphs; the full list stays in scripts/README.md.
- Compress the launch/exit reporting paragraph to what the user sees on screen; RUN_ID, summary.txt, and exit-code details remain in scripts/README.md.
- Remove Harbor as a concept from the Quick Start flow and flag table; it stays in More details for readers going deeper.
- Link the taskset index (Tasks/README.md, now including TMax) and Tips & Caveats from More details.

## Other details

Documentation only; diff is README.md alone. Addresses the three review comments left on #10 (preinstalled packages, detail placement, run-reporting verbosity). All deep-link anchors verified against the current scripts/README.md and Tasks/README.md.