### PR TITLE
Fix Ruff issues in benchmark tasks

### DIFF
--- a/Tasks/Pinchbench/scripts/run-parallel-workers.py
+++ b/Tasks/Pinchbench/scripts/run-parallel-workers.py
@@ -9,9 +9,9 @@ import os
 import shlex
 import subprocess
 import sys
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Callable
 from urllib.parse import urlsplit, urlunsplit
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -525,10 +525,20 @@ def validate(args: argparse.Namespace, config: dict[str, str]) -> None:
 def apply_patch(pinchbench_dir: Path, patch_file: Path) -> None:
     git = ["git", "-C", str(pinchbench_dir)]
     # Accept both a clean checkout and one where the target patch is already present.
-    if subprocess.run(git + ["apply", "--check", str(patch_file)], capture_output=True).returncode == 0:
+    forward_check = subprocess.run(
+        git + ["apply", "--check", str(patch_file)],
+        capture_output=True,
+        check=False,
+    )
+    if forward_check.returncode == 0:
         subprocess.run(git + ["apply", str(patch_file)], check=True)
         return
-    if subprocess.run(git + ["apply", "-R", "--check", str(patch_file)], capture_output=True).returncode == 0:
+    reverse_check = subprocess.run(
+        git + ["apply", "-R", "--check", str(patch_file)],
+        capture_output=True,
+        check=False,
+    )
+    if reverse_check.returncode == 0:
         return  # patch already applied
     sys.exit(f"Error: failed to apply patch {patch_file} to {pinchbench_dir}")
 
@@ -934,7 +944,7 @@ def summarize_iteration(
     runtime_failed = len(failed_tasks)
     runtime_skipped = len(skipped_web_search_disabled)
     runtime_succeeded = total - runtime_failed - runtime_skipped
-    finished_at = datetime.now()
+    finished_at = datetime.now()  # noqa: DTZ005 - preserve naive persisted timestamps
     return {
         "iteration": iteration,
         "started_at": started_at.isoformat(),
@@ -986,7 +996,7 @@ def write_iterations_summary_files(run_root_dir: Path, iteration_summaries: list
     iterations_summary_json.write_text(
         json.dumps(
             {
-                "generated_at": datetime.now().isoformat(),
+                "generated_at": datetime.now().isoformat(),  # noqa: DTZ005
                 "iterations": iteration_summaries,
             },
             indent=2,
@@ -1061,6 +1071,7 @@ def main() -> None:
     image_missing = subprocess.run(
         ["docker", "image", "inspect", config["PINCHBENCH_DOCKER_IMAGE"]],
         capture_output=True,
+        check=False,
     ).returncode != 0
     force_build = config_bool(config.get("PINCHBENCH_FORCE_BUILD"), False)
     image_unusable = False
@@ -1071,6 +1082,7 @@ def main() -> None:
                 tracing_enabled=tracing_enabled,
             ),
             capture_output=True,
+            check=False,
         ).returncode != 0
 
     if force_build or image_missing or image_unusable:
@@ -1081,7 +1093,9 @@ def main() -> None:
 
     output_dir = Path(config["PINCHBENCH_OUTPUT_DIR"])
     output_dir.mkdir(parents=True, exist_ok=True)
-    run_root_dir = output_dir / datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_root_dir = output_dir / datetime.now().strftime(  # noqa: DTZ005
+        "%Y%m%d-%H%M%S"
+    )
     run_root_dir.mkdir()
 
     suite_name = "core" if args.core else args.suite
@@ -1111,7 +1125,7 @@ def main() -> None:
     had_failures = False
 
     for iteration in range(1, args.iterations + 1):
-        iteration_started_at = datetime.now()
+        iteration_started_at = datetime.now()  # noqa: DTZ005
         run_dir = run_root_dir / f"iteration-{iteration:03d}"
         run_dir.mkdir(parents=True, exist_ok=True)
 

--- a/Tasks/Pinchbench/scripts/summary.py
+++ b/Tasks/Pinchbench/scripts/summary.py
@@ -78,7 +78,7 @@ def main() -> None:
     print(f"Execution time (s): {format_float(efficiency.get('total_execution_time_seconds'), 2)}")
     print(f"Score / 1K tokens: {format_float(efficiency.get('score_per_1k_tokens'), 6)}")
     print(f"Score / dollar: {format_float(efficiency.get('score_per_dollar'), 4)}")
-    print("")
+    print()
     print("Per-task:")
     print("task_id\tstatus\tscore\ttokens\tcost_usd")
     for task in tasks[: args.top]:

--- a/Tasks/Pinchbench/tests/test_run_parallel_workers.py
+++ b/Tasks/Pinchbench/tests/test_run_parallel_workers.py
@@ -1,9 +1,9 @@
 import importlib.util
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest import mock
-
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "run-parallel-workers.py"
@@ -503,6 +503,29 @@ class BenchmarkCommandTests(unittest.TestCase):
         self.assertEqual(summary["success_count"], 1)
         self.assertEqual(summary["failure_count"], 0)
         self.assertEqual(summary["skipped_web_search_disabled_count"], 1)
+
+    def test_summarize_iteration_preserves_naive_timestamp_format(self):
+        timestamp = datetime(  # noqa: DTZ001 - verifies legacy naive output contract
+            2026, 7, 25, 12, 34, 56
+        )
+        with mock.patch.object(self.runner, "datetime") as datetime_type:
+            datetime_type.now.return_value = timestamp
+            summary = self.runner.summarize_iteration(
+                iteration=1,
+                merged={"tasks": []},
+                run_dir=Path("/tmp"),
+                started_at=timestamp,
+                completion={
+                    "ok": True,
+                    "expected_count": 0,
+                    "actual_count": 0,
+                    "missing_task_ids": [],
+                    "non_terminal_task_ids": [],
+                },
+            )
+
+        self.assertEqual(summary["started_at"], "2026-07-25T12:34:56")
+        self.assertEqual(summary["finished_at"], "2026-07-25T12:34:56")
 
 
 if __name__ == "__main__":

--- a/Tasks/Pinchbench/tests/test_worker_mounts.py
+++ b/Tasks/Pinchbench/tests/test_worker_mounts.py
@@ -2,7 +2,6 @@ import importlib.util
 import unittest
 from pathlib import Path
 
-
 MODULE_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "run-parallel-workers.py"
 )

--- a/Tasks/clawBio/scripts/run-benchmark.py
+++ b/Tasks/clawBio/scripts/run-benchmark.py
@@ -311,7 +311,7 @@ def ensure_prerequisites(instances: list[Instance], requested: int) -> list[Inst
 def recover_failed_instances(
     instances: list[Instance],
     failed_container_names: set[str],
-    run_logger: "RunLogger",
+    run_logger: RunLogger,
     *,
     health_timeout_seconds: int = 120,
 ) -> None:
@@ -378,7 +378,7 @@ class RunLogger:
         self.path.write_text("", encoding="utf-8")
 
     def log(self, message: str) -> None:
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        timestamp = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
         line = f"[{timestamp}] {message}"
         with self._lock:
             print(line, flush=True)
@@ -445,8 +445,7 @@ def make_path_removable(root: Path) -> None:
     proc = subprocess.run(
         [chmod, "-R", "a+rwX", str(root)],
         check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     if proc.returncode == 0:
@@ -457,8 +456,7 @@ def make_path_removable(root: Path) -> None:
         subprocess.run(
             [sudo, "-n", chmod, "-R", "a+rwX", str(root)],
             check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
 
@@ -594,7 +592,7 @@ def _extract_expected_scripts(skill_name: str) -> list[str]:
 
 
 def _copy_session_jsonl(
-    container: str, session_id: str, dest: Path, run_logger: "RunLogger | None" = None
+    container: str, session_id: str, dest: Path, run_logger: RunLogger | None = None
 ) -> Path | None:
     """Copy the session JSONL file from a container to dest.
 
@@ -773,7 +771,7 @@ def run_task(
 
         agent_finished = True
 
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - task boundary records arbitrary failures
         status = "failed"
         if not failure_stage:
             failure_stage = "task"
@@ -1275,7 +1273,7 @@ def main() -> None:
         run_root_dir.mkdir(exist_ok=True)
         # Caller (shell script) manages 'latest' symlink when --run-id is used.
     else:
-        run_root_dir = output_dir / datetime.now().strftime("%Y%m%d-%H%M%S")
+        run_root_dir = output_dir / datetime.now().astimezone().strftime("%Y%m%d-%H%M%S")
         run_root_dir.mkdir()
         ensure_latest_link(output_dir, run_root_dir)
 

--- a/Tasks/clawBio/tests/test_run_benchmark.py
+++ b/Tasks/clawBio/tests/test_run_benchmark.py
@@ -6,7 +6,6 @@ import unittest
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "run-benchmark.py"
 SPEC = importlib.util.spec_from_file_location("clawbio_run_benchmark", MODULE_PATH)
 run_benchmark = importlib.util.module_from_spec(SPEC)
@@ -53,14 +52,12 @@ class ClawBioRunnerTest(unittest.TestCase):
             self.assertFalse(outputs.exists())
 
     def test_clear_artifact_paths_rejects_escape(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(ValueError):
-                run_benchmark.clear_artifact_paths(Path(tmp), ["../outside"])
+        with tempfile.TemporaryDirectory() as tmp, self.assertRaises(ValueError):
+            run_benchmark.clear_artifact_paths(Path(tmp), ["../outside"])
 
     def test_clear_artifact_paths_rejects_workspace_root(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(ValueError):
-                run_benchmark.clear_artifact_paths(Path(tmp), ["."])
+        with tempfile.TemporaryDirectory() as tmp, self.assertRaises(ValueError):
+            run_benchmark.clear_artifact_paths(Path(tmp), ["."])
 
     def test_task_session_id_is_stable_across_worker_assignment(self) -> None:
         started_at = datetime(2026, 5, 6, 3, 4, 5, 123456, tzinfo=timezone.utc)


### PR DESCRIPTION
## 1. Why the change?

The Ruff cleanup in #27 was too broad to review as one pull request. This PR isolates PinchBench and ClawBio.

## 2. Summary of the change

- Resolve Ruff findings in PinchBench worker execution and summaries.
- Preserve PinchBench's timezone-naive persisted timestamp format.
- Resolve Ruff findings in the ClawBio runner and tests.

## 3. Other details

This PR targets `main` independently from the other #27 replacements.

Verification:

- Targeted Ruff 0.16.0 check
- 28 PinchBench tests
- 5 ClawBio tests (1 Linux-specific test skipped on macOS)
