### PR TITLE
Add Ruff lint workflow

### DIFF
--- a/.github/scripts/tests/test_ruff_workflow.py
+++ b/.github/scripts/tests/test_ruff_workflow.py
@@ -34,10 +34,12 @@ class RuffWorkflowContractTest(unittest.TestCase):
             "278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0",
             self.workflow,
         )
-        self.assertEqual(
-            len(re.findall(r"uses: [^\s@]+@[0-9a-f]{40}", self.workflow)),
-            2,
+        action_refs = re.findall(r"uses:\s+([^\s#]+)", self.workflow)
+        pinned_action_refs = re.findall(
+            r"uses:\s+([^\s@]+@[0-9a-f]{40})(?=\s|$)",
+            self.workflow,
         )
+        self.assertEqual(action_refs, pinned_action_refs)
         self.assertIn("persist-credentials: false", self.workflow)
 
     def test_runs_only_pinned_ruff_lint_with_the_repository_config(self):

--- a/.github/scripts/tests/test_ruff_workflow.py
+++ b/.github/scripts/tests/test_ruff_workflow.py
@@ -1,0 +1,54 @@
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "ruff.yml"
+
+
+class RuffWorkflowContractTest(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(WORKFLOW.is_file(), f"missing workflow: {WORKFLOW}")
+        self.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_runs_for_pull_requests_and_main_pushes(self):
+        self.assertIn(
+            '"on":\n  pull_request:\n  push:\n    branches: [main]',
+            self.workflow,
+        )
+        self.assertNotIn("pull_request_target", self.workflow)
+
+    def test_uses_a_hosted_runner_with_least_privilege(self):
+        self.assertIn("permissions:\n  contents: read", self.workflow)
+        self.assertIn("runs-on: ubuntu-latest", self.workflow)
+        self.assertNotIn("secrets.", self.workflow)
+
+    def test_pins_checkout_and_ruff_actions(self):
+        self.assertIn(
+            "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            " # v7.0.1",
+            self.workflow,
+        )
+        self.assertIn(
+            "uses: astral-sh/ruff-action@"
+            "278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0",
+            self.workflow,
+        )
+        self.assertEqual(
+            len(re.findall(r"uses: [^\s@]+@[0-9a-f]{40}", self.workflow)),
+            2,
+        )
+        self.assertIn("persist-credentials: false", self.workflow)
+
+    def test_runs_only_pinned_ruff_lint_with_the_repository_config(self):
+        self.assertIn('version: "0.16.0"', self.workflow)
+        self.assertIn(
+            'args: "check --config .github/ruff.toml"',
+            self.workflow,
+        )
+        self.assertNotIn("--fix", self.workflow)
+        self.assertNotIn("format", self.workflow.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,27 @@
+name: Ruff
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Ruff lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run Ruff
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.16.0"
+          args: "check --config .github/ruff.toml"


### PR DESCRIPTION
## 1. Why the change?

The repository is adopting Ruff 0.16.0 through cleanup PRs #28 through #34, but it does not yet enforce that lint baseline in GitHub Actions.

## 2. Summary of the change

- Add a dedicated GitHub-hosted Ruff workflow for pull requests and pushes to `main`.
- Run lint only with Ruff 0.16.0 and `.github/ruff.toml`.
- Pin `actions/checkout` and `astral-sh/ruff-action` to full commit SHAs.
- Add contract tests for triggers, permissions, runner selection, action pins, Ruff version, and lint-only arguments.

## 3. Other details

This draft depends on #28 through #34. Until those cleanup PRs merge, the full-repository Ruff job is expected to fail because `main` does not yet contain `.github/ruff.toml` or the complete lint cleanup.

Verification:

- `python3 -m unittest discover -s .github/scripts/tests -v` — 100 tests passed.
- `docker run --rm --volume "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color .github/workflows/ruff.yml`
- `uvx ruff@0.16.0 check --config .github/ruff.toml .` — passed against an assembled tree containing #28 through #34 and this PR.
- `git diff --check`
