### PR TITLE
Fix Ruff issues in GitHub scripts

### DIFF
--- a/.github/scripts/llm_pr_review.py
+++ b/.github/scripts/llm_pr_review.py
@@ -95,7 +95,7 @@ def parse_patch(path: str, patch: str) -> ParsedFile:
             rendered.append(f"- OLD {old_line}: {raw_line[1:]}")
             old_line += 1
         else:
-            content = raw_line[1:] if raw_line.startswith(" ") else raw_line
+            content = raw_line.removeprefix(" ")
             rendered.append(f"  OLD {old_line} RIGHT {new_line}: {content}")
             old_line += 1
             new_line += 1
@@ -313,7 +313,7 @@ class GitHubClient:
                 f"{path}{separator}{urlencode({'per_page': 100, 'page': page})}",
             )
             if not isinstance(batch, list):
-                raise ValueError("GitHub list response must be an array")
+                raise TypeError("GitHub list response must be an array")
             items.extend(batch)
             if len(batch) < 100:
                 return items
@@ -455,8 +455,10 @@ def build_summary(
         lines.extend(
             [
                 "",
-                f"- {incomplete_chunks} diff chunk(s) returned an empty model "
-                "response and were not reviewed.",
+                (
+                    f"- {incomplete_chunks} diff chunk(s) returned an empty model "
+                    "response and were not reviewed."
+                ),
             ]
         )
     return "\n".join(lines)

--- a/.github/scripts/pi_pr_review.py
+++ b/.github/scripts/pi_pr_review.py
@@ -186,8 +186,7 @@ class PiClient:
                     env=minimal_environment(runtime_dir, self.api_key),
                     stdin=subprocess.DEVNULL,
                     text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    capture_output=True,
                     timeout=self.timeout,
                     check=False,
                 )

--- a/.github/scripts/tests/test_llm_pr_review.py
+++ b/.github/scripts/tests/test_llm_pr_review.py
@@ -201,7 +201,7 @@ class FakeResponse:
     def __init__(self, payload: object) -> None:
         self.body = json.dumps(payload).encode()
 
-    def __enter__(self) -> FakeResponse:
+    def __enter__(self) -> FakeResponse:  # noqa: PYI034 - keep Python 3.10 compatibility
         return self
 
     def __exit__(self, *_args: object) -> None:

--- a/.github/scripts/tests/test_llm_pr_review_workflow.py
+++ b/.github/scripts/tests/test_llm_pr_review_workflow.py
@@ -2,7 +2,6 @@ import re
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
@@ -53,8 +52,10 @@ class LlmPrReviewWorkflowTest(unittest.TestCase):
     def test_self_hosted_workflow_keeps_distinct_configuration(self):
         expected = (
             "name: Self-Hosted LLM PR Review",
-            "group: self-hosted-llm-pr-review-"
-            "${{ github.event.pull_request.number }}",
+            (
+                "group: self-hosted-llm-pr-review-"
+                "${{ github.event.pull_request.number }}"
+            ),
             "runs-on: [self-hosted, Linux, X64]",
             "environment: self-hosted-env",
             "LLM_REVIEW_ID: self-hosted-pi-pr-review",

--- a/.github/scripts/tests/test_pi_pr_review.py
+++ b/.github/scripts/tests/test_pi_pr_review.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 import tempfile
@@ -13,7 +12,6 @@ SCRIPT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPT_DIR))
 
 import pi_pr_review as pi_review
-
 
 # -- stub pi binary helpers ------------------------------------------------
 
@@ -298,14 +296,14 @@ class PiClientTest(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def _make_client(self, **overrides) -> pi_review.PiClient:
-        kwargs = dict(
-            pi_binary=str(self.bin_dir / "pi"),
-            base_url="https://api.example.com/v1/chat/completions",
-            api_key="test-api-key",
-            model="test-model",
-            repository_root=self.repository_root,
-            timeout=30,
-        )
+        kwargs = {
+            "pi_binary": str(self.bin_dir / "pi"),
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "api_key": "test-api-key",
+            "model": "test-model",
+            "repository_root": self.repository_root,
+            "timeout": 30,
+        }
         kwargs.update(overrides)
         return pi_review.PiClient(**kwargs)
 

--- a/.github/scripts/tests/test_pr_ci_workflow.py
+++ b/.github/scripts/tests/test_pr_ci_workflow.py
@@ -2,7 +2,6 @@ import re
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = ROOT / ".github" / "workflows" / "pr-ci.yml"
 


### PR DESCRIPTION
## 1. Why the change?

The Ruff cleanup in #27 was too broad to review as one pull request. This PR isolates the GitHub review tooling.

## 2. Summary of the change

- Resolve Ruff findings in the hosted and Pi review scripts.
- Keep subprocess and response-validation behavior unchanged.
- Clean the corresponding workflow contract tests.

## 3. Other details

This PR targets `main` independently from the other #27 replacements.

Verification:

- Targeted Ruff 0.16.0 check
- 96 GitHub script tests
