### PR TITLE
feat(harbor): add Fixer planning context

### DIFF
--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -31,6 +31,11 @@ Agents/utils/common/Harbor/
     │   ├── evaluator.py        # Compose one monitor sample
     │   ├── contracts.py        # User, analyzer, and runner output contracts
     │   └── runner.py           # Control commands, retries, and follow loop
+    ├── harbor_fixer/
+    │   ├── analyzer_inputs.py  # Analyzer artifact to task-input translation
+    │   ├── artifact_io.py      # JSON, JSONL, and text artifact I/O
+    │   ├── planning_context/   # Runtime inventory and workspace evidence
+    │   └── validation.py       # Analyzer, task-summary, and Fix Plan validation
     ├── online_rule_analyzer.py # Optional console-only online analysis
     └── write_harbor_registry_summary.py # Native registry summary writer
 ```
@@ -43,6 +48,15 @@ in the environment as `HARBOR_ANALYZER_*` variables.
 JSON-event validation, final JSON extraction, and provenance shared by Harbor
 Pi callers. Analyzer-specific tool access, path gating, prompts, artifact
 locations, and error compatibility remain in `harbor_analyzer/pi.py`.
+
+## Harbor Fixer Planning Context
+
+The Fixer foundation validates Analyzer handoff artifacts and builds a bounded,
+redacted planning context without invoking an agent. It records runtime
+inventory and selected workspace evidence for later plan generation. Analyzer
+inputs are selected through `analyzer-artifacts-latest.json`; Fixer reads the
+current env/infra and evidence snapshot for each handover without depending on
+the deprecated flat latest-report files.
 
 ```text
 Agents/utils/rl/

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/__init__.py
@@ -1,0 +1,1 @@
+"""Harbor Fixer MVP implementation."""

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/analyzer_inputs.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/analyzer_inputs.py
@@ -1,0 +1,158 @@
+"""Translate Analyzer output artifacts into validated Fixer task inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .artifact_io import read_json, read_jsonl
+from .validation import (
+    ValidationError,
+    task_key,
+    validate_analyzer_manifest,
+    validate_env_infra_tasks,
+    validate_fix_line_index,
+    validate_task_input,
+)
+
+
+def _path_component(value: Any, name: str) -> str:
+    text = str(value or "")
+    if not text or Path(text).name != text or text in {".", ".."}:
+        raise ValidationError(f"{name} must be a path-safe identifier")
+    return text
+
+
+def resolve_analyzer_paths(analyzer_output_path: Path) -> dict[str, Any]:
+    """Resolve manifest-selected snapshots without trusting recorded absolute paths."""
+
+    requested = analyzer_output_path.expanduser().resolve()
+    if requested.is_file():
+        if requested.parent.parent.name != "env-infra-tasks" or requested.suffix != ".json":
+            raise ValidationError(
+                "analyzer output file must be env-infra-tasks/<handover_id>/<publication_id>.json"
+            )
+        analyzer_root = requested.parents[2]
+        selected_identity = (requested.parent.name, requested.stem)
+    else:
+        analyzer_root = requested
+        selected_identity = None
+
+    manifest_path = analyzer_root / "analyzer-artifacts-latest.json"
+    manifest = read_json(manifest_path)
+    validate_analyzer_manifest(manifest)
+
+    publications: list[dict[str, str]] = []
+    for index, item in enumerate(manifest["publications"]):
+        handover_id = _path_component(item["handover_id"], f"publications[{index}].handover_id")
+        publication_id = _path_component(
+            item["publication_id"],
+            f"publications[{index}].publication_id",
+        )
+        if selected_identity is not None and selected_identity != (handover_id, publication_id):
+            continue
+        publications.append(
+            {
+                "handover_id": handover_id,
+                "publication_id": publication_id,
+                "env_infra_tasks_path": str(
+                    analyzer_root / "env-infra-tasks" / handover_id / f"{publication_id}.json"
+                ),
+                "fix_line_index_path": str(
+                    analyzer_root / "fix-line-index" / handover_id / f"{publication_id}.jsonl"
+                ),
+            }
+        )
+    if selected_identity is not None and not publications:
+        raise ValidationError("selected env/infra snapshot is not current in analyzer manifest")
+    return {
+        "analyzer_root": analyzer_root,
+        "manifest_path": manifest_path,
+        "run_id": manifest["run_id"],
+        "publications": publications,
+    }
+
+
+def _index_fix_lines(
+    records: list[dict[str, Any]],
+) -> dict[tuple[str, str, str], list[dict[str, Any]]]:
+    indexed: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for record in records:
+        task = record["task"]
+        indexed.setdefault(task_key(task), []).append(record)
+    return indexed
+
+
+def _identity_from_task(task: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task_index": task["task_index"],
+        "task_name": task["task_name"],
+        "attempt_id": task["attempt_id"],
+    }
+
+
+def build_task_inputs(analyzer_output_path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    resolved = resolve_analyzer_paths(analyzer_output_path)
+    source = {
+        "analyzer_root": str(resolved["analyzer_root"]),
+        "manifest_path": str(resolved["manifest_path"]),
+        "run_id": resolved["run_id"],
+        "publications": resolved["publications"],
+    }
+
+    task_inputs: list[dict[str, Any]] = []
+    for publication in resolved["publications"]:
+        env_infra = read_json(Path(publication["env_infra_tasks_path"]))
+        fix_lines = read_jsonl(Path(publication["fix_line_index_path"]))
+        validate_env_infra_tasks(env_infra)
+        validate_fix_line_index(fix_lines)
+        if env_infra.get("handover_id") != publication["handover_id"]:
+            raise ValidationError("env/infra handover_id does not match analyzer manifest")
+
+        env_tasks = {task_key(item["task"]): item for item in env_infra["tasks"]}
+        fix_line_index = _index_fix_lines(fix_lines)
+        for key, records in fix_line_index.items():
+            item = env_tasks.get(key)
+            if item is None:
+                raise ValidationError("fix-line-index task is absent from env/infra tasks")
+            if any(record["root_cause_code"] != item["root_cause_code"] for record in records):
+                raise ValidationError("fix-line-index root_cause_code does not match env/infra task")
+
+        task_source = {
+            "handover_id": publication["handover_id"],
+            "publication_id": publication["publication_id"],
+            "run_id": source["run_id"],
+            "env_infra_tasks_path": publication["env_infra_tasks_path"],
+            "fix_line_index_path": publication["fix_line_index_path"],
+        }
+        for item in env_infra["tasks"]:
+            task = item["task"]
+            evidence_records = fix_line_index.get(task_key(task), [])
+            evidence = [
+                {
+                    "path": record["path"],
+                    "line_start": record["line_start"],
+                    "line_end": record["line_end"],
+                    "fact": record["fact"],
+                    "reason": record["reason"],
+                }
+                for record in evidence_records
+            ]
+            payload = {
+                "schema_version": 1,
+                "kind": "harbor_fixer_task_input",
+                "source": task_source,
+                "task": _identity_from_task(task),
+                "analyzer_result": {
+                    "final_class": item["final_class"],
+                    "failure_stage": item["failure_stage"],
+                    "scope": item["scope"],
+                    "confidence": float(item["confidence"]),
+                    "root_cause_code": item["root_cause_code"],
+                    "root_cause_summary": item["root_cause_summary"],
+                },
+                "evidence": evidence,
+            }
+            validate_task_input(payload)
+            task_inputs.append(payload)
+    return task_inputs, source

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/artifact_io.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/artifact_io.py
@@ -1,0 +1,54 @@
+"""Small JSON and text helpers for Fixer artifact files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .validation import ValidationError
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing JSON file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON file {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValidationError(f"expected JSON object: {path}")
+    return payload
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing JSONL file: {path}") from exc
+    for line_number, raw in enumerate(raw_lines, start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValidationError(f"invalid JSONL record {path}:{line_number}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise ValidationError(f"expected JSON object at {path}:{line_number}")
+        records.append(payload)
+    return records
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/__init__.py
@@ -1,0 +1,11 @@
+"""Bounded runtime and workspace context used during Fix Plan generation."""
+
+from .builder import collect_planning_context
+from .runtime_inventory import collect_runtime_inventory
+from .workspace_evidence import collect_workspace_evidence
+
+__all__ = [
+    "collect_planning_context",
+    "collect_runtime_inventory",
+    "collect_workspace_evidence",
+]

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/builder.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/builder.py
@@ -1,0 +1,31 @@
+"""Build the two bounded context snapshots consumed by the Fix Plan agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .runtime_inventory import collect_runtime_inventory
+from .workspace_evidence import collect_workspace_evidence
+
+
+def collect_planning_context(
+    workspace_root: Path,
+    analyzer_output_path: Path,
+    task_inputs: list[dict[str, Any]],
+    *,
+    pi_bin: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return runtime inventory and workspace evidence without changing output schemas."""
+
+    runtime_inventory = collect_runtime_inventory(
+        workspace_root,
+        task_inputs,
+        pi_bin=pi_bin,
+    )
+    workspace_evidence = collect_workspace_evidence(
+        workspace_root,
+        analyzer_output_path,
+        task_inputs,
+    )
+    return runtime_inventory, workspace_evidence

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/runtime_inventory.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/runtime_inventory.py
@@ -1,0 +1,307 @@
+"""Collect a read-only inventory of runtimes and tools available to Fixer."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from ..validation import ValidationError
+from .safe_paths import inspect_path
+
+COMMANDS = (
+    "bash",
+    "sh",
+    "find",
+    "grep",
+    "sed",
+    "awk",
+    "stat",
+    "tar",
+    "curl",
+    "wget",
+    "jq",
+    "python3",
+    "python3.12",
+    "git",
+    "git-lfs",
+    "zellij",
+    "node",
+    "npm",
+    "npx",
+    "pi",
+    "opik",
+    "harbor",
+)
+
+VERSION_ARGS: dict[str, tuple[str, ...]] = {
+    "git": ("--version",),
+    "git-lfs": ("version",),
+    "zellij": ("--version",),
+    "node": ("--version",),
+    "npm": ("--version",),
+    "npx": ("--version",),
+    "pi": ("--version",),
+    "opik": ("--version",),
+    "harbor": ("--version",),
+}
+
+PYTHON_MODULES = ("harbor", "opik", "pydantic", "uuid6", "socksio")
+MAX_EVIDENCE_PATHS = 500
+PROBE_TIMEOUT_SECONDS = 5
+
+
+def _path_state(path: Path) -> dict[str, Any]:
+    return inspect_path(
+        path,
+        expand_user=True,
+        include_writable=True,
+        include_executable=True,
+        include_mode=True,
+    )
+
+
+def _run_probe(argv: list[str], *, timeout: int = PROBE_TIMEOUT_SECONDS) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(
+            argv,
+            shell=False,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "succeeded": False,
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+    stdout = (completed.stdout or "").strip()
+    stderr = (completed.stderr or "").strip()
+    result: dict[str, Any] = {
+        "succeeded": completed.returncode == 0,
+        "exit_code": completed.returncode,
+    }
+    if stdout:
+        result["stdout"] = stdout[:2000]
+    if stderr:
+        result["stderr"] = stderr[:2000]
+    return result
+
+
+def _find_repo_root(start: Path) -> Path | None:
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _command_snapshot(pi_bin: str | None = None) -> dict[str, dict[str, Any]]:
+    snapshot: dict[str, dict[str, Any]] = {}
+    for name in COMMANDS:
+        configured = pi_bin if name == "pi" and pi_bin else name
+        resolved = shutil.which(configured)
+        item: dict[str, Any] = {
+            "available": resolved is not None,
+            "path": resolved or "",
+        }
+        args = VERSION_ARGS.get(name)
+        if resolved and args:
+            item["version_probe"] = _run_probe([resolved, *args])
+        snapshot[name] = item
+    return snapshot
+
+
+def _python_snapshot(commands: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    candidates = [
+        Path(sys.executable),
+        *(Path(commands[name]["path"]) for name in ("python3", "python3.12") if commands[name]["path"]),
+    ]
+    module_script = "\n".join(
+        [
+            "import importlib.metadata as metadata",
+            "import importlib.util as util",
+            "import json",
+            "import sys",
+            f"names = {PYTHON_MODULES!r}",
+            "def package_version(name):",
+            "    try:",
+            "        return metadata.version(name)",
+            "    except metadata.PackageNotFoundError:",
+            "        return None",
+            "modules = {}",
+            "for name in names:",
+            "    spec = util.find_spec(name)",
+            "    modules[name] = {",
+            "        'available': spec is not None,",
+            "        'path': getattr(spec, 'origin', None),",
+            "        'version': package_version(name),",
+            "    }",
+            "print(json.dumps({",
+            "    'executable': sys.executable,",
+            "    'version': sys.version.split()[0],",
+            "    'modules': modules,",
+            "}))",
+        ]
+    )
+    snapshots: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        candidate = candidate.expanduser().absolute()
+        if not candidate.exists() or not os.access(candidate, os.X_OK):
+            continue
+        executable = str(candidate)
+        if executable in seen:
+            continue
+        seen.add(executable)
+        probe = _run_probe([executable, "-c", module_script])
+        parsed: dict[str, Any] | None = None
+        if probe.get("succeeded") and isinstance(probe.get("stdout"), str):
+            try:
+                value = json.loads(probe["stdout"])
+                parsed = value if isinstance(value, dict) else None
+            except json.JSONDecodeError:
+                parsed = None
+        snapshots.append(
+            parsed
+            or {
+                "executable": executable,
+                "probe_error": probe,
+            }
+        )
+    return snapshots
+
+
+def _uv_snapshot() -> dict[str, Any]:
+    uv = shutil.which("uv")
+    snapshot: dict[str, Any] = {
+        "cli": {
+            "available": uv is not None,
+            "path": uv or "",
+        }
+    }
+    if uv:
+        snapshot["tool_dir_probe"] = _run_probe([uv, "tool", "dir"])
+        snapshot["cache_dir_probe"] = _run_probe([uv, "cache", "dir"])
+    return snapshot
+
+
+def _docker_snapshot() -> dict[str, Any]:
+    docker = shutil.which("docker")
+    docker_host = os.environ.get("DOCKER_HOST", "")
+    socket = (
+        _path_state(Path(docker_host.removeprefix("unix://") or "/var/run/docker.sock"))
+        if not docker_host or docker_host.startswith("unix://")
+        else {
+            "path": "",
+            "exists": False,
+            "note": "non-unix DOCKER_HOST is configured; endpoint value omitted",
+        }
+    )
+    snapshot: dict[str, Any] = {
+        "cli": {
+            "available": docker is not None,
+            "path": docker or "",
+        },
+        "socket": socket,
+    }
+    if docker:
+        snapshot.update(
+            {
+                "compose_probe": _run_probe([docker, "compose", "version"]),
+                "daemon_probe": _run_probe(
+                    [
+                        docker,
+                        "info",
+                        "--format",
+                        (
+                            "server_version={{.ServerVersion}}\n"
+                            "containers={{.Containers}}\n"
+                            "images={{.Images}}\n"
+                            "driver={{.Driver}}\n"
+                            "operating_system={{.OperatingSystem}}\n"
+                            "architecture={{.Architecture}}"
+                        ),
+                    ]
+                ),
+            }
+        )
+    return snapshot
+
+
+def _evidence_paths(task_inputs: list[dict[str, Any]]) -> dict[str, Any]:
+    paths: list[str] = []
+    seen: set[str] = set()
+    for task_input in task_inputs:
+        for evidence in task_input["evidence"]:
+            value = evidence["path"]
+            if value in seen:
+                continue
+            seen.add(value)
+            paths.append(value)
+    selected = paths[:MAX_EVIDENCE_PATHS]
+    return {
+        "total_count": len(paths),
+        "truncated": len(paths) > len(selected),
+        "paths": [_path_state(Path(value)) for value in selected],
+    }
+
+
+def collect_runtime_inventory(
+    workspace_root: Path,
+    task_inputs: list[dict[str, Any]],
+    *,
+    pi_bin: str | None = None,
+) -> dict[str, Any]:
+    """Collect a bounded, non-secret snapshot without modifying the target environment."""
+
+    try:
+        workspace = workspace_root.expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise ValidationError(f"workspace root is missing or unreadable: {workspace_root}") from exc
+    if not workspace.is_dir() or not os.access(workspace, os.R_OK):
+        raise ValidationError(f"workspace root must be a readable directory: {workspace_root}")
+
+    harbor_root = Path(__file__).resolve().parents[3]
+    repo_root = _find_repo_root(harbor_root)
+    commands = _command_snapshot(pi_bin)
+    cache_root = Path(
+        os.environ.get(
+            "AGENT_FLEET_CACHE_DIR",
+            Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+            / "agent-fleet",
+        )
+    )
+    local_dependency_cache = Path(
+        os.environ.get("LOCAL_WHEEL_DIR", cache_root / "harbor-deps")
+    )
+    repository_paths: dict[str, dict[str, Any]] = {
+        "workspace_root": _path_state(workspace),
+        "harbor_common": _path_state(harbor_root),
+        "local_dependency_cache": _path_state(local_dependency_cache),
+    }
+    if repo_root is not None:
+        repository_paths.update(
+            {
+                "repository_root": _path_state(repo_root),
+                "tasks": _path_state(repo_root / "Tasks"),
+                "claude_code_adapter": _path_state(repo_root / "Agents/Harbor-claude-code"),
+                "opencode_adapter": _path_state(repo_root / "Agents/Harbor-opencode"),
+                "opik_plugin": _path_state(repo_root / "third_party/agent-opik-plugin"),
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "kind": "harbor_fixer_target_environment",
+        "repository_paths": repository_paths,
+        "commands": commands,
+        "python_runtimes": _python_snapshot(commands),
+        "uv": _uv_snapshot(),
+        "docker": _docker_snapshot(),
+        "evidence_files": _evidence_paths(task_inputs),
+    }

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/safe_paths.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/safe_paths.py
@@ -1,0 +1,75 @@
+"""Shared, non-throwing path inspection for planning context collectors."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def inspect_path(
+    path: Path,
+    *,
+    expand_user: bool,
+    include_writable: bool,
+    include_executable: bool,
+    include_mode: bool,
+) -> dict[str, Any]:
+    inspected = path.expanduser() if expand_user else path
+    try:
+        exists = inspected.exists()
+        readable = os.access(inspected, os.R_OK)
+        writable = os.access(inspected, os.W_OK) if include_writable else None
+        executable = os.access(inspected, os.X_OK) if include_executable else None
+    except OSError as exc:
+        payload: dict[str, Any] = {
+            "path": str(inspected),
+            "status": "unavailable",
+            "reason": f"path_unavailable:{exc.__class__.__name__}",
+            "exists": False,
+            "readable": False,
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+        if include_writable:
+            payload["writable"] = False
+        if include_executable:
+            payload["executable"] = False
+        return payload
+
+    payload = {
+        "path": str(inspected),
+        "exists": exists,
+        "readable": readable,
+    }
+    if include_writable:
+        payload["writable"] = bool(writable)
+    if include_executable:
+        payload["executable"] = bool(executable)
+    if not exists:
+        return payload
+
+    try:
+        resolved = inspected.resolve(strict=True)
+        info = resolved.stat()
+    except OSError as exc:
+        payload["status"] = "unavailable"
+        payload["reason"] = f"path_unavailable:{exc.__class__.__name__}"
+        payload["error"] = f"{exc.__class__.__name__}: {exc}"
+        return payload
+
+    payload.update(
+        {
+            "realpath": str(resolved),
+            "type": (
+                "directory"
+                if resolved.is_dir()
+                else "file"
+                if resolved.is_file()
+                else "other"
+            ),
+            "size_bytes": info.st_size,
+        }
+    )
+    if include_mode:
+        payload["mode"] = oct(info.st_mode & 0o777)
+    return payload

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/workspace_evidence.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/planning_context/workspace_evidence.py
@@ -1,0 +1,314 @@
+"""Collect deterministic, bounded workspace manifests and evidence excerpts."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from ..analyzer_inputs import resolve_analyzer_paths
+from ..validation import task_key
+from .safe_paths import inspect_path
+
+MAX_TOP_LEVEL_ENTRIES = 200
+MAX_MANIFESTS = 100
+MAX_MANIFEST_LINES = 160
+MAX_EVIDENCE_EXCERPTS = 100
+MAX_EVIDENCE_LINES = 80
+MAX_FILE_BYTES = 32 * 1024 * 1024
+MAX_OUTPUT_CHARS = 24_000
+MAX_PROJECT_DEPTH = 4
+MAX_SCAN_ENTRIES = 10_000
+EXCLUDED_DIRECTORIES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "target",
+}
+MANIFEST_PATTERNS = {
+    "Cargo.toml",
+    "Dockerfile",
+    "Pipfile",
+    "compose.yaml",
+    "compose.yml",
+    "docker-compose.yaml",
+    "docker-compose.yml",
+    "environment.yml",
+    "go.mod",
+    "package.json",
+    "pyproject.toml",
+    "requirements*.txt",
+    "setup.cfg",
+    "setup.py",
+    "tox.ini",
+}
+SENSITIVE_PARTS = {".ssh", ".aws", ".gnupg"}
+SENSITIVE_NAMES = {
+    ".env",
+    ".git-credentials",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "auth.json",
+    "credentials",
+    "credentials.json",
+    "secrets",
+    "secrets.json",
+    "token",
+    "tokens.json",
+}
+SENSITIVE_SUFFIXES = {".key", ".p12", ".pem", ".pfx"}
+SECRET_PATTERNS = (
+    re.compile(r"(?i)(authorization\s*:\s*bearer\s+)[^\s\"']+"),
+    re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/=-]{12,}"),
+    re.compile(
+        r"""(?i)(["']?(?:api[_-]?key|access[_-]?token|base[_-]?url|password|secret|token)["']?\s*[=:]\s*["']?)[^"'\s,}]+"""
+    ),
+    re.compile(r"(?<![A-Za-z0-9])(?:sk[-_]|gh[pousr]_)[A-Za-z0-9_-]{12,}"),
+)
+PRIVATE_KEY_PATTERN = re.compile(
+    r"-----BEGIN [^-]*PRIVATE KEY-----.*?-----END [^-]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+BASE64_SECRET_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9+/])[A-Za-z0-9+/]{32,}={0,2}(?![A-Za-z0-9+/=])"
+)
+URL_USERINFO_PATTERN = re.compile(
+    r"(?i)\b([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^@/\s]+@"
+)
+
+
+def _is_sensitive(path: Path) -> bool:
+    lowered_parts = [part.lower() for part in path.parts]
+    for part in lowered_parts:
+        if part in SENSITIVE_PARTS or part.startswith(".env"):
+            return True
+    name = path.name.lower()
+    return (
+        name in SENSITIVE_NAMES
+        or name.endswith(tuple(SENSITIVE_SUFFIXES))
+        or "private_key" in name
+        or (".docker" in lowered_parts and name == "config.json")
+    )
+
+
+def _redact(text: str) -> str:
+    redacted = URL_USERINFO_PATTERN.sub(r"\1<REDACTED>@", text)
+    redacted = PRIVATE_KEY_PATTERN.sub("<REDACTED PRIVATE KEY>", redacted)
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub(
+            lambda match: (
+                f"{match.group(1)}<REDACTED>"
+                if match.lastindex
+                else "<REDACTED>"
+            ),
+            redacted,
+        )
+    return BASE64_SECRET_PATTERN.sub(
+        lambda match: (
+            "<REDACTED>"
+            if any(character.isupper() for character in match.group())
+            and any(character.islower() for character in match.group())
+            and any(character.isdigit() for character in match.group())
+            and any(character in "+/=" for character in match.group())
+            else match.group()
+        ),
+        redacted,
+    )
+
+
+def _bounded(text: str) -> str:
+    redacted = _redact(text)
+    if len(redacted) <= MAX_OUTPUT_CHARS:
+        return redacted
+    return redacted[:MAX_OUTPUT_CHARS] + "\n<TRUNCATED>"
+
+
+def _path_state(path: Path) -> dict[str, Any]:
+    return inspect_path(
+        path,
+        expand_user=False,
+        include_writable=False,
+        include_executable=False,
+        include_mode=False,
+    )
+
+
+def _read_lines(path: Path, start: int, end: int) -> tuple[str, str]:
+    if _is_sensitive(path):
+        return "", "sensitive_path"
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        return "", f"path_unavailable:{exc.__class__.__name__}"
+    if _is_sensitive(resolved):
+        return "", "sensitive_path"
+    if not resolved.is_file():
+        return "", "path_is_not_file"
+    try:
+        if resolved.stat().st_size > MAX_FILE_BYTES:
+            return "", "file_too_large"
+        with resolved.open("rb") as handle:
+            if b"\x00" in handle.read(8192):
+                return "", "binary_file"
+        selected: list[str] = []
+        with resolved.open(encoding="utf-8", errors="replace") as handle:
+            for line_number, line in enumerate(handle, 1):
+                if line_number > end:
+                    break
+                if line_number >= start:
+                    selected.append(f"{line_number}: {line.rstrip()}")
+    except OSError as exc:
+        return "", f"read_failed:{exc.__class__.__name__}"
+    return _bounded("\n".join(selected)), ""
+
+
+def _top_level_entries(workspace: Path) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    try:
+        children = sorted(workspace.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return entries
+    for child in children:
+        if child.is_symlink() or _is_sensitive(child):
+            continue
+        kind = "directory" if child.is_dir() else "file" if child.is_file() else "other"
+        entries.append({"path": str(child), "type": kind})
+        if len(entries) >= MAX_TOP_LEVEL_ENTRIES:
+            break
+    return entries
+
+
+def _is_manifest(path: Path) -> bool:
+    return any(fnmatch.fnmatch(path.name, pattern) for pattern in MANIFEST_PATTERNS)
+
+
+def _project_manifests(workspace: Path) -> tuple[list[dict[str, Any]], bool]:
+    manifests: list[dict[str, Any]] = []
+    scanned = 0
+    truncated = False
+    for current_root, directories, filenames in os.walk(workspace, followlinks=False):
+        current = Path(current_root)
+        depth = len(current.relative_to(workspace).parts)
+        directories[:] = sorted(
+            name
+            for name in directories
+            if name not in EXCLUDED_DIRECTORIES
+            and depth < MAX_PROJECT_DEPTH
+            and not (current / name).is_symlink()
+            and not _is_sensitive(current / name)
+        )
+        scanned += len(directories)
+        if scanned > MAX_SCAN_ENTRIES:
+            return manifests, True
+        for name in sorted(filenames):
+            scanned += 1
+            if scanned > MAX_SCAN_ENTRIES:
+                return manifests, True
+            candidate = current / name
+            if candidate.is_symlink() or _is_sensitive(candidate) or not _is_manifest(candidate):
+                continue
+            state = _path_state(candidate)
+            excerpt, error = _read_lines(candidate, 1, MAX_MANIFEST_LINES)
+            state["excerpt"] = excerpt
+            state["status"] = "success" if not error else "unavailable"
+            state["reason"] = error
+            manifests.append(state)
+            if len(manifests) >= MAX_MANIFESTS:
+                truncated = True
+                return manifests, truncated
+    return manifests, truncated
+
+
+def _evidence_excerpts(task_inputs: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+    excerpts: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str, str, int, int]] = set()
+    truncated = False
+    for task_input in task_inputs:
+        task = task_input["task"]
+        for evidence in task_input["evidence"]:
+            path_value = evidence["path"]
+            requested_start = max(1, evidence["line_start"])
+            requested_end = max(requested_start, evidence["line_end"])
+            start = max(1, requested_start - 3)
+            end = min(
+                max(requested_end + 3, start),
+                start + MAX_EVIDENCE_LINES - 1,
+            )
+            key = (*task_key(task), path_value, start, end)
+            if key in seen:
+                continue
+            seen.add(key)
+            path = Path(path_value)
+            excerpt, error = _read_lines(path, start, end)
+            entry: dict[str, Any] = {
+                "task": task,
+                "path": path_value,
+                "line_start": start,
+                "line_end": end,
+                "status": "success" if not error else "unavailable",
+                "reason": error,
+                "excerpt": excerpt,
+            }
+            excerpts.append(entry)
+            if len(excerpts) >= MAX_EVIDENCE_EXCERPTS:
+                truncated = True
+                return excerpts, truncated
+    return excerpts, truncated
+
+
+def collect_workspace_evidence(
+    workspace_root: Path,
+    analyzer_output_path: Path,
+    task_inputs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Collect deterministic project and evidence context without model involvement."""
+
+    workspace = workspace_root.expanduser().resolve(strict=True)
+    analyzer_output = analyzer_output_path.expanduser().resolve(strict=True)
+    manifests, manifests_truncated = _project_manifests(workspace)
+    evidence, evidence_truncated = _evidence_excerpts(task_inputs)
+    resolved_analyzer = resolve_analyzer_paths(analyzer_output)
+    analyzer_artifacts = {
+        "manifest": _path_state(resolved_analyzer["manifest_path"]),
+        "publications": [
+            {
+                "handover_id": publication["handover_id"],
+                "publication_id": publication["publication_id"],
+                "env_infra_tasks": _path_state(Path(publication["env_infra_tasks_path"])),
+                "fix_line_index": _path_state(Path(publication["fix_line_index_path"])),
+            }
+            for publication in resolved_analyzer["publications"]
+        ],
+    }
+    return {
+        "schema_version": 1,
+        "kind": "harbor_fixer_target_context",
+        "workspace": {
+            "root": str(workspace),
+            "top_level_entries": _top_level_entries(workspace),
+            "project_manifests": manifests,
+            "project_manifests_truncated": manifests_truncated,
+        },
+        "analyzer_artifacts": analyzer_artifacts,
+        "evidence_excerpts": evidence,
+        "evidence_excerpts_truncated": evidence_truncated,
+        "collection_limits": {
+            "max_top_level_entries": MAX_TOP_LEVEL_ENTRIES,
+            "max_project_depth": MAX_PROJECT_DEPTH,
+            "max_manifests": MAX_MANIFESTS,
+            "max_manifest_lines": MAX_MANIFEST_LINES,
+            "max_evidence_excerpts": MAX_EVIDENCE_EXCERPTS,
+            "max_evidence_lines": MAX_EVIDENCE_LINES,
+            "max_file_bytes": MAX_FILE_BYTES,
+        },
+    }

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -1,0 +1,220 @@
+"""Lightweight validation helpers for Harbor Fixer MVP artifacts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class ValidationError(ValueError):
+    """Raised when an external artifact or agent output is unusable."""
+
+
+ENV_INFRA_CLASSES = {"env_fail", "infra_fail"}
+ANALYZER_SCOPES = {"task", "benchmark", "host"}
+FIX_SCOPES = {"task", "benchmark", "host"}
+SUMMARY_SCOPES = {"task", "benchmark", "host", "unknown"}
+SCOPE_AGREEMENTS = {"agree", "unclear", "disagree"}
+CONFIDENCE_LABELS = {"high", "medium", "low"}
+
+
+def require_dict(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValidationError(f"{name} must be an object")
+    return value
+
+
+def require_list(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValidationError(f"{name} must be a list")
+    return value
+
+
+def require_string(value: Any, name: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{name} must be a string")
+    if not allow_empty and not value:
+        raise ValidationError(f"{name} must be non-empty")
+    return value
+
+
+def require_enum(value: Any, name: str, allowed: set[str]) -> str:
+    text = require_string(value, name)
+    if text not in allowed:
+        raise ValidationError(f"{name} must be one of: {', '.join(sorted(allowed))}")
+    return text
+
+
+def task_key(task: dict[str, Any]) -> tuple[str, str, str]:
+    attempt_id = task.get("attempt_id")
+    return (
+        str(task.get("task_index") or ""),
+        str(task.get("task_name") or ""),
+        "" if attempt_id is None else str(attempt_id),
+    )
+
+
+def parse_strict_json_object(raw: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON: {exc}") from exc
+    return require_dict(payload, "model output")
+
+
+def _check_kind(payload: dict[str, Any], *, version: int, kind: str, name: str) -> None:
+    require_dict(payload, name)
+    if payload.get("schema_version") != version:
+        raise ValidationError(f"{name} schema_version must be {version}")
+    if payload.get("kind") != kind:
+        raise ValidationError(f"{name} kind must be {kind}")
+
+
+def _check_kind_versions(payload: dict[str, Any], *, versions: set[int], kind: str, name: str) -> int:
+    require_dict(payload, name)
+    version = payload.get("schema_version")
+    if version not in versions:
+        raise ValidationError(f"{name} schema_version must be one of: {', '.join(str(item) for item in sorted(versions))}")
+    if payload.get("kind") != kind:
+        raise ValidationError(f"{name} kind must be {kind}")
+    return int(version)
+
+
+def validate_analyzer_manifest(payload: dict[str, Any]) -> None:
+    _check_kind(
+        payload,
+        version=2,
+        kind="harbor_analyzer_latest_artifacts",
+        name="analyzer artifact manifest",
+    )
+    require_string(payload.get("run_id"), "analyzer artifact manifest run_id")
+    seen_handovers: set[str] = set()
+    for index, item in enumerate(
+        require_list(payload.get("publications"), "analyzer artifact manifest publications")
+    ):
+        publication = require_dict(item, f"publications[{index}]")
+        handover_id = require_string(
+            publication.get("handover_id"),
+            f"publications[{index}].handover_id",
+        )
+        require_string(
+            publication.get("publication_id"),
+            f"publications[{index}].publication_id",
+        )
+        if handover_id in seen_handovers:
+            raise ValidationError(f"duplicate analyzer publication for handover_id={handover_id}")
+        seen_handovers.add(handover_id)
+
+
+def validate_env_infra_tasks(payload: dict[str, Any]) -> None:
+    _check_kind(payload, version=2, kind="harbor_env_infra_task_list", name="env/infra task list")
+    for index, item in enumerate(require_list(payload.get("tasks"), "env/infra tasks")):
+        item_obj = require_dict(item, f"env/infra tasks[{index}]")
+        task = require_dict(item_obj.get("task"), f"env/infra tasks[{index}].task")
+        require_string(task.get("task_index"), f"env/infra tasks[{index}].task.task_index")
+        require_string(task.get("task_name"), f"env/infra tasks[{index}].task.task_name")
+        if "attempt_id" not in task:
+            raise ValidationError(f"env/infra tasks[{index}].task.attempt_id is required")
+        require_enum(item_obj.get("final_class"), f"env/infra tasks[{index}].final_class", ENV_INFRA_CLASSES)
+        require_string(item_obj.get("failure_stage"), f"env/infra tasks[{index}].failure_stage")
+        require_enum(item_obj.get("scope"), f"env/infra tasks[{index}].scope", ANALYZER_SCOPES)
+        confidence = item_obj.get("confidence")
+        if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+            raise ValidationError(f"env/infra tasks[{index}].confidence must be a number")
+        if not 0 <= confidence <= 1:
+            raise ValidationError(f"env/infra tasks[{index}].confidence must be between 0 and 1")
+        require_string(item_obj.get("root_cause_code"), f"env/infra tasks[{index}].root_cause_code")
+        require_string(
+            item_obj.get("root_cause_summary"),
+            f"env/infra tasks[{index}].root_cause_summary",
+        )
+
+
+def validate_fix_line_index(records: list[dict[str, Any]]) -> None:
+    for index, record in enumerate(records):
+        _check_kind(
+            record,
+            version=2,
+            kind="harbor_fix_line_reference",
+            name=f"fix-line-index[{index}]",
+        )
+        task = require_dict(record.get("task"), f"fix-line-index[{index}].task")
+        require_string(task.get("task_index"), f"fix-line-index[{index}].task.task_index")
+        require_string(task.get("task_name"), f"fix-line-index[{index}].task.task_name")
+        if "attempt_id" not in task:
+            raise ValidationError(f"fix-line-index[{index}].task.attempt_id is required")
+        require_string(record.get("root_cause_code"), f"fix-line-index[{index}].root_cause_code")
+        require_string(record.get("path"), f"fix-line-index[{index}].path")
+        require_string(record.get("fact"), f"fix-line-index[{index}].fact")
+        require_string(record.get("reason"), f"fix-line-index[{index}].reason")
+        line_start = record.get("line_start")
+        line_end = record.get("line_end")
+        if (
+            isinstance(line_start, bool)
+            or isinstance(line_end, bool)
+            or not isinstance(line_start, int)
+            or not isinstance(line_end, int)
+            or line_start <= 0
+            or line_end < line_start
+        ):
+            raise ValidationError(f"fix-line-index[{index}] has an invalid line range")
+
+
+def validate_task_input(payload: dict[str, Any]) -> None:
+    _check_kind(payload, version=1, kind="harbor_fixer_task_input", name="task input")
+    require_string(require_dict(payload.get("task"), "task input task").get("task_index"), "task.task_index")
+    analyzer = require_dict(payload.get("analyzer_result"), "analyzer_result")
+    require_enum(analyzer.get("final_class"), "analyzer_result.final_class", ENV_INFRA_CLASSES)
+    require_enum(analyzer.get("scope"), "analyzer_result.scope", ANALYZER_SCOPES)
+    require_string(analyzer.get("root_cause_code"), "analyzer_result.root_cause_code")
+    require_string(analyzer.get("root_cause_summary"), "analyzer_result.root_cause_summary")
+    if not require_list(payload.get("evidence"), "evidence"):
+        raise ValidationError("evidence must be non-empty")
+
+
+def validate_task_summary(payload: dict[str, Any], expected_task: dict[str, Any] | None = None) -> None:
+    _check_kind(payload, version=1, kind="harbor_fixer_task_summary", name="task summary")
+    task = require_dict(payload.get("task"), "task summary task")
+    require_string(task.get("task_index"), "task.task_index")
+    if expected_task is not None and task_key(task) != task_key(expected_task):
+        raise ValidationError("task summary identity does not match task input")
+    alignment = require_dict(payload.get("analyzer_alignment"), "analyzer_alignment")
+    require_enum(alignment.get("final_class"), "analyzer_alignment.final_class", ENV_INFRA_CLASSES)
+    require_enum(alignment.get("analyzer_scope"), "analyzer_alignment.analyzer_scope", ANALYZER_SCOPES)
+    require_string(alignment.get("root_cause_code"), "analyzer_alignment.root_cause_code")
+    require_enum(alignment.get("scope_agreement"), "analyzer_alignment.scope_agreement", SCOPE_AGREEMENTS)
+    require_string(payload.get("root_cause_summary"), "root_cause_summary")
+    require_list(payload.get("strongest_evidence"), "strongest_evidence")
+    fix_direction = require_dict(payload.get("fix_direction"), "fix_direction")
+    require_enum(fix_direction.get("suggested_scope"), "fix_direction.suggested_scope", SUMMARY_SCOPES)
+    require_string(fix_direction.get("summary"), "fix_direction.summary")
+    require_enum(payload.get("confidence"), "confidence", CONFIDENCE_LABELS)
+    require_list(payload.get("unknowns"), "unknowns")
+
+
+def validate_fix_plan_set(payload: dict[str, Any]) -> None:
+    _check_kind(payload, version=1, kind="harbor_fixer_fix_plan_set", name="fix plan set")
+    require_dict(payload.get("source"), "source")
+    seen_plan_ids: set[str] = set()
+    for index, plan in enumerate(require_list(payload.get("plans"), "plans")):
+        plan_obj = require_dict(plan, f"plans[{index}]")
+        plan_id = require_string(plan_obj.get("plan_id"), f"plans[{index}].plan_id")
+        if plan_id in seen_plan_ids:
+            raise ValidationError(f"duplicate plan_id: {plan_id}")
+        seen_plan_ids.add(plan_id)
+        require_enum(plan_obj.get("fix_scope"), f"plans[{index}].fix_scope", FIX_SCOPES)
+        require_dict(plan_obj.get("analyzer_scope_comparison"), f"plans[{index}].analyzer_scope_comparison")
+        if not require_list(plan_obj.get("task_list"), f"plans[{index}].task_list"):
+            raise ValidationError(f"plans[{index}].task_list must be non-empty")
+        commands = require_list(plan_obj.get("commands"), f"plans[{index}].commands")
+        if not commands:
+            raise ValidationError(f"plans[{index}].commands must be non-empty")
+        for command_index, command in enumerate(commands):
+            command_obj = require_dict(command, f"plans[{index}].commands[{command_index}]")
+            require_string(command_obj.get("command_id"), f"plans[{index}].commands[{command_index}].command_id")
+            require_string(command_obj.get("cwd"), f"plans[{index}].commands[{command_index}].cwd")
+            require_string(command_obj.get("command"), f"plans[{index}].commands[{command_index}].command")
+        require_dict(plan_obj.get("fix_reason"), f"plans[{index}].fix_reason")
+        require_dict(plan_obj.get("verification_hint"), f"plans[{index}].verification_hint")
+    require_list(payload.get("unplanned_tasks"), "unplanned_tasks")
+    require_list(payload.get("generation_errors"), "generation_errors")

--- a/Agents/utils/common/Harbor/tests/fixer_test_support.py
+++ b/Agents/utils/common/Harbor/tests/fixer_test_support.py
@@ -1,0 +1,114 @@
+"""Shared fixtures and test doubles for Harbor Fixer stage tests."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+class FixerTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+
+
+def make_task(index: int) -> dict:
+    return {
+        "task": {"task_index": str(index), "task_name": f"task-{index}", "attempt_id": None},
+        "final_class": "env_fail",
+        "failure_stage": "environment_setup",
+        "scope": "benchmark",
+        "confidence": 0.91,
+        "root_cause_code": "docker_registry_unavailable",
+        "root_cause_summary": "Docker registry is unreachable.",
+        "evidence": {
+            "path": f"/logs/task-{index}.log",
+            "line_start": 10,
+            "line_end": 12,
+            "fact": "docker pull cannot reach registry",
+            "reason": "The environment setup fails before task execution.",
+        },
+    }
+
+
+def write_analyzer_fixture(root: Path, count: int = 1) -> Path:
+    analyzer_dir = root / "analyzer"
+    handover_id = "handover-1"
+    publication_id = "publication-current"
+    tasks = [make_task(index) for index in range(1, count + 1)]
+    env_infra_path = (
+        analyzer_dir / "env-infra-tasks" / handover_id / f"{publication_id}.json"
+    )
+    fix_line_index_path = (
+        analyzer_dir / "fix-line-index" / handover_id / f"{publication_id}.jsonl"
+    )
+    write_json(
+        analyzer_dir / "analyzer-artifacts-latest.json",
+        {
+            "schema_version": 2,
+            "kind": "harbor_analyzer_latest_artifacts",
+            "handover_id": handover_id,
+            "publication_id": publication_id,
+            "run_id": "run-1",
+            "generated_at": "2026-07-16T00:00:00Z",
+            "artifacts": {
+                "env_infra_tasks_path": "/stale-copy/env-infra-tasks.json",
+                "fix_line_index_path": "/stale-copy/fix-line-index.jsonl",
+            },
+            "publications": [
+                {
+                    "handover_id": handover_id,
+                    "publication_id": publication_id,
+                    "generated_at": "2026-07-16T00:00:00Z",
+                    "artifacts": {
+                        "env_infra_tasks_path": "/stale-copy/env-infra-tasks.json",
+                        "fix_line_index_path": "/stale-copy/fix-line-index.jsonl",
+                    },
+                }
+            ],
+        },
+    )
+    write_json(
+        env_infra_path,
+        {
+            "schema_version": 2,
+            "kind": "harbor_env_infra_task_list",
+            "handover_id": handover_id,
+            "generated_at": "2026-07-16T00:00:00Z",
+            "task_count": count,
+            "tasks": [
+                {
+                    "task": task["task"],
+                    "final_class": task["final_class"],
+                    "failure_stage": task["failure_stage"],
+                    "scope": task["scope"],
+                    "confidence": task["confidence"],
+                    "root_cause_code": task["root_cause_code"],
+                    "root_cause_summary": task["root_cause_summary"],
+                }
+                for task in tasks
+            ],
+        },
+    )
+    fix_line_index_path.parent.mkdir(parents=True, exist_ok=True)
+    with fix_line_index_path.open("w", encoding="utf-8") as handle:
+        for task in tasks:
+            ref = dict(task["evidence"])
+            ref.update(
+                {
+                    "schema_version": 2,
+                    "kind": "harbor_fix_line_reference",
+                    "task": task["task"],
+                    "root_cause_code": task["root_cause_code"],
+                }
+            )
+            handle.write(json.dumps(ref) + "\n")
+    return analyzer_dir

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_runtime_context.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_runtime_context.py
@@ -1,0 +1,224 @@
+"""Tests for Harbor Fixer runtime context."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+if str(TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(TEST_DIR))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from fixer_test_support import (  # noqa: E402
+    FixerTestCase,
+    write_analyzer_fixture,
+    write_json,
+)
+from harbor_fixer.analyzer_inputs import build_task_inputs  # noqa: E402
+from harbor_fixer.planning_context import (
+    collect_planning_context,  # noqa: E402
+    workspace_evidence,  # noqa: E402
+)
+from harbor_fixer.planning_context.runtime_inventory import (  # noqa: E402
+    collect_runtime_inventory,
+)
+from harbor_fixer.planning_context.safe_paths import inspect_path  # noqa: E402
+from harbor_fixer.planning_context.workspace_evidence import (  # noqa: E402
+    collect_workspace_evidence,
+)
+from harbor_fixer.validation import ValidationError, task_key  # noqa: E402
+
+
+class HarborFixerRuntimeContextTest(FixerTestCase):
+    def test_analyzer_artifacts_build_task_inputs(self) -> None:
+        analyzer = write_analyzer_fixture(self.root)
+        write_json(
+            analyzer / "env-infra-tasks" / "handover-1" / "publication-zzzz.json",
+            {"stale": True},
+        )
+        inputs, source = build_task_inputs(analyzer)
+
+        self.assertEqual(source["run_id"], "run-1")
+        self.assertEqual(source["publications"][0]["publication_id"], "publication-current")
+        self.assertEqual(inputs[0]["task"]["task_index"], "1")
+        self.assertEqual(inputs[0]["source"]["handover_id"], "handover-1")
+        self.assertEqual(inputs[0]["source"]["publication_id"], "publication-current")
+        self.assertEqual(inputs[0]["evidence"][0]["path"], "/logs/task-1.log")
+        self.assertNotIn("reasoning_summary", inputs[0]["analyzer_result"])
+        self.assertNotIn("analyzer_report_path", inputs[0]["source"])
+        self.assertNotIn("/stale-copy/", json.dumps(inputs))
+
+        selected_env = Path(source["publications"][0]["env_infra_tasks_path"])
+        selected_inputs, selected_source = build_task_inputs(selected_env)
+        self.assertEqual(selected_inputs, inputs)
+        self.assertEqual(selected_source, source)
+
+    def test_empty_analyzer_output_is_valid_planning_context(self) -> None:
+        analyzer = write_analyzer_fixture(self.root, count=0)
+
+        inputs, source = build_task_inputs(analyzer)
+        runtime, context = collect_planning_context(
+            self.root,
+            analyzer,
+            inputs,
+            pi_bin=sys.executable,
+        )
+
+        self.assertEqual(inputs, [])
+        self.assertEqual(len(source["publications"]), 1)
+        self.assertEqual(runtime["evidence_files"]["paths"], [])
+        self.assertEqual(context["evidence_excerpts"], [])
+        self.assertTrue(context["analyzer_artifacts"]["manifest"]["readable"])
+        self.assertEqual(len(context["analyzer_artifacts"]["publications"]), 1)
+
+    def test_analyzer_task_requires_matching_evidence(self) -> None:
+        analyzer = write_analyzer_fixture(self.root)
+        fix_line_index = (
+            analyzer / "fix-line-index" / "handover-1" / "publication-current.jsonl"
+        )
+        fix_line_index.write_text("", encoding="utf-8")
+
+        with self.assertRaisesRegex(ValidationError, "evidence must be non-empty"):
+            build_task_inputs(analyzer)
+
+    def test_target_environment_rejects_missing_workspace_and_records_file_state(self) -> None:
+        evidence = self.root / "evidence.log"
+        dependency_cache = self.root / "configured-harbor-deps"
+        evidence.write_text("fixture\n", encoding="utf-8")
+        dependency_cache.mkdir()
+        with mock.patch.dict(
+            os.environ,
+            {"LOCAL_WHEEL_DIR": str(dependency_cache)},
+        ):
+            snapshot = collect_runtime_inventory(
+                self.root,
+                [{"evidence": [{"path": str(evidence)}]}],
+                pi_bin=sys.executable,
+            )
+
+        self.assertEqual(snapshot["kind"], "harbor_fixer_target_environment")
+        self.assertTrue(snapshot["repository_paths"]["workspace_root"]["readable"])
+        self.assertEqual(
+            snapshot["repository_paths"]["local_dependency_cache"]["path"],
+            str(dependency_cache),
+        )
+        self.assertTrue(
+            snapshot["repository_paths"]["opik_plugin"]["path"].endswith(
+                "third_party/agent-opik-plugin"
+            )
+        )
+        self.assertEqual(snapshot["evidence_files"]["paths"][0]["type"], "file")
+        self.assertEqual(snapshot["commands"]["pi"]["path"], sys.executable)
+        self.assertNotIn("docker", snapshot["commands"])
+        self.assertNotIn("available", snapshot["docker"])
+
+        with self.assertRaisesRegex(ValidationError, "workspace root"):
+            collect_runtime_inventory(self.root / "missing", [])
+
+    def test_path_probe_degrades_permission_error_to_unavailable(self) -> None:
+        inaccessible = Path("/home/other-user/private/evidence.log")
+        with mock.patch.object(
+            Path,
+            "exists",
+            side_effect=PermissionError(13, "Permission denied", str(inaccessible)),
+        ):
+            state = inspect_path(
+                inaccessible,
+                expand_user=False,
+                include_writable=False,
+                include_executable=False,
+                include_mode=False,
+            )
+
+        self.assertEqual(state["status"], "unavailable")
+        self.assertEqual(state["reason"], "path_unavailable:PermissionError")
+
+    def test_target_context_is_deterministic_bounded_and_redacted(self) -> None:
+        workspace = self.root / "workspace"
+        analyzer = write_analyzer_fixture(self.root, count=0)
+        workspace.mkdir()
+        (workspace / "pyproject.toml").write_text(
+            '[project]\nname = "fixture"\npassword = "manifest-secret"\n',
+            encoding="utf-8",
+        )
+        evidence = self.root / "evidence.log"
+        evidence.write_text(
+            "before\nAPI_KEY=super-secret-value\nfailure line\n"
+            "registry=https://user:password@registry.example\n"
+            "sk-proj-fixture0123456789abcdefghijklmnop\nafter\n",
+            encoding="utf-8",
+        )
+        secret_evidence = workspace / ".env"
+        secret_evidence.write_text("TOKEN=hidden\n", encoding="utf-8")
+        task_inputs = [
+            {
+                "task": {
+                    "task_index": "1",
+                    "task_name": "fixture",
+                    "attempt_id": None,
+                },
+                "evidence": [
+                    {"path": str(evidence), "line_start": 3, "line_end": 3},
+                    {"path": str(secret_evidence), "line_start": 1, "line_end": 1},
+                ],
+            },
+            {
+                "task": {
+                    "task_index": "2",
+                    "task_name": "fixture-2",
+                    "attempt_id": None,
+                },
+                "evidence": [
+                    {"path": str(evidence), "line_start": 3, "line_end": 3},
+                ],
+            },
+        ]
+
+        first = collect_workspace_evidence(workspace, analyzer, task_inputs)
+        self.assertEqual(first, collect_workspace_evidence(workspace, analyzer, task_inputs))
+        serialized = json.dumps(first)
+        self.assertNotIn("manifest-secret", serialized)
+        self.assertNotIn("super-secret-value", serialized)
+        self.assertNotIn("user:password", serialized)
+        self.assertNotIn("sk-proj-fixture0123456789abcdefghijklmnop", serialized)
+        self.assertIn("<REDACTED>", serialized)
+        self.assertIn("failure line", first["evidence_excerpts"][0]["excerpt"])
+        self.assertEqual(first["evidence_excerpts"][1]["reason"], "sensitive_path")
+        self.assertEqual(
+            [item["task"]["task_index"] for item in first["evidence_excerpts"]],
+            ["1", "1", "2"],
+        )
+
+    def test_workspace_scan_counts_directories_toward_limit(self) -> None:
+        analyzer = write_analyzer_fixture(self.root, count=0)
+        workspace = self.root / "workspace"
+        (workspace / "one").mkdir(parents=True)
+        (workspace / "two").mkdir()
+
+        with mock.patch.object(workspace_evidence, "MAX_SCAN_ENTRIES", 1):
+            context = collect_workspace_evidence(workspace, analyzer, [])
+
+        self.assertTrue(context["workspace"]["project_manifests_truncated"])
+
+    def test_task_key_matches_analyzer_normalization(self) -> None:
+        base = {"task_index": "1", "task_name": "task"}
+
+        self.assertEqual(
+            task_key({**base, "attempt_id": 0}),
+            task_key({**base, "attempt_id": "0"}),
+        )
+        self.assertEqual(
+            task_key({**base, "attempt_id": None}),
+            task_key({**base, "attempt_id": ""}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

The Harbor auto-fixer needs a deterministic and reviewable input boundary before an agent is allowed to propose changes. Analyzer output currently exists as several related artifacts, while relevant runtime and workspace evidence may be large, unavailable, or contain credentials.

This PR introduces the non-agent foundation for the Fixer: validate the Analyzer handoff, normalize task inputs, and collect a bounded, redacted planning context. It supports the auto-fixer work tracked in [sii-system/tasks#115](https://github.com/sii-system/tasks/issues/115) without invoking Pi or executing any fix command.

## 2. Summary of the change

- Add Analyzer artifact readers and validation for:
  - `analyzer-report-latest.json`;
  - `env-infra-tasks-latest.json`;
  - `fix-line-index-latest.jsonl`.
- Translate environment and infrastructure failures into deterministic per-task Fixer inputs.
- Add a bounded runtime inventory covering repository paths, available commands, Python, uv, Docker, and evidence-file state.
- Add a bounded workspace/evidence snapshot with:
  - sensitive-path exclusion;
  - credential and token redaction;
  - capped manifest and evidence excerpts;
  - explicit unavailable-path results instead of probe failures.
- Add shared JSON/JSONL artifact helpers and schema validation used by later Fixer stages.
- Add focused tests for Analyzer handoff translation, unavailable paths, deterministic context generation, bounds, and redaction.
- Document the new `harbor_fixer` planning-context boundary.

This PR intentionally does not add Pi invocation, prompts, plan generation, command execution, verification, reporting, or batch processing.

## 3. Other details

This branch is independently based on `main`; it does not depend on the shared Pi runtime PR.

Safety properties:

- No agent or subprocess is launched by the planning-context flow.
- Evidence collection is read-only and bounded.
- Known credential patterns and sensitive files are excluded or redacted before artifacts are written.
- Missing and permission-denied paths are represented as structured unavailable states.

Validation performed:

- `python3 -m unittest Agents/utils/common/Harbor/tests/test_harbor_fixer_runtime_context.py Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py Agents/utils/common/Harbor/tests/test_harbor_analyzer_validation.py`
  - 23 tests passed.
- `git diff --check` passed.
