### PR TITLE
fix(opencode): stop faking git for non-repository tasks

### DIFF
--- a/Agents/Harbor-opencode/opik_opencode_harbor.py
+++ b/Agents/Harbor-opencode/opik_opencode_harbor.py
@@ -536,7 +536,6 @@ class OpikOpenCodeHarbor(OpenCode):
                 if key in env:
                     env[key] = _rewrite_container_opik_url(env[key])
 
-        env["OPENCODE_FAKE_VCS"] = "git"
         if trace_enabled:
             # Harbor only downloads EnvironmentPaths.agent_dir after timeout.
             # Keep the hook runtime backup there so the outer worker can replay

--- a/Agents/Harbor-opencode/tests/test_trace_disabled.py
+++ b/Agents/Harbor-opencode/tests/test_trace_disabled.py
@@ -179,6 +179,10 @@ class OpenCodeTraceDisabledTests(unittest.TestCase):
             "OC_OPIK_LOGS_DIR",
             agent.agent_commands[-1].get("env", {}),
         )
+        self.assertNotIn(
+            "OPENCODE_FAKE_VCS",
+            agent.agent_commands[-1].get("env", {}),
+        )
 
     def test_run_trace_on_keeps_plugin_registration_and_finalizer(self) -> None:
         agent = self.make_agent("true")


### PR DESCRIPTION
## 1. Why the change?

Harbor's OpenCode adapter forced `OPENCODE_FAKE_VCS=git` for every task. On
non-repository task images, OpenCode consequently treated `/` as a Git
worktree and snapshotted the entire container with `git add --all`. Under the
task's 1 GiB memory limit, the second snapshot pass was OOM-killed after the
tool had already completed, so successful tasks exited 137 and triggered
unnecessary Harbor retries.

Fixes #36.

## 2. Summary of the change

- Stop injecting OpenCode's testing-only fake-VCS flag.
- Add a regression assertion that the adapter does not restore the flag.

OpenCode still detects real Git repositories normally, so repository-scoped
snapshot and undo behavior remains available.

## 3. Other details

Validation:

- `python3 -m unittest discover -s Agents/Harbor-opencode/tests -p 'test_*.py'`
  (9 tests passed)
- OpenCode 1.18.5 baseline, 1 GiB, zero retries: 4m47s, Docker `container oom`,
  exit 137, reward 1, one `NonZeroAgentExitCodeError`
- Same run with this change: 34s, reward 1, zero exceptions, two
  `step_finish` events, no snapshot hash, and no Docker OOM event

A trace-enabled live run was blocked before task startup by a TLS EOF from the
remote Opik health endpoint. The trace-enabled adapter path remains covered by
the unit suite.
