### PR TITLE
refactor(harbor): extract shared Pi subprocess runtime

### DIFF
--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -23,7 +23,8 @@ Agents/utils/common/Harbor/
 └── scripts/
     ├── monitor.py              # Monitor CLI entrypoint and path resolution
     ├── analyzer_subagent.py    # Analyzer entrypoint for Pi/GLM-5.2 root-cause analysis
-    ├── harbor_analyzer/        # Contract validation, fixed prompt, Pi dispatch, output validation
+    ├── harbor_analyzer/        # Analyzer policy, Pi adapter, contracts, and output validation
+    ├── harbor_pi_runtime/      # Shared isolated Pi process and JSON-event helper
     ├── harbor_monitor/
     │   ├── artifacts.py        # Queue, result, manifest, environment, and state I/O
     │   ├── classification.py   # Task and benchmark status classification
@@ -37,6 +38,11 @@ Agents/utils/common/Harbor/
 Analyzer architecture and output boundaries are documented in
 [ANALYZER_ARCHITECTURE.md](ANALYZER_ARCHITECTURE.md). Analyzer credentials stay
 in the environment as `HARBOR_ANALYZER_*` variables.
+
+`harbor_pi_runtime` owns only provider setup, isolated process lifecycle,
+JSON-event validation, final JSON extraction, and provenance shared by Harbor
+Pi callers. Analyzer-specific tool access, path gating, prompts, artifact
+locations, and error compatibility remain in `harbor_analyzer/pi.py`.
 
 ```text
 Agents/utils/rl/

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
@@ -2,24 +2,28 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
-import os
-import re
-import shutil
-import signal
-import subprocess
-import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, BinaryIO
-from urllib.parse import urlparse
+from typing import Any
 
-from .io import canonical_json, write_text_atomic
+from harbor_pi_runtime import (
+    PiProcessResult,
+    run_pi_json_process,
+    write_text_atomic,
+)
+from harbor_pi_runtime import (
+    load_final_json_from_event_stream as _load_final_json_from_event_stream,
+)
+from harbor_pi_runtime.process import models_config, normalized_base_url
 
-ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-MESSAGE_UPDATE_RE = re.compile(br'^\s*\{\s*"type"\s*:\s*"message_update"\s*[,}]')
 PI_EXTENSION_PATH = Path(__file__).resolve().parent / "pi_extensions" / "analyzer_path_gate.ts"
+ANALYZER_SYSTEM_PROMPT = (
+    "You are a read-only Harbor failure analyzer. You may use only read-only file tools "
+    "(read, grep, find, ls) to inspect the handover and referenced artifacts. Do not run "
+    "shell commands, edit files, write files, repair tasks, restart workers, or stop a "
+    "benchmark. Return exactly one JSON object."
+)
 
 
 @dataclass
@@ -30,65 +34,6 @@ class DispatchResult:
     stderr_tail: str
 
 
-def _enabled(value: str | None) -> bool:
-    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _normalized_base_url(base_url: str) -> str:
-    value = base_url.strip().rstrip("/")
-    if value and not value.endswith("/v1"):
-        value = f"{value}/v1"
-    return value
-
-
-def _reason_code(message: str) -> str:
-    value = re.sub(r"[^A-Za-z0-9]+", "_", message.strip().lower()).strip("_")
-    return value[:80] or "unknown_error"
-
-
-def _pi_environment(base_url: str, runtime_home: Path, api_key_env: str) -> tuple[dict[str, str], bool]:
-    environment: dict[str, str] = {}
-    passthrough_keys = {
-        "PATH",
-        "LANG",
-        "LC_ALL",
-        "SSL_CERT_FILE",
-        "REQUESTS_CA_BUNDLE",
-        "CURL_CA_BUNDLE",
-        "NODE_EXTRA_CA_CERTS",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "NO_PROXY",
-        "ALL_PROXY",
-        "http_proxy",
-        "https_proxy",
-        "no_proxy",
-        "all_proxy",
-    }
-    for key in passthrough_keys:
-        value = os.environ.get(key)
-        if value:
-            environment[key] = value
-    environment.setdefault("PATH", os.defpath)
-    environment["HOME"] = str(runtime_home)
-    environment["PI_CODING_AGENT_DIR"] = str(runtime_home)
-    environment["PI_OFFLINE"] = "1"
-    if os.environ.get(api_key_env):
-        environment[api_key_env] = os.environ[api_key_env]
-    if not _enabled(os.environ.get("HARBOR_ANALYZER_NO_PROXY")):
-        return environment, False
-
-    hostname = urlparse(base_url).hostname
-    if not hostname:
-        return environment, False
-    for key in ("NO_PROXY", "no_proxy"):
-        entries = [item.strip() for item in environment.get(key, "").split(",") if item.strip()]
-        if hostname not in entries:
-            entries.append(hostname)
-        environment[key] = ",".join(entries)
-    return environment, True
-
-
 def _models_config(
     *,
     provider: str,
@@ -96,258 +41,26 @@ def _models_config(
     base_url: str,
     api_key_env: str,
 ) -> dict[str, Any]:
-    return {
-        "providers": {
-            provider: {
-                "baseUrl": base_url,
-                "api": "openai-completions",
-                "apiKey": f"${api_key_env}",
-                "authHeader": True,
-                "compat": {
-                    "supportsDeveloperRole": False,
-                    "supportsReasoningEffort": False,
-                    "supportsUsageInStreaming": True,
-                    "maxTokensField": "max_tokens",
-                    "thinkingFormat": "zai",
-                },
-                "models": [
-                    {
-                        "id": model,
-                        "name": "Harbor Analyzer",
-                        "reasoning": True,
-                        "input": ["text"],
-                        "contextWindow": 204800,
-                        "maxTokens": 32768,
-                        "cost": {
-                            "input": 0,
-                            "output": 0,
-                            "cacheRead": 0,
-                            "cacheWrite": 0,
-                        },
-                    }
-                ],
-            }
-        }
-    }
+    """Keep the Analyzer's existing model-config helper contract."""
 
-
-def _message_text(message: Any) -> str:
-    if not isinstance(message, dict) or message.get("role") != "assistant":
-        return ""
-    content = message.get("content")
-    if isinstance(content, str):
-        return content.strip()
-    if not isinstance(content, list):
-        return ""
-    parts: list[str] = []
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") not in {"text", "output_text"}:
-            continue
-        text = block.get("text")
-        if isinstance(text, str):
-            parts.append(text)
-    return "\n".join(parts).strip()
-
-
-@dataclass
-class _EventStreamState:
-    stored_sha256: Any = field(default_factory=hashlib.sha256)
-    session_ids: list[str] = field(default_factory=list)
-    jsonl_event_count: int = 0
-    jsonl_invalid_line_count: int = 0
-    agent_start_count: int = 0
-    agent_end_count: int = 0
-    turn_start_count: int = 0
-    turn_end_count: int = 0
-    tool_event_count: int = 0
-    retry_start_count: int = 0
-    retry_end_count: int = 0
-    message_updates_dropped: int = 0
-    observed_bytes: int = 0
-    stored_bytes: int = 0
-    final_retry_error: str = ""
-    last_provider_error: str = ""
-    final_message: dict[str, Any] | None = None
-    stream_error: OSError | None = None
-
-    def observe(self, event: dict[str, Any]) -> None:
-        self.jsonl_event_count += 1
-        event_type = str(event.get("type") or "")
-        if event_type == "session" and event.get("id"):
-            self.session_ids.append(str(event["id"]))
-        elif event_type == "agent_start":
-            self.agent_start_count += 1
-        elif event_type == "agent_end":
-            self.agent_end_count += 1
-        elif event_type == "turn_start":
-            self.turn_start_count += 1
-        elif event_type == "turn_end":
-            self.turn_end_count += 1
-        elif event_type == "auto_retry_start":
-            self.retry_start_count += 1
-        elif event_type == "auto_retry_end":
-            self.retry_end_count += 1
-            final_error = str(event.get("finalError") or "")
-            if final_error:
-                self.final_retry_error = final_error
-        if event_type.startswith("tool_execution_"):
-            self.tool_event_count += 1
-
-        message = event.get("message")
-        if isinstance(message, dict):
-            provider_error = str(message.get("errorMessage") or "")
-            if provider_error:
-                self.last_provider_error = provider_error
-            if event_type in {"message_end", "turn_end"} and message.get("role") == "assistant":
-                self.final_message = message
-
-    @property
-    def final_text(self) -> str:
-        return _message_text(self.final_message)
-
-    @property
-    def provider_error(self) -> str:
-        return self.final_retry_error or self.last_provider_error
-
-    @property
-    def final_stop_reason(self) -> str:
-        return str((self.final_message or {}).get("stopReason") or "")
-
-
-def _message_update_line(raw_line: bytes) -> bool:
-    return MESSAGE_UPDATE_RE.match(raw_line) is not None
-
-
-def _consume_event_stream(
-    stream: BinaryIO,
-    output: BinaryIO,
-    state: _EventStreamState,
-) -> None:
-    try:
-        for raw_line in iter(stream.readline, b""):
-            if not raw_line.strip():
-                continue
-            state.observed_bytes += len(raw_line)
-            if _message_update_line(raw_line):
-                state.jsonl_event_count += 1
-                state.message_updates_dropped += 1
-                continue
-
-            try:
-                event = json.loads(raw_line)
-            except (UnicodeDecodeError, json.JSONDecodeError):
-                state.jsonl_invalid_line_count += 1
-            else:
-                if isinstance(event, dict):
-                    state.observe(event)
-                else:
-                    state.jsonl_invalid_line_count += 1
-
-            if state.stream_error is not None:
-                continue
-            try:
-                output.write(raw_line)
-                output.flush()
-            except OSError as exc:
-                state.stream_error = exc
-                continue
-            state.stored_sha256.update(raw_line)
-            state.stored_bytes += len(raw_line)
-    except OSError as exc:
-        state.stream_error = exc
-
-
-def _update_event_provenance(
-    provenance: dict[str, Any],
-    state: _EventStreamState,
-) -> None:
-    provenance.update(
-        {
-            "events_sha256": state.stored_sha256.hexdigest(),
-            "jsonl_event_count": state.jsonl_event_count,
-            "jsonl_invalid_line_count": state.jsonl_invalid_line_count,
-            "agent_start_count": state.agent_start_count,
-            "agent_end_count": state.agent_end_count,
-            "turn_start_count": state.turn_start_count,
-            "turn_end_count": state.turn_end_count,
-            "tool_event_count": state.tool_event_count,
-            "auto_retry_start_count": state.retry_start_count,
-            "auto_retry_end_count": state.retry_end_count,
-            "message_updates_dropped": state.message_updates_dropped,
-            "events_observed_bytes": state.observed_bytes,
-            "events_stored_bytes": state.stored_bytes,
-        }
+    return models_config(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        display_name="Harbor Analyzer",
+        auth_header=True,
     )
 
 
-def _loads_final_json(text: str) -> tuple[dict[str, Any] | None, bool]:
-    try:
-        value = json.loads(text)
-    except json.JSONDecodeError:
-        value = None
-    if isinstance(value, dict):
-        return value, False
-
-    decoder = json.JSONDecoder()
-    for index, character in enumerate(text):
-        if character != "{":
-            continue
-        try:
-            value, _ = decoder.raw_decode(text[index:])
-        except json.JSONDecodeError:
-            continue
-        if isinstance(value, dict):
-            return value, True
-    return None, False
-
-
 def load_final_json_from_event_stream(path: Path) -> dict[str, Any] | None:
-    state = _EventStreamState()
-    try:
-        with path.open("rb") as stream:
-            for raw_line in stream:
-                if not raw_line.strip():
-                    continue
-                try:
-                    event = json.loads(raw_line)
-                except (UnicodeDecodeError, json.JSONDecodeError):
-                    return None
-                if not isinstance(event, dict):
-                    return None
-                state.observe(event)
-    except OSError:
-        return None
-    report, _ = _loads_final_json(state.final_text)
-    if report is None:
-        return None
-    return report
+    return _load_final_json_from_event_stream(path)
 
 
 def load_report_from_event_stream(path: Path) -> dict[str, Any] | None:
     """Backward-compatible alias for callers that only need the final JSON."""
 
     return load_final_json_from_event_stream(path)
-
-
-def _pi_version(binary: str, environment: dict[str, str], cwd: Path) -> str | None:
-    try:
-        completed = subprocess.run(
-            [binary, "--version"],
-            cwd=cwd,
-            env=environment,
-            shell=False,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            timeout=10,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    value = (completed.stdout or "").strip()
-    return value or None
 
 
 def _existing_paths(paths: list[Path | None]) -> list[str]:
@@ -370,6 +83,29 @@ def _existing_paths(paths: list[Path | None]) -> list[str]:
     return resolved
 
 
+def _analyzer_block_reason(reason: str | None) -> str | None:
+    if reason == "pi_api_key_env_invalid":
+        return "analyzer_api_key_env_invalid"
+    if reason and reason.startswith("pi_api_key_env_missing:"):
+        return reason.replace("pi_api_key_env_missing:", "analyzer_api_key_env_missing:", 1)
+    if reason == "pi_base_url_invalid":
+        return "analyzer_base_url_invalid"
+    if reason == "pi_extension_missing":
+        return "analyzer_path_gate_extension_missing"
+    return reason
+
+
+def _dispatch_result(result: PiProcessResult) -> DispatchResult:
+    provenance = dict(result.provenance)
+    provenance.pop("thinking_level", None)
+    return DispatchResult(
+        report=result.output_json,
+        provenance=provenance,
+        block_reason=_analyzer_block_reason(result.block_reason),
+        stderr_tail=result.stderr_tail,
+    )
+
+
 def dispatch_to_child(
     *,
     prompt: str,
@@ -388,14 +124,14 @@ def dispatch_to_child(
     runtime_home = output_dir / ".pi-analyzer-home" / analysis_id
     runtime_workdir = output_dir / ".pi-analyzer-work" / analysis_id
     access_audit_path = output_dir / "analyzer-tool-access" / f"{analysis_id}.jsonl"
-    normalized_base_url = _normalized_base_url(base_url)
+    normalized_url = normalized_base_url(base_url)
     provenance: dict[str, Any] = {
         "launch_mode": "independent_pi_analyzer_subprocess",
         "pi_binary": pi_bin,
         "child_agent": agent_name,
         "provider": provider,
         "provider_api": "openai-completions",
-        "provider_base_url": normalized_base_url,
+        "provider_base_url": normalized_url,
         "api_key_env": api_key_env,
         "events_path": str(events_path),
         "tools_disabled": False,
@@ -411,42 +147,9 @@ def dispatch_to_child(
         "code_only_fallback_used": False,
     }
 
-    resolved_pi = shutil.which(pi_bin)
-    if resolved_pi is None:
-        return DispatchResult(None, provenance, "pi_binary_not_found", "")
-    if not provider.strip():
-        return DispatchResult(None, provenance, "pi_provider_not_configured", "")
-    if not model.strip():
-        return DispatchResult(None, provenance, "pi_model_not_configured", "")
-    if not ENV_NAME_RE.fullmatch(api_key_env):
-        return DispatchResult(None, provenance, "analyzer_api_key_env_invalid", "")
-    if not os.environ.get(api_key_env):
-        return DispatchResult(None, provenance, f"analyzer_api_key_env_missing:{api_key_env}", "")
-    parsed_url = urlparse(normalized_base_url)
-    if parsed_url.scheme not in {"http", "https"} or not parsed_url.hostname:
-        return DispatchResult(None, provenance, "analyzer_base_url_invalid", "")
-    if not PI_EXTENSION_PATH.is_file():
-        return DispatchResult(None, provenance, "analyzer_path_gate_extension_missing", "")
-
-    models_config = _models_config(
-        provider=provider,
-        model=model,
-        base_url=normalized_base_url,
-        api_key_env=api_key_env,
-    )
-    models_text = canonical_json(models_config) + "\n"
-    runtime_home.mkdir(parents=True, exist_ok=True)
     runtime_workdir.mkdir(parents=True, exist_ok=True)
-    events_path.parent.mkdir(parents=True, exist_ok=True)
     access_audit_path.parent.mkdir(parents=True, exist_ok=True)
-    write_text_atomic(runtime_home / "models.json", models_text)
-    environment, proxy_bypassed = _pi_environment(normalized_base_url, runtime_home, api_key_env)
     allowed_path_values = _existing_paths([runtime_workdir, *(allowed_paths or [])])
-    environment["HARBOR_ANALYZER_ALLOWED_PATHS_JSON"] = json.dumps(
-        allowed_path_values,
-        ensure_ascii=False,
-    )
-    environment["HARBOR_ANALYZER_ACCESS_AUDIT_PATH"] = str(access_audit_path)
     write_text_atomic(
         runtime_workdir / "allowed-paths.json",
         json.dumps(
@@ -462,147 +165,43 @@ def dispatch_to_child(
         )
         + "\n",
     )
-    provenance.update(
-        {
-            "pi_binary_resolved": resolved_pi,
-            "pi_version": _pi_version(resolved_pi, environment, runtime_workdir),
-            "child_model": model,
-            "runtime_pi_home": str(runtime_home),
-            "runtime_workdir": str(runtime_workdir),
-            "models_config_sha256": hashlib.sha256(models_text.encode("utf-8")).hexdigest(),
-            "provider_proxy_bypassed": proxy_bypassed,
-            "environment_mode": "minimal",
-            "environment_keys": sorted(environment),
-            "allowed_paths": allowed_path_values,
-        }
-    )
-
-    command = [
-        resolved_pi,
-        "--mode",
-        "json",
-        "--print",
-        "--provider",
-        provider,
-        "--model",
-        model,
-        "--no-session",
-        "--no-builtin-tools",
-        "--tools",
-        "read,grep,find,ls",
-        "--extension",
-        str(PI_EXTENSION_PATH),
-        "--no-extensions",
-        "--no-skills",
-        "--no-prompt-templates",
-        "--no-context-files",
-        "--system-prompt",
-        (
-            "You are a read-only Harbor failure analyzer. You may use only read-only file tools "
-            "(read, grep, find, ls) to inspect the handover and referenced artifacts. Do not run "
-            "shell commands, edit files, write files, repair tasks, restart workers, or stop a "
-            "benchmark. Return exactly one JSON object."
+    extra_env = {
+        "HARBOR_ANALYZER_ALLOWED_PATHS_JSON": json.dumps(
+            allowed_path_values,
+            ensure_ascii=False,
         ),
-        prompt,
-    ]
-    stderr_path = output_dir / "analyzer-subagent-stderr" / f"{analysis_id}.txt"
-    stderr_path.parent.mkdir(parents=True, exist_ok=True)
-    provenance["stderr_path"] = str(stderr_path)
-    provenance["timeout_seconds"] = timeout_seconds
-    state = _EventStreamState()
-    timed_out = False
-    try:
-        with events_path.open("wb") as events_file, stderr_path.open(
-            "w",
-            encoding="utf-8",
-        ) as stderr_file:
-            process = subprocess.Popen(
-                command,
-                cwd=runtime_workdir,
-                env=environment,
-                shell=False,
-                stdout=subprocess.PIPE,
-                stderr=stderr_file,
-                start_new_session=True,
-            )
-            assert process.stdout is not None
-            reader = threading.Thread(
-                target=_consume_event_stream,
-                args=(process.stdout, events_file, state),
-            )
-            reader.start()
-            try:
-                return_code = process.wait(timeout=timeout_seconds)
-            except subprocess.TimeoutExpired:
-                timed_out = True
-                try:
-                    os.killpg(process.pid, signal.SIGKILL)
-                except OSError:
-                    process.kill()
-                return_code = process.wait()
-            reader.join()
-            process.stdout.close()
-            stderr_file.flush()
-    except OSError as exc:
-        return DispatchResult(None, provenance, f"pi_dispatch_os_error:{exc}", "")
-
-    stderr = stderr_path.read_text(encoding="utf-8", errors="replace")
-    provenance["pi_exit_code"] = return_code
-    provenance["pi_session_ids"] = state.session_ids
-    _update_event_provenance(provenance, state)
-    if timed_out:
-        provenance["events_partial"] = True
-        return DispatchResult(None, provenance, "pi_dispatch_timeout", stderr[-4000:])
-    if state.stream_error is not None:
-        return DispatchResult(
-            None,
-            provenance,
-            f"pi_event_stream_os_error:{state.stream_error}",
-            stderr[-4000:],
-        )
-    if return_code != 0:
-        return DispatchResult(
-            None,
-            provenance,
-            f"pi_dispatch_exit_code:{return_code}",
-            stderr[-4000:],
-        )
-
-    if state.jsonl_invalid_line_count:
-        return DispatchResult(None, provenance, "pi_jsonl_invalid", stderr[-4000:])
-    if len(state.session_ids) != 1:
-        return DispatchResult(None, provenance, "pi_subagent_session_not_observed", stderr[-4000:])
-    if state.agent_start_count < 1 or state.agent_start_count != state.agent_end_count:
-        return DispatchResult(None, provenance, "pi_subagent_lifecycle_invalid", stderr[-4000:])
-    if state.turn_start_count < 1 or state.turn_start_count != state.turn_end_count:
-        return DispatchResult(None, provenance, "pi_subagent_turn_invalid", stderr[-4000:])
-    provider_error = state.provider_error
-    output_block_reason = (
-        f"pi_provider_request_failed:{_reason_code(provider_error)}"
-        if provider_error
-        else "pi_final_message_truncated"
-        if state.final_stop_reason == "length"
-        else None
+        "HARBOR_ANALYZER_ACCESS_AUDIT_PATH": str(access_audit_path),
+    }
+    result = run_pi_json_process(
+        prompt=prompt,
+        events_path=events_path,
+        stderr_path=output_dir / "analyzer-subagent-stderr" / f"{analysis_id}.txt",
+        runtime_home=runtime_home,
+        runtime_workdir=runtime_workdir,
+        pi_bin=pi_bin,
+        provider=provider,
+        model=model,
+        base_url=normalized_url,
+        api_key_env=api_key_env,
+        agent_name=agent_name,
+        display_name="Harbor Analyzer",
+        timeout_seconds=timeout_seconds,
+        launch_mode="independent_pi_analyzer_subprocess",
+        system_prompt=ANALYZER_SYSTEM_PROMPT,
+        provenance=provenance,
+        no_proxy_env="HARBOR_ANALYZER_NO_PROXY",
+        extra_env=extra_env,
+        prompt_in_stdin=False,
+        no_tools=False,
+        no_builtin_tools=True,
+        tools=["read", "grep", "find", "ls"],
+        extension_path=PI_EXTENSION_PATH,
+        disable_extensions=True,
+        disable_skills=True,
+        disable_prompt_templates=True,
+        disable_context_files=True,
+        stream_compaction=True,
+        auth_header=True,
     )
-    final_stop_reason = state.final_stop_reason
-    if final_stop_reason:
-        provenance["pi_final_stop_reason"] = final_stop_reason
-    final_text = state.final_text
-    if not final_text and output_block_reason:
-        if provider_error:
-            provenance["pi_provider_final_error"] = provider_error
-        return DispatchResult(None, provenance, output_block_reason, stderr[-4000:])
-    report, extracted_from_text = _loads_final_json(final_text)
-    if report is None:
-        if output_block_reason:
-            if provider_error:
-                provenance["pi_provider_final_error"] = provider_error
-            return DispatchResult(None, provenance, output_block_reason, stderr[-4000:])
-        if final_text:
-            provenance["final_message_sha256"] = hashlib.sha256(final_text.encode("utf-8")).hexdigest()
-        return DispatchResult(None, provenance, "pi_final_message_invalid_json", stderr[-4000:])
-
-    provenance["final_message_sha256"] = hashlib.sha256(final_text.encode("utf-8")).hexdigest()
-    provenance["final_json_extracted_from_text"] = extracted_from_text
-    provenance["provenance_valid"] = True
-    return DispatchResult(report, provenance, None, stderr[-4000:])
+    result.provenance["allowed_paths"] = allowed_path_values
+    return _dispatch_result(result)

--- a/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/__init__.py
@@ -1,0 +1,15 @@
+"""Small shared helper for isolated Harbor Pi subprocesses."""
+
+from .process import (
+    PiProcessResult,
+    load_final_json_from_event_stream,
+    run_pi_json_process,
+    write_text_atomic,
+)
+
+__all__ = [
+    "PiProcessResult",
+    "load_final_json_from_event_stream",
+    "run_pi_json_process",
+    "write_text_atomic",
+]

--- a/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/process.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/process.py
@@ -1,0 +1,760 @@
+"""Launch isolated Pi subprocesses and validate their JSON event streams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO
+from urllib.parse import urlparse
+
+ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+MESSAGE_UPDATE_RE = re.compile(br'^\s*\{\s*"type"\s*:\s*"message_update"\s*[,}]')
+THINKING_LEVELS = {"off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
+PERSISTED_EVENT_TYPES = {
+    "agent_end",
+    "agent_start",
+    "auto_retry_end",
+    "auto_retry_start",
+    "message_end",
+    "result",
+    "session",
+    "turn_end",
+    "turn_start",
+}
+@dataclass
+class PiProcessResult:
+    output_json: dict[str, Any] | None
+    output_text: str
+    provenance: dict[str, Any]
+    block_reason: str | None
+    stderr_tail: str
+
+
+class _StreamingEventState:
+    def __init__(self) -> None:
+        self.hasher = hashlib.sha256()
+        self.event_count = 0
+        self.invalid_lines = 0
+        self.message_updates_dropped = 0
+        self.observed_bytes = 0
+        self.stored_bytes = 0
+        self.stream_error: OSError | None = None
+
+
+def _consume_compact_stream(
+    stream: BinaryIO,
+    output: BinaryIO,
+    state: _StreamingEventState,
+) -> None:
+    try:
+        for raw_line in iter(stream.readline, b""):
+            if not raw_line.strip():
+                continue
+            state.observed_bytes += len(raw_line)
+            if MESSAGE_UPDATE_RE.match(raw_line):
+                state.event_count += 1
+                state.message_updates_dropped += 1
+                continue
+            try:
+                event = json.loads(raw_line)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                state.invalid_lines += 1
+            else:
+                if isinstance(event, dict):
+                    state.event_count += 1
+                else:
+                    state.invalid_lines += 1
+            if state.stream_error is not None:
+                continue
+            try:
+                output.write(raw_line)
+                output.flush()
+            except OSError as exc:
+                state.stream_error = exc
+                continue
+            state.hasher.update(raw_line)
+            state.stored_bytes += len(raw_line)
+    except OSError as exc:
+        state.stream_error = exc
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def normalized_base_url(base_url: str) -> str:
+    value = base_url.strip().rstrip("/")
+    if value and not value.endswith("/v1"):
+        value = f"{value}/v1"
+    return value
+
+
+def reason_code(message: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9]+", "_", message.strip().lower()).strip("_")
+    return value[:80] or "unknown_error"
+
+
+def _enabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def pi_environment(
+    *,
+    base_url: str,
+    runtime_home: Path,
+    api_key_env: str,
+    no_proxy_env: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[dict[str, str], bool]:
+    environment: dict[str, str] = {}
+    passthrough_keys = {
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "NODE_EXTRA_CA_CERTS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "all_proxy",
+    }
+    for key in passthrough_keys:
+        value = os.environ.get(key)
+        if value:
+            environment[key] = value
+    environment.setdefault("PATH", os.defpath)
+    environment["HOME"] = str(runtime_home)
+    environment["PI_CODING_AGENT_DIR"] = str(runtime_home)
+    environment["PI_OFFLINE"] = "1"
+    if os.environ.get(api_key_env):
+        environment[api_key_env] = os.environ[api_key_env]
+    if extra_env:
+        environment.update(extra_env)
+
+    if no_proxy_env is None or not _enabled(os.environ.get(no_proxy_env)):
+        return environment, False
+    hostname = urlparse(base_url).hostname
+    if not hostname:
+        return environment, False
+    for key in ("NO_PROXY", "no_proxy"):
+        entries = [item.strip() for item in environment.get(key, "").split(",") if item.strip()]
+        if hostname not in entries:
+            entries.append(hostname)
+        environment[key] = ",".join(entries)
+    return environment, True
+
+
+def models_config(
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+    api_key_env: str,
+    display_name: str,
+    auth_header: bool | None = None,
+) -> dict[str, Any]:
+    provider_config: dict[str, Any] = {
+        "baseUrl": base_url,
+        "api": "openai-completions",
+        "apiKey": f"${api_key_env}",
+        "compat": {
+            "supportsDeveloperRole": False,
+            "supportsReasoningEffort": False,
+            "supportsUsageInStreaming": True,
+            "maxTokensField": "max_tokens",
+            "thinkingFormat": "zai",
+        },
+        "models": [
+            {
+                "id": model,
+                "name": display_name,
+                "reasoning": True,
+                "input": ["text"],
+                "contextWindow": 204800,
+                "maxTokens": 32768,
+                "cost": {
+                    "input": 0,
+                    "output": 0,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                },
+            }
+        ],
+    }
+    if auth_header is not None:
+        provider_config["authHeader"] = auth_header
+    return {"providers": {provider: provider_config}}
+
+
+def parse_jsonl(raw: str) -> tuple[list[dict[str, Any]], int]:
+    events: list[dict[str, Any]] = []
+    invalid_lines = 0
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            invalid_lines += 1
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+        else:
+            invalid_lines += 1
+    return events, invalid_lines
+
+
+def compact_jsonl_event_stream(
+    raw_path: Path,
+    compact_path: Path,
+) -> tuple[list[dict[str, Any]], int, dict[str, Any]]:
+    """Persist final/audit events while discarding cumulative streaming updates."""
+
+    raw_hasher = hashlib.sha256()
+    kept_events: list[dict[str, Any]] = []
+    invalid_lines = 0
+    raw_event_count = 0
+    discarded_counts: dict[str, int] = {}
+    compact_path.parent.mkdir(parents=True, exist_ok=True)
+    with raw_path.open("rb") as source, compact_path.open("w", encoding="utf-8") as target:
+        for raw_line in source:
+            raw_hasher.update(raw_line)
+            decoded = raw_line.decode("utf-8", errors="replace")
+            if not decoded.strip():
+                continue
+            try:
+                event = json.loads(decoded)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                target.write(decoded if decoded.endswith("\n") else f"{decoded}\n")
+                continue
+            if not isinstance(event, dict):
+                invalid_lines += 1
+                target.write(decoded if decoded.endswith("\n") else f"{decoded}\n")
+                continue
+            raw_event_count += 1
+            event_type = str(event.get("type") or "")
+            persist = (
+                event_type in PERSISTED_EVENT_TYPES
+                or event_type.startswith("tool_execution_")
+                or "error" in event_type
+            )
+            if persist:
+                kept_events.append(event)
+                target.write(json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n")
+            else:
+                discarded_counts[event_type or "unknown"] = (
+                    discarded_counts.get(event_type or "unknown", 0) + 1
+                )
+    compact_sha256 = hashlib.sha256(compact_path.read_bytes()).hexdigest()
+    return kept_events, invalid_lines, {
+        "raw_events_sha256": raw_hasher.hexdigest(),
+        "raw_jsonl_event_count": raw_event_count,
+        "persisted_jsonl_event_count": len(kept_events),
+        "discarded_event_counts": dict(sorted(discarded_counts.items())),
+        "events_sha256": compact_sha256,
+    }
+
+
+def _message_text(message: Any) -> str:
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") not in {"text", "output_text"}:
+            continue
+        text = block.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def final_assistant_text(events: list[dict[str, Any]]) -> str:
+    return _message_text(final_assistant_message(events))
+
+
+def final_assistant_message(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    candidate: dict[str, Any] | None = None
+    for event in events:
+        if event.get("type") not in {"message_end", "turn_end"}:
+            continue
+        message = event.get("message")
+        if isinstance(message, dict) and message.get("role") == "assistant":
+            candidate = message
+    return candidate
+
+
+def _provider_error_message(
+    events: list[dict[str, Any]],
+    retry_end_events: list[dict[str, Any]],
+) -> str:
+    if retry_end_events:
+        final_retry_error = str(retry_end_events[-1].get("finalError") or "")
+        if final_retry_error:
+            return final_retry_error
+    error_messages = [
+        str((event.get("message") or {}).get("errorMessage") or "")
+        for event in events
+        if isinstance(event.get("message"), dict)
+    ]
+    error_messages = [message for message in error_messages if message]
+    return error_messages[-1] if error_messages else ""
+
+
+def final_output_block_reason(
+    events: list[dict[str, Any]],
+    retry_end_events: list[dict[str, Any]],
+) -> tuple[str | None, str | None]:
+    provider_error = _provider_error_message(events, retry_end_events)
+    if provider_error:
+        return f"pi_provider_request_failed:{reason_code(provider_error)}", provider_error
+    final_message = final_assistant_message(events)
+    stop_reason = str((final_message or {}).get("stopReason") or "")
+    if stop_reason == "length":
+        return "pi_final_message_truncated", None
+    return None, None
+
+
+def loads_final_json(text: str) -> tuple[dict[str, Any] | None, bool]:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        value = None
+    if isinstance(value, dict):
+        return value, False
+
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(text):
+        if character != "{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            return value, True
+    return None, False
+
+
+def load_final_json_from_event_stream(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    events, invalid_lines = parse_jsonl(raw)
+    if invalid_lines:
+        return None
+    report, _ = loads_final_json(final_assistant_text(events))
+    return report
+
+
+def pi_version(binary: str, environment: dict[str, str], cwd: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            [binary, "--version"],
+            cwd=cwd,
+            env=environment,
+            shell=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    value = (completed.stdout or "").strip()
+    return value or None
+
+
+def write_text_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temp_path.write_text(content, encoding="utf-8")
+    temp_path.replace(path)
+
+
+def _read_event_stream(path: Path) -> tuple[list[dict[str, Any]], int]:
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    return parse_jsonl(raw)
+
+
+def _run_streaming_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    events_path: Path,
+    stderr_path: Path,
+    prompt: str | None,
+    timeout_seconds: int,
+) -> tuple[int, bool, _StreamingEventState]:
+    state = _StreamingEventState()
+    timed_out = False
+    with events_path.open("wb") as events_file, stderr_path.open(
+        "w",
+        encoding="utf-8",
+    ) as stderr_file:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=environment,
+            shell=False,
+            stdin=subprocess.PIPE if prompt is not None else None,
+            stdout=subprocess.PIPE,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
+        assert process.stdout is not None
+        reader = threading.Thread(
+            target=_consume_compact_stream,
+            args=(process.stdout, events_file, state),
+        )
+        reader.start()
+        if prompt is not None:
+            assert process.stdin is not None
+            process.stdin.write(prompt.encode())
+            process.stdin.close()
+        try:
+            return_code = process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                process.kill()
+            return_code = process.wait()
+        reader.join()
+        process.stdout.close()
+        stderr_file.flush()
+    return return_code, timed_out, state
+
+
+def run_pi_json_process(
+    *,
+    prompt: str,
+    events_path: Path,
+    stderr_path: Path,
+    runtime_home: Path,
+    runtime_workdir: Path,
+    pi_bin: str,
+    provider: str,
+    model: str,
+    base_url: str,
+    api_key_env: str,
+    agent_name: str,
+    display_name: str,
+    timeout_seconds: int,
+    launch_mode: str,
+    system_prompt: str,
+    provenance: dict[str, Any] | None = None,
+    no_proxy_env: str | None = None,
+    extra_env: dict[str, str] | None = None,
+    prompt_in_stdin: bool = False,
+    no_tools: bool = False,
+    no_builtin_tools: bool = True,
+    tools: list[str] | None = None,
+    extension_path: Path | None = None,
+    thinking_level: str | None = None,
+    disable_extensions: bool = True,
+    disable_skills: bool = True,
+    disable_prompt_templates: bool = True,
+    disable_context_files: bool = True,
+    stream_compaction: bool = False,
+    auth_header: bool | None = None,
+) -> PiProcessResult:
+    normalized_url = normalized_base_url(base_url)
+    record: dict[str, Any] = {
+        **(provenance or {}),
+        "launch_mode": launch_mode,
+        "pi_binary": pi_bin,
+        "child_agent": agent_name,
+        "provider": provider,
+        "provider_api": "openai-completions",
+        "provider_base_url": normalized_url,
+        "api_key_env": api_key_env,
+        "events_path": str(events_path),
+        "independent_pi_process": True,
+    }
+
+    if prompt_in_stdin and stream_compaction:
+        return PiProcessResult(None, "", record, "pi_streaming_stdin_unsupported", "")
+    resolved_pi = shutil.which(pi_bin)
+    if resolved_pi is None:
+        return PiProcessResult(None, "", record, "pi_binary_not_found", "")
+    if not provider.strip():
+        return PiProcessResult(None, "", record, "pi_provider_not_configured", "")
+    if not model.strip():
+        return PiProcessResult(None, "", record, "pi_model_not_configured", "")
+    if not ENV_NAME_RE.fullmatch(api_key_env):
+        return PiProcessResult(None, "", record, "pi_api_key_env_invalid", "")
+    if thinking_level is not None and thinking_level not in THINKING_LEVELS:
+        return PiProcessResult(None, "", record, "pi_thinking_level_invalid", "")
+    if not os.environ.get(api_key_env):
+        return PiProcessResult(None, "", record, f"pi_api_key_env_missing:{api_key_env}", "")
+    parsed_url = urlparse(normalized_url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.hostname:
+        return PiProcessResult(None, "", record, "pi_base_url_invalid", "")
+    if extension_path is not None and not extension_path.is_file():
+        return PiProcessResult(None, "", record, "pi_extension_missing", "")
+
+    runtime_home.mkdir(parents=True, exist_ok=True)
+    runtime_workdir.mkdir(parents=True, exist_ok=True)
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    stderr_path.parent.mkdir(parents=True, exist_ok=True)
+    models_text = canonical_json(
+        models_config(
+            provider=provider,
+            model=model,
+            base_url=normalized_url,
+            api_key_env=api_key_env,
+            display_name=display_name,
+            auth_header=auth_header,
+        )
+    ) + "\n"
+    write_text_atomic(runtime_home / "models.json", models_text)
+    environment, proxy_bypassed = pi_environment(
+        base_url=normalized_url,
+        runtime_home=runtime_home,
+        api_key_env=api_key_env,
+        no_proxy_env=no_proxy_env,
+        extra_env=extra_env,
+    )
+    record.update(
+        {
+            "pi_binary_resolved": resolved_pi,
+            "pi_version": pi_version(resolved_pi, environment, runtime_workdir),
+            "child_model": model,
+            "runtime_pi_home": str(runtime_home),
+            "runtime_workdir": str(runtime_workdir),
+            "models_config_sha256": hashlib.sha256(models_text.encode("utf-8")).hexdigest(),
+            "provider_proxy_bypassed": proxy_bypassed,
+            "environment_mode": "minimal",
+            "environment_keys": sorted(environment),
+            "stderr_path": str(stderr_path),
+            "timeout_seconds": timeout_seconds,
+            "thinking_level": thinking_level or "default",
+        }
+    )
+
+    command = [
+        resolved_pi,
+        "--mode",
+        "json",
+        "--print",
+        "--provider",
+        provider,
+        "--model",
+        model,
+        "--no-session",
+    ]
+    if thinking_level is not None:
+        command.extend(["--thinking", thinking_level])
+    if no_tools:
+        command.append("--no-tools")
+    if no_builtin_tools:
+        command.append("--no-builtin-tools")
+    if tools is not None:
+        command.extend(["--tools", ",".join(tools)])
+    if extension_path is not None:
+        command.extend(["--extension", str(extension_path)])
+    if disable_extensions:
+        command.append("--no-extensions")
+    if disable_skills:
+        command.append("--no-skills")
+    if disable_prompt_templates:
+        command.append("--no-prompt-templates")
+    if disable_context_files:
+        command.append("--no-context-files")
+    command.extend(["--system-prompt", system_prompt])
+    if not prompt_in_stdin:
+        command.append(prompt)
+
+    raw_events_path = (
+        events_path if stream_compaction else events_path.with_name(f".{events_path.name}.raw")
+    )
+    stream_state: _StreamingEventState | None = None
+    try:
+        if stream_compaction:
+            return_code, timed_out, stream_state = _run_streaming_process(
+                command,
+                cwd=runtime_workdir,
+                environment=environment,
+                events_path=events_path,
+                stderr_path=stderr_path,
+                prompt=prompt if prompt_in_stdin else None,
+                timeout_seconds=timeout_seconds,
+            )
+        else:
+            with raw_events_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
+                "w",
+                encoding="utf-8",
+            ) as stderr_file:
+                process = subprocess.Popen(
+                    command,
+                    cwd=runtime_workdir,
+                    env=environment,
+                    shell=False,
+                    text=True,
+                    stdin=subprocess.PIPE if prompt_in_stdin else None,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    start_new_session=True,
+                )
+                try:
+                    process.communicate(
+                        input=prompt if prompt_in_stdin else None,
+                        timeout=timeout_seconds,
+                    )
+                    return_code = process.returncode
+                except subprocess.TimeoutExpired:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except OSError:
+                        process.kill()
+                    return_code = process.wait()
+                    stdout_file.flush()
+                    stderr_file.flush()
+                    stderr = stderr_path.read_text(encoding="utf-8", errors="replace")
+                    record["pi_exit_code"] = return_code
+                    record["events_partial"] = True
+                    _, _, event_record = compact_jsonl_event_stream(
+                        raw_events_path,
+                        events_path,
+                    )
+                    raw_events_path.unlink(missing_ok=True)
+                    record.update(event_record)
+                    return PiProcessResult(None, "", record, "pi_dispatch_timeout", stderr[-4000:])
+    except OSError as exc:
+        if not stream_compaction:
+            record["raw_events_path"] = str(raw_events_path)
+        return PiProcessResult(None, "", record, f"pi_dispatch_os_error:{exc}", "")
+
+    stderr = stderr_path.read_text(encoding="utf-8", errors="replace")
+    record["pi_exit_code"] = return_code
+    if stream_compaction and timed_out:
+        record["events_partial"] = True
+    try:
+        if stream_compaction:
+            assert stream_state is not None
+            events, invalid_lines = _read_event_stream(events_path)
+            event_record = {
+                "raw_jsonl_event_count": stream_state.event_count,
+                "persisted_jsonl_event_count": len(events),
+                "discarded_event_counts": {
+                    "message_update": stream_state.message_updates_dropped,
+                },
+                "message_updates_dropped": stream_state.message_updates_dropped,
+                "events_observed_bytes": stream_state.observed_bytes,
+                "events_stored_bytes": stream_state.stored_bytes,
+                "events_sha256": stream_state.hasher.hexdigest(),
+            }
+        else:
+            events, invalid_lines, event_record = compact_jsonl_event_stream(
+                raw_events_path,
+                events_path,
+            )
+        record.update(event_record)
+        if not stream_compaction:
+            raw_events_path.unlink(missing_ok=True)
+    except OSError as exc:
+        if not stream_compaction:
+            record["raw_events_path"] = str(raw_events_path)
+        return PiProcessResult(
+            None,
+            "",
+            record,
+            f"pi_event_compaction_error:{exc}",
+            stderr[-4000:],
+        )
+    session_ids = [
+        str(event.get("id"))
+        for event in events
+        if event.get("type") == "session" and event.get("id")
+    ]
+    agent_start_count = sum(event.get("type") == "agent_start" for event in events)
+    agent_end_count = sum(event.get("type") == "agent_end" for event in events)
+    turn_start_count = sum(event.get("type") == "turn_start" for event in events)
+    turn_end_count = sum(event.get("type") == "turn_end" for event in events)
+    retry_start_count = sum(event.get("type") == "auto_retry_start" for event in events)
+    retry_end_events = [event for event in events if event.get("type") == "auto_retry_end"]
+    tool_event_count = sum(str(event.get("type") or "").startswith("tool_execution_") for event in events)
+    record.update(
+        {
+            "pi_session_ids": session_ids,
+            "jsonl_event_count": event_record["raw_jsonl_event_count"],
+            "jsonl_invalid_line_count": invalid_lines,
+            "agent_start_count": agent_start_count,
+            "agent_end_count": agent_end_count,
+            "turn_start_count": turn_start_count,
+            "turn_end_count": turn_end_count,
+            "tool_event_count": tool_event_count,
+            "auto_retry_start_count": retry_start_count,
+            "auto_retry_end_count": len(retry_end_events),
+        }
+    )
+    record["persisted_jsonl_event_count"] = len(events)
+    if stream_state is not None and stream_state.stream_error is not None and not timed_out:
+        return PiProcessResult(
+            None,
+            "",
+            record,
+            f"pi_event_stream_os_error:{stream_state.stream_error}",
+            stderr[-4000:],
+        )
+    if stream_compaction and timed_out:
+        return PiProcessResult(None, "", record, "pi_dispatch_timeout", stderr[-4000:])
+    if return_code != 0:
+        return PiProcessResult(None, "", record, f"pi_dispatch_exit_code:{return_code}", stderr[-4000:])
+    if invalid_lines:
+        return PiProcessResult(None, "", record, "pi_jsonl_invalid", stderr[-4000:])
+    if len(session_ids) != 1:
+        return PiProcessResult(None, "", record, "pi_subagent_session_not_observed", stderr[-4000:])
+    if agent_start_count < 1 or agent_start_count != agent_end_count:
+        return PiProcessResult(None, "", record, "pi_subagent_lifecycle_invalid", stderr[-4000:])
+    if turn_start_count < 1 or turn_start_count != turn_end_count:
+        return PiProcessResult(None, "", record, "pi_subagent_turn_invalid", stderr[-4000:])
+
+    output_block_reason, provider_error = final_output_block_reason(events, retry_end_events)
+    final_message = final_assistant_message(events)
+    final_stop_reason = str((final_message or {}).get("stopReason") or "")
+    if final_stop_reason:
+        record["pi_final_stop_reason"] = final_stop_reason
+    final_text = final_assistant_text(events)
+    output_json, extracted_from_text = (
+        loads_final_json(final_text) if final_text else (None, False)
+    )
+    if output_json is None:
+        if output_block_reason:
+            if provider_error:
+                record["pi_provider_final_error"] = provider_error
+            return PiProcessResult(None, final_text, record, output_block_reason, stderr[-4000:])
+        if final_text:
+            record["final_message_sha256"] = hashlib.sha256(final_text.encode("utf-8")).hexdigest()
+        return PiProcessResult(None, final_text, record, "pi_final_message_invalid_json", stderr[-4000:])
+
+    record["final_message_sha256"] = hashlib.sha256(final_text.encode("utf-8")).hexdigest()
+    record["final_json_extracted_from_text"] = extracted_from_text
+    record["provenance_valid"] = True
+    return PiProcessResult(output_json, final_text, record, None, stderr[-4000:])

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -300,6 +300,36 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
 
             self.assertEqual(result.block_reason, "pi_dispatch_timeout")
             self.assertTrue(result.provenance["events_partial"])
+            self.assertEqual(result.provenance["pi_session_ids"], ["session-1"])
+            self.assertEqual(result.provenance["jsonl_event_count"], 1)
+            self.assertEqual(result.provenance["jsonl_invalid_line_count"], 0)
+
+    def test_dispatch_nonzero_exit_records_partial_event_counters(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            fake_pi = self._fake_pi(
+                root_path,
+                "print(json.dumps({'type': 'session', 'id': 'session-1'}), flush=True)\n"
+                "raise SystemExit(7)\n",
+            )
+
+            with mock.patch.dict(os.environ, {"HARBOR_ANALYZER_API_KEY": "test-key"}):
+                result = dispatch_to_child(
+                    prompt="{}",
+                    analysis_id="sha256-" + ("4" * 64),
+                    output_dir=root_path / "out",
+                    pi_bin=str(fake_pi),
+                    provider="harbor-analyzer",
+                    model="test-model",
+                    base_url="https://example.test/v1",
+                    api_key_env="HARBOR_ANALYZER_API_KEY",
+                    agent_name="harbor_analyzer_pi_subagent",
+                    timeout_seconds=1,
+                )
+
+            self.assertEqual(result.block_reason, "pi_dispatch_exit_code:7")
+            self.assertEqual(result.provenance["pi_session_ids"], ["session-1"])
+            self.assertEqual(result.provenance["jsonl_event_count"], 1)
 
     def test_task_slug_uses_safe_basename_for_untrusted_task_index(self) -> None:
         slug = _task_slug(task(task_index="/tmp/pr83-escape"))

--- a/Agents/utils/common/Harbor/tests/test_harbor_pi_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_pi_runtime.py
@@ -1,0 +1,275 @@
+"""Tests for the small shared Harbor Pi subprocess helper."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from harbor_analyzer.pi import dispatch_to_child
+from harbor_pi_runtime import load_final_json_from_event_stream, run_pi_json_process
+from harbor_pi_runtime.process import models_config
+
+
+def write_fixture_pi(path: Path) -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json",
+                "import sys",
+                "if sys.argv[1:] == ['--version']:",
+                "    print('fixture-pi 1.0')",
+                "    raise SystemExit(0)",
+                "args = sys.argv[1:]",
+                "prompt = sys.stdin.read() if args[-1] == 'system' else args[-1]",
+                "payload = {'ok': True, 'prompt': prompt}",
+                "events = [",
+                "    {'type': 'session', 'id': 'fixture-session'},",
+                "    {'type': 'agent_start'},",
+                "    {'type': 'turn_start'},",
+                "    {'type': 'message_update', 'message': {'role': 'assistant', 'content': 'partial'}},",
+                "    {'type': 'message_end', 'message': {'role': 'assistant', 'content': json.dumps(payload), 'stopReason': 'stop'}},",
+                "    {'type': 'turn_end'},",
+                "    {'type': 'agent_end'},",
+                "]",
+                "for event in events:",
+                "    print(json.dumps(event), flush=True)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def write_custom_pi(path: Path, body: str) -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import json",
+                "import sys",
+                "if sys.argv[1:] == ['--version']:",
+                "    print('fixture-pi 1.0')",
+                "    raise SystemExit(0)",
+                body,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+class HarborPiRuntimeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.pi_bin = write_fixture_pi(self.root / "fixture-pi")
+
+    def run_runtime(self, prompt: str, **overrides: object):
+        options = {
+            "prompt": prompt,
+            "events_path": self.root / "events.jsonl",
+            "stderr_path": self.root / "stderr.txt",
+            "runtime_home": self.root / "home",
+            "runtime_workdir": self.root / "work",
+            "pi_bin": str(self.pi_bin),
+            "provider": "fixture",
+            "model": "fixture-model",
+            "base_url": "https://example.test/v1",
+            "api_key_env": "FIXTURE_API_KEY",
+            "agent_name": "fixture-agent",
+            "display_name": "Fixture",
+            "timeout_seconds": 5,
+            "launch_mode": "fixture",
+            "system_prompt": "system",
+        }
+        options.update(overrides)
+        with mock.patch.dict(os.environ, {"FIXTURE_API_KEY": "fake"}, clear=True):
+            return run_pi_json_process(**options)
+
+    def test_models_config_preserves_explicit_and_omitted_auth_header(self) -> None:
+        explicit = models_config(
+            provider="analyzer",
+            model="fixture",
+            base_url="https://example.test/v1",
+            api_key_env="FIXTURE_API_KEY",
+            display_name="Analyzer",
+            auth_header=True,
+        )
+        omitted = models_config(
+            provider="fixer",
+            model="fixture",
+            base_url="https://example.test/v1",
+            api_key_env="FIXTURE_API_KEY",
+            display_name="Fixer",
+        )
+
+        self.assertTrue(explicit["providers"]["analyzer"]["authHeader"])
+        self.assertNotIn("authHeader", omitted["providers"]["fixer"])
+
+    def test_compact_events_and_stdin_prompt(self) -> None:
+        result = self.run_runtime(
+            "stdin-prompt",
+            base_url="https://example.test",
+            prompt_in_stdin=True,
+            no_tools=True,
+            thinking_level="off",
+        )
+
+        self.assertIsNone(result.block_reason)
+        self.assertEqual(result.output_json, {"ok": True, "prompt": "stdin-prompt"})
+        self.assertEqual(result.provenance["thinking_level"], "off")
+        self.assertEqual(result.provenance["discarded_event_counts"], {"message_update": 1})
+        self.assertNotIn(
+            "message_update",
+            (self.root / "events.jsonl").read_text(encoding="utf-8"),
+        )
+
+    def test_rejects_streaming_stdin_combination(self) -> None:
+        result = self.run_runtime(
+            "fixture",
+            prompt_in_stdin=True,
+            stream_compaction=True,
+        )
+
+        self.assertEqual(result.block_reason, "pi_streaming_stdin_unsupported")
+        self.assertFalse((self.root / "events.jsonl").exists())
+
+    def test_empty_failed_final_message_does_not_reuse_earlier_json(self) -> None:
+        self.pi_bin = write_custom_pi(
+            self.root / "multi-turn-pi",
+            "\n".join(
+                [
+                    (
+                        "first = {'role': 'assistant', 'content': "
+                        "json.dumps({'stale': True}), 'stopReason': 'stop'}"
+                    ),
+                    "final = {'role': 'assistant', 'content': [], 'stopReason': 'length'}",
+                    "events = [",
+                    "    {'type': 'session', 'id': 'fixture-session'},",
+                    "    {'type': 'agent_start'},",
+                    "    {'type': 'turn_start'},",
+                    "    {'type': 'message_end', 'message': first},",
+                    "    {'type': 'turn_end', 'message': first},",
+                    "    {'type': 'turn_start'},",
+                    "    {'type': 'message_end', 'message': final},",
+                    "    {'type': 'turn_end', 'message': final},",
+                    "    {'type': 'agent_end'},",
+                    "]",
+                    "for event in events:",
+                    "    print(json.dumps(event), flush=True)",
+                ]
+            ),
+        )
+
+        result = self.run_runtime("fixture")
+
+        self.assertIsNone(result.output_json)
+        self.assertEqual(result.output_text, "")
+        self.assertEqual(result.block_reason, "pi_final_message_truncated")
+
+    def test_event_stream_loader_treats_non_utf8_as_invalid(self) -> None:
+        events_path = self.root / "undecodable.jsonl"
+        events_path.write_bytes(b"\xff\n")
+
+        self.assertIsNone(load_final_json_from_event_stream(events_path))
+
+    def test_runtime_provenance_overrides_conflicting_caller_metadata(self) -> None:
+        result = self.run_runtime(
+            "fixture",
+            provenance={
+                "provider": "spoofed",
+                "events_path": "/tmp/spoofed.jsonl",
+                "independent_pi_process": False,
+                "caller_fact": "preserved",
+            },
+        )
+
+        self.assertEqual(result.provenance["provider"], "fixture")
+        self.assertEqual(result.provenance["events_path"], str(self.root / "events.jsonl"))
+        self.assertTrue(result.provenance["independent_pi_process"])
+        self.assertEqual(result.provenance["caller_fact"], "preserved")
+
+    def test_compaction_failure_preserves_raw_events(self) -> None:
+        with mock.patch(
+            "harbor_pi_runtime.process.compact_jsonl_event_stream",
+            side_effect=OSError("fixture compaction failure"),
+        ):
+            result = self.run_runtime("fixture")
+
+        raw_path = self.root / ".events.jsonl.raw"
+        self.assertIn("pi_event_compaction_error", result.block_reason or "")
+        self.assertEqual(result.provenance["raw_events_path"], str(raw_path))
+        self.assertTrue(raw_path.is_file())
+        self.assertIn("message_update", raw_path.read_text(encoding="utf-8"))
+
+    def test_analyzer_adapter_streams_compact_events_and_domain_provenance(self) -> None:
+        evidence = self.root / "evidence.txt"
+        evidence.write_text("fixture\n", encoding="utf-8")
+        with mock.patch.dict(os.environ, {"HARBOR_ANALYZER_API_KEY": "fake"}, clear=True):
+            result = dispatch_to_child(
+                prompt="analyzer-prompt",
+                analysis_id="analysis-1",
+                output_dir=self.root / "out",
+                pi_bin=str(self.pi_bin),
+                provider="harbor-analyzer",
+                model="fixture-model",
+                base_url="https://example.test/v1",
+                api_key_env="HARBOR_ANALYZER_API_KEY",
+                agent_name="harbor_analyzer_pi_subagent",
+                timeout_seconds=5,
+                allowed_paths=[evidence],
+            )
+
+        self.assertIsNone(result.block_reason)
+        self.assertEqual(result.report, {"ok": True, "prompt": "analyzer-prompt"})
+        self.assertNotIn("thinking_level", result.provenance)
+        self.assertEqual(result.provenance["tools_allowlist"], ["read", "grep", "find", "ls"])
+        self.assertIn(str(evidence.resolve()), result.provenance["allowed_paths"])
+        self.assertEqual(result.provenance["message_updates_dropped"], 1)
+        events_path = self.root / "out" / "analyzer-subagent-events" / "analysis-1.jsonl"
+        self.assertNotIn("message_update", events_path.read_text(encoding="utf-8"))
+
+    def test_analyzer_adapter_maps_shared_configuration_errors(self) -> None:
+        common = {
+            "prompt": "fixture",
+            "analysis_id": "analysis-1",
+            "output_dir": self.root / "out",
+            "pi_bin": sys.executable,
+            "provider": "harbor-analyzer",
+            "model": "fixture-model",
+            "agent_name": "harbor_analyzer_pi_subagent",
+            "timeout_seconds": 5,
+        }
+        invalid_env = dispatch_to_child(
+            **common,
+            base_url="https://example.test/v1",
+            api_key_env="INVALID-NAME",
+        )
+        with mock.patch.dict(os.environ, {"FIXTURE_API_KEY": "fake"}, clear=True):
+            invalid_url = dispatch_to_child(
+                **common,
+                base_url="not-a-url",
+                api_key_env="FIXTURE_API_KEY",
+            )
+
+        self.assertEqual(invalid_env.block_reason, "analyzer_api_key_env_invalid")
+        self.assertEqual(invalid_url.block_reason, "analyzer_base_url_invalid")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor Analyzer currently owns Pi provider configuration, subprocess lifecycle management, JSON event parsing, final-output extraction, and provenance generation in a single component-specific module.

The staged Harbor Fixer work requires the same process and protocol mechanics. Duplicating this implementation would increase the initial Fixer PR substantially and allow runtime behavior—such as provider configuration, timeout handling, and event validation—to drift between Harbor components.

This PR extracts the component-independent mechanics into a small shared helper package while preserving the existing Analyzer behavior and interfaces.

## 2. Summary of the change

- Add `harbor_pi_runtime`, a small shared helper package responsible for:
  - isolated Pi subprocess startup and process-group timeout handling;
  - provider URL, environment, and `models.json` configuration;
  - raw or compact JSON event persistence;
  - Pi session and turn lifecycle validation;
  - provider-error and truncation detection;
  - final JSON extraction and runtime provenance.
- Convert `harbor_analyzer/pi.py` into a thin Analyzer-specific adapter.
- Keep Analyzer-specific behavior in the adapter, including:
  - read-only tools and path-gated extension configuration;
  - allowed-path and access-audit artifacts;
  - Analyzer prompts, output paths, return types, and error codes;
  - raw event retention and bearer authentication configuration.
- Add focused tests for shared runtime behavior and Analyzer compatibility.
- Update the Harbor structure documentation to describe the new package boundary.

The shared package intentionally does not contain Harbor task semantics, Analyzer/Fixer schemas, component prompts, or retry policy.

This PR does not migrate or otherwise modify Harbor Fixer. Fixer integration will be submitted in a subsequent staged PR.

## 3. Other details

Compatibility was checked against the existing Analyzer contracts:

- `dispatch_to_child()` and `DispatchResult` remain compatible.
- Analyzer artifact paths, raw event retention, tool restrictions, error codes, and provenance fields are preserved.
- Defensive handling remains at actual process and protocol boundaries, including process-group termination, malformed JSONL detection, lifecycle validation, provider failures, and truncated output.

Validation performed:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'`
  - PR branch: 34 tests passed.
- A temporary, uncommitted Fixer adapter was used to validate the shared runtime against the latest `feat/fixer`.
  - Integrated Harbor suite: 54 tests passed.
- `git diff --check` passed.

The temporary Fixer adapter was discarded and is not part of this PR.
