### PR TITLE
Fix Ruff issues in Harbor analysis

### DIFF
--- a/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
+++ b/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
@@ -14,7 +14,6 @@ from typing import Any
 from harbor_analyzer.io import load_json, stable_hash, utc_now, write_json_atomic
 from harbor_analyzer.runner import AnalyzerConfig, run_handover
 
-
 FOLLOW_MAX_BACKOFF_SECONDS = 300.0
 FOLLOW_MAX_FAILURE_ATTEMPTS = 3
 

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/io.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/io.py
@@ -30,7 +30,7 @@ def load_json(path: Path) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"Cannot read JSON file {path}: {exc}") from exc
     if not isinstance(payload, dict):
-        raise ValueError(f"Expected a JSON object in {path}")
+        raise TypeError(f"Expected a JSON object in {path}")
     return payload
 
 

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/io.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/io.py
@@ -30,7 +30,7 @@ def load_json(path: Path) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"Cannot read JSON file {path}: {exc}") from exc
     if not isinstance(payload, dict):
-        raise TypeError(f"Expected a JSON object in {path}")
+        raise ValueError(f"Expected a JSON object in {path}")  # noqa: TRY004 - compatibility contract
     return payload
 
 

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
@@ -16,7 +16,6 @@ from urllib.parse import urlparse
 
 from .io import canonical_json, write_text_atomic
 
-
 ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 PI_EXTENSION_PATH = Path(__file__).resolve().parent / "pi_extensions" / "analyzer_path_gate.ts"
 
@@ -216,9 +215,8 @@ def _final_output_block_reason(
         return f"pi_provider_request_failed:{_reason_code(provider_error)}", provider_error
     final_message = _final_assistant_message(events)
     stop_reason = str((final_message or {}).get("stopReason") or "")
-    if stop_reason:
-        if stop_reason == "length":
-            return "pi_final_message_truncated", None
+    if stop_reason == "length":
+        return "pi_final_message_truncated", None
     return None, None
 
 
@@ -530,11 +528,10 @@ def dispatch_to_child(
     if final_stop_reason:
         provenance["pi_final_stop_reason"] = final_stop_reason
     final_text = _final_assistant_text(events)
-    if not final_text:
-        if output_block_reason:
-            if provider_error:
-                provenance["pi_provider_final_error"] = provider_error
-            return DispatchResult(None, provenance, output_block_reason, stderr[-4000:])
+    if not final_text and output_block_reason:
+        if provider_error:
+            provenance["pi_provider_final_error"] = provider_error
+        return DispatchResult(None, provenance, output_block_reason, stderr[-4000:])
     report, extracted_from_text = _loads_final_json(final_text)
     if report is None:
         if output_block_reason:

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/prompt.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/prompt.py
@@ -6,7 +6,12 @@ import json
 from pathlib import Path
 
 from . import PROMPT_VERSION, TAXONOMY_VERSION
-from .taxonomy import FAILURE_STAGES, FINAL_CLASSES, SCOPES, UNMAPPED_ROOT_CAUSE_BY_CLASS
+from .taxonomy import (
+    FAILURE_STAGES,
+    FINAL_CLASSES,
+    SCOPES,
+    UNMAPPED_ROOT_CAUSE_BY_CLASS,
+)
 
 
 def _task_identity(task: dict) -> dict[str, object]:

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import fcntl
+import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -15,10 +15,13 @@ from . import PROMPT_VERSION, SCHEMA_VERSION, TAXONOMY_VERSION
 from .contract import validate_handover
 from .io import stable_hash, utc_now, write_json_atomic, write_text_atomic
 from .pi import dispatch_to_child
-from .prompt import build_dispatch_retry_prompt, build_task_prompt, build_validation_retry_prompt
+from .prompt import (
+    build_dispatch_retry_prompt,
+    build_task_prompt,
+    build_validation_retry_prompt,
+)
 from .taxonomy import ENV_INFRA_CLASSES, FINAL_CLASSES, UNKNOWN_ROOT_CAUSE
 from .validation import validate_final_json, validate_task_analysis
-
 
 AGENT_NAME = "harbor_analyzer_pi_subagent"
 MAX_TASK_ATTEMPTS = 2

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/validation.py
@@ -22,7 +22,6 @@ from .taxonomy import (
     expected_final_class_for_root_cause,
 )
 
-
 ROOT_CAUSE_CODE_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+){1,11}$")
 
 REQUIRED_TASK_REPORT_KEYS = {

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/artifacts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/artifacts.py
@@ -195,7 +195,7 @@ def read_result_json(result_path: str | None, base_dirs: list[Path]) -> tuple[bo
         return False, None, None, None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
         return False, None, None, None
 
     verifier = payload.get("verifier_result") if isinstance(payload, dict) else None
@@ -259,7 +259,7 @@ def load_state(state_path: Path) -> dict[str, Any]:
         return {"retry_count": 0, "history": [], "adaptive_S": None}
     try:
         return json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
         return {"retry_count": 0, "history": [], "adaptive_S": None}
 
 

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/artifacts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/artifacts.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+
 def to_float_value(raw: str | None) -> float | None:
     if raw is None:
         return None
@@ -194,7 +195,7 @@ def read_result_json(result_path: str | None, base_dirs: list[Path]) -> tuple[bo
         return False, None, None, None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         return False, None, None, None
 
     verifier = payload.get("verifier_result") if isinstance(payload, dict) else None
@@ -235,7 +236,7 @@ def read_int(path: Path, default: int | None = None) -> int | None:
         return default
     try:
         return int(path.read_text(encoding="utf-8").strip())
-    except Exception:
+    except (OSError, ValueError):
         return default
 
 
@@ -258,7 +259,7 @@ def load_state(state_path: Path) -> dict[str, Any]:
         return {"retry_count": 0, "history": [], "adaptive_S": None}
     try:
         return json.loads(state_path.read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         return {"retry_count": 0, "history": [], "adaptive_S": None}
 
 

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/classification.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/classification.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from .artifacts import TaskInput, read_result_json, to_float_value
 
+
 def classify_task_status(
     task: TaskInput,
     result_base_dirs: list[Path],
@@ -146,9 +147,8 @@ def classify_benchmark_status(
         return "blocked", "unknown_or_conflicting_fields"
     finished = finished_count
     finished_delta = finished_deltas[-1] if finished_deltas else 0
-    if finished_delta < 0:
-        # defensive: avoid unstable data
-        finished_delta = 0
+    # Defensive: avoid unstable data.
+    finished_delta = max(finished_delta, 0)
     unclaimed_remaining = remaining if remaining is not None else (total - claimed if claimed is not None else None)
     if unclaimed_remaining is not None:
         unclaimed_remaining = max(0, unclaimed_remaining)

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/contracts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/contracts.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from .classification import SIGNAL_DEFINITIONS
 
-
 RUNTIME_EVIDENCE_KEYS = {
     "elapsed_since_run_start",
     "blocked_duration",

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/evaluator.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/evaluator.py
@@ -73,7 +73,6 @@ def evaluate_once(
     unfinished = max(0, total - finished) if total is not None else None
     previous = state.get("history", [])
     history: list[dict[str, Any]] = [item for item in previous if isinstance(item, dict)]
-    initial_history_empty = not history
 
     prev_sample = history[-1] if history else None
     prev_finished = prev_sample.get("finished") if prev_sample else None

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
@@ -281,6 +281,7 @@ def run_loop(
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,
                             timeout=120,
+                            check=False,
                         )
                         if result.returncode == 0:
                             control_ts = now_ts()
@@ -326,7 +327,7 @@ def run_loop(
                             "control_attempted": True,
                             "external_control_performed": True,
                         }
-                    except Exception as exc:
+                    except Exception as exc:  # noqa: BLE001 - control boundary reports failures
                         output["action"] = {
                             "type": "notify",
                             "retry_count": state["retry_count"],
@@ -359,6 +360,7 @@ def run_loop(
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,
                             timeout=120,
+                            check=False,
                         )
                         output["action"] = {
                             "type": "stop" if result.returncode == 0 else "notify",
@@ -380,7 +382,7 @@ def run_loop(
                             "control_attempted": True,
                             "external_control_performed": True,
                         }
-                    except Exception as exc:
+                    except Exception as exc:  # noqa: BLE001 - control boundary reports failures
                         output["action"] = {
                             "type": "notify",
                             "retry_count": state.get("retry_count", 0),

--- a/Agents/utils/common/Harbor/scripts/online_rule_analyzer.py
+++ b/Agents/utils/common/Harbor/scripts/online_rule_analyzer.py
@@ -26,23 +26,23 @@ TASK_BLOCKING_ALLOWLIST = {
     ("agent_setup", "agent_configuration", "auth_token_missing"),
 }
 RAW_RULES = (
-    (re.compile(r"Docker Hub preflight failed|cannot reach https://(?:auth|registry-1)\.docker\.io", re.I), "harbor_console_compat", "docker-registry-preflight-degraded", "docker_registry", "warning"),
+    (re.compile(r"Docker Hub preflight failed|cannot reach https://(?:auth|registry-1)\.docker\.io", re.IGNORECASE), "harbor_console_compat", "docker-registry-preflight-degraded", "docker_registry", "warning"),
     (re.compile(r"NonZeroAgentExitCodeError"), "agent_runtime", "agent-process-exit-abnormal", "agent", "warning"),
     (re.compile(r"AgentTimeoutError"), "agent_runtime", "agent-timeout", "agent", "warning"),
 )
 SETA_JOB_LOG_RULES = (
-    (re.compile(r"E: Could not open lock file /var/lib/apt/lists/lock - open \(13: Permission denied\)", re.I), "agent_setup", "apt", "apt-lock-permission-denied"),
-    (re.compile(r"E: Unable to lock directory /var/lib/apt/lists/", re.I), "agent_setup", "apt", "apt-lock-directory-denied"),
-    (re.compile(r"The following packages have unmet dependencies", re.I), "agent_setup", "apt", "apt-unmet-dependencies"),
-    (re.compile(r"Unable to correct problems, you have held broken packages", re.I), "agent_setup", "apt", "apt-held-broken-packages"),
-    (re.compile(r"curl\s*:\s*Depends:\s*libcurl4t64", re.I), "agent_setup", "apt", "apt-curl-libcurl-mismatch"),
-    (re.compile(r"E: Unable to locate package (?:nodejs|npm|curl)\b", re.I), "agent_setup", "apt", "apt-setup-package-unavailable"),
-    (re.compile(r"Docker compose command failed for environment\b", re.I), "environment_build", "docker", "docker-compose-env-failed"),
-    (re.compile(r"failed to solve: process .+ did not complete successfully", re.I), "environment_build", "docker", "docker-build-step-failed"),
-    (re.compile(r"Error response from daemon: invalid reference format", re.I), "environment_setup", "docker", "docker-daemon-invalid-reference"),
-    (re.compile(r"no space left on device", re.I), "environment_setup", "storage", "storage-no-space-left"),
+    (re.compile(r"E: Could not open lock file /var/lib/apt/lists/lock - open \(13: Permission denied\)", re.IGNORECASE), "agent_setup", "apt", "apt-lock-permission-denied"),
+    (re.compile(r"E: Unable to lock directory /var/lib/apt/lists/", re.IGNORECASE), "agent_setup", "apt", "apt-lock-directory-denied"),
+    (re.compile(r"The following packages have unmet dependencies", re.IGNORECASE), "agent_setup", "apt", "apt-unmet-dependencies"),
+    (re.compile(r"Unable to correct problems, you have held broken packages", re.IGNORECASE), "agent_setup", "apt", "apt-held-broken-packages"),
+    (re.compile(r"curl\s*:\s*Depends:\s*libcurl4t64", re.IGNORECASE), "agent_setup", "apt", "apt-curl-libcurl-mismatch"),
+    (re.compile(r"E: Unable to locate package (?:nodejs|npm|curl)\b", re.IGNORECASE), "agent_setup", "apt", "apt-setup-package-unavailable"),
+    (re.compile(r"Docker compose command failed for environment\b", re.IGNORECASE), "environment_build", "docker", "docker-compose-env-failed"),
+    (re.compile(r"failed to solve: process .+ did not complete successfully", re.IGNORECASE), "environment_build", "docker", "docker-build-step-failed"),
+    (re.compile(r"Error response from daemon: invalid reference format", re.IGNORECASE), "environment_setup", "docker", "docker-daemon-invalid-reference"),
+    (re.compile(r"no space left on device", re.IGNORECASE), "environment_setup", "storage", "storage-no-space-left"),
 )
-IGNORED_RAW = (re.compile(r"No module named ['\"]botocore['\"]", re.I),)
+IGNORED_RAW = (re.compile(r"No module named ['\"]botocore['\"]", re.IGNORECASE),)
 
 
 def utc_now() -> str:

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -18,6 +18,7 @@ if str(SCRIPT_DIR) not in sys.path:
 from Agents.utils.common.Harbor.scripts.analyzer_subagent import (
     FOLLOW_MAX_FAILURE_ATTEMPTS,
     _default_model,
+    _load_follow_state,
     _pending_handovers,
     _record_follow_failure,
 )
@@ -269,6 +270,30 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
                 ["attempt-1", "attempt-2"],
             )
             self.assertEqual(len({item[2] for item in pending}), 2)
+
+    def test_follow_state_recovers_from_non_object_json(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state_path = Path(root) / ".analyzer_state.json"
+            state_path.write_text("[]", encoding="utf-8")
+
+            self.assertEqual(_load_follow_state(state_path), (set(), {}))
+
+    def test_pending_handovers_skip_non_object_json(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            handoff_dir = Path(root) / "handoffs"
+            handoff_dir.mkdir()
+            (handoff_dir / "1.json").write_text("[]", encoding="utf-8")
+
+            self.assertEqual(
+                _pending_handovers(
+                    latest_path=Path(root) / "latest.json",
+                    handoff_dir=handoff_dir,
+                    processed=set(),
+                    failed={},
+                    now=0.0,
+                ),
+                [],
+            )
 
     def test_pending_handovers_stop_after_follow_failure_limit(self) -> None:
         with tempfile.TemporaryDirectory() as root:

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests for Harbor analyzer runtime artifact and handover helpers."""
 
 from __future__ import annotations
@@ -23,6 +22,10 @@ from Agents.utils.common.Harbor.scripts.analyzer_subagent import (
     _record_follow_failure,
 )
 from Agents.utils.common.Harbor.scripts.harbor_analyzer import runner as analyzer_runner
+from Agents.utils.common.Harbor.scripts.harbor_analyzer.pi import (
+    _models_config,
+    dispatch_to_child,
+)
 from Agents.utils.common.Harbor.scripts.harbor_analyzer.runner import (
     AnalyzerConfig,
     _task_allowed_paths,
@@ -30,9 +33,9 @@ from Agents.utils.common.Harbor.scripts.harbor_analyzer.runner import (
     _write_outputs,
     run_handover,
 )
-from Agents.utils.common.Harbor.scripts.harbor_analyzer.pi import _models_config, dispatch_to_child
-from Agents.utils.common.Harbor.scripts.harbor_monitor.contracts import build_analyzer_handover
-
+from Agents.utils.common.Harbor.scripts.harbor_monitor.contracts import (
+    build_analyzer_handover,
+)
 
 HANDOVER_ID = "sha256-" + ("b" * 64)
 RUN_ID = "run-1"

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_validation.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_validation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests for Harbor analyzer contract and validation helpers."""
 
 from __future__ import annotations
@@ -9,12 +8,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from Agents.utils.common.Harbor.scripts.harbor_analyzer.contract import validate_handover
+from Agents.utils.common.Harbor.scripts.harbor_analyzer.contract import (
+    validate_handover,
+)
 from Agents.utils.common.Harbor.scripts.harbor_analyzer.validation import (
     validate_final_json,
     validate_task_analysis,
 )
-
 
 HANDOVER_ID = "sha256-" + ("a" * 64)
 RUN_ID = "run-1"

--- a/Agents/utils/common/Harbor/tests/test_harbor_monitor_artifacts.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_monitor_artifacts.py
@@ -1,0 +1,38 @@
+"""Tests for Harbor monitor artifact resilience."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from Agents.utils.common.Harbor.scripts.harbor_monitor.artifacts import (
+    load_state,
+    read_result_json,
+)
+
+
+class HarborMonitorArtifactsTest(unittest.TestCase):
+    def test_read_result_json_ignores_invalid_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            result_path = Path(root) / "result.json"
+            result_path.write_bytes(b"\xff")
+
+            self.assertEqual(
+                read_result_json(str(result_path), []),
+                (False, None, None, None),
+            )
+
+    def test_load_state_resets_invalid_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            state_path = Path(root) / "state.json"
+            state_path.write_bytes(b"\xff")
+
+            self.assertEqual(
+                load_state(state_path),
+                {"retry_count": 0, "history": [], "adaptive_S": None},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_online_rule_analyzer.py
+++ b/Agents/utils/common/Harbor/tests/test_online_rule_analyzer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests for Harbor console online analysis summaries."""
 
 from __future__ import annotations
@@ -11,7 +10,6 @@ import unittest
 from argparse import Namespace
 from pathlib import Path
 from unittest import mock
-
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "online_rule_analyzer.py"
 SPEC = importlib.util.spec_from_file_location("online_rule_analyzer", SCRIPT)
@@ -29,9 +27,11 @@ class OnlineRuleAnalyzerTest(unittest.TestCase):
             console.write_text(
                 "\n".join(
                     [
-                        '[ONLINE_ENV] {"schema":1,"task_id":null,"phase":"preflight",'
-                        '"component":"docker","event":"daemon_unavailable","severity":"critical",'
-                        '"fatal":true,"scope":"task","message":"docker info failed"}',
+                        (
+                            '[ONLINE_ENV] {"schema":1,"task_id":null,"phase":"preflight",'
+                            '"component":"docker","event":"daemon_unavailable","severity":"critical",'
+                            '"fatal":true,"scope":"task","message":"docker info failed"}'
+                        ),
                         "AgentTimeoutError",
                         "NonZeroAgentExitCodeError",
                     ]


### PR DESCRIPTION
## 1. Why the change?

The Ruff cleanup in #27 was too broad to review as one pull request. This PR isolates Harbor analyzer and monitor code.

## 2. Summary of the change

- Resolve Ruff findings in Harbor analyzer validation, prompting, and execution.
- Clean Harbor monitor classification, evaluation, and artifact handling.
- Preserve broad exception handling only at documented task and HTTP boundaries.

## 3. Other details

This PR targets `main` independently from the other #27 replacements.

Verification:

- Targeted Ruff 0.16.0 check
- 37 shared Harbor tests
