### PR TITLE
Add OpenClaw task selection to FleetSpec runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ for the full format.
 | Flag | Short | Purpose |
 | --- | --- | --- |
 | `--taskset` | `-t` | Taskset to run ([available tasksets](./scripts/README.md#fleet-launch-modes)) |
-| `--task` | — | Exact task name(s) for supported Harbor tasksets, comma-separated or repeated |
+| `--task` | — | Exact task name(s), comma-separated or repeated |
 | `--agent` | `-a` | `claude-code`, `opencode`, or `openclaw` |
 | `--workers` | `-n` | Concurrency |
 | `--prompt` | `-p` | Natural-language run request (AI mode) |

--- a/Tasks/Pinchbench/README.md
+++ b/Tasks/Pinchbench/README.md
@@ -212,10 +212,14 @@ The runner reads defaults from [`config/pinchbench.env`](./config/pinchbench.env
 ./Tasks/Pinchbench/scripts/run-parallel-workers.py [options]
 
   --instances N   Number of OpenClaw instances/workers (default: COUNT from config/fleet.env)
-  --suite SUITE   Task suite: all, automated-only, core, a manifest category, category+category, or comma-separated task IDs
+  --suite SUITE   Task suite: all, automated-only, core, a manifest category, category+category, or comma-separated exact task IDs
   --core          Run the manifest-defined core task subset
   -n, --iterations N  Number of benchmark iterations (default: 1)
 ```
+
+FleetSpec/`run_fleet.sh` exact selections are checked against the pinned
+checkout before the worker image is built or a result directory is created.
+Any unknown IDs fail together.
 
 ## Output
 

--- a/Tasks/Pinchbench/scripts/run-parallel-workers.py
+++ b/Tasks/Pinchbench/scripts/run-parallel-workers.py
@@ -483,6 +483,11 @@ def parse_args(config: dict[str, str]) -> argparse.Namespace:
         metavar="N",
         help="Number of benchmark iterations to run (default: 1).",
     )
+    parser.add_argument(
+        "--validate-tasks-only",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     return parser.parse_args()
 
 
@@ -558,19 +563,25 @@ def ensure_clean_checkout(pinchbench_dir: Path) -> None:
         )
 
 
+def ensure_checkout_repository(pinchbench_dir: Path, repo_url: str) -> bool:
+    """Ensure the checkout's Git repository exists; return whether it was created."""
+    if (pinchbench_dir / ".git").exists():
+        return False
+    pinchbench_dir.parent.mkdir(parents=True, exist_ok=True)
+    if pinchbench_dir.exists():
+        sys.exit(f"Error: {pinchbench_dir} exists but is not a pinchbench git checkout.")
+    subprocess.run(["git", "init", str(pinchbench_dir)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(pinchbench_dir), "remote", "add", "origin", repo_url],
+        check=True,
+        capture_output=True,
+    )
+    return True
+
+
 def prepare_checkout(pinchbench_dir: Path, repo_url: str, ref: str, patches_dir: Path) -> None:
     """Clone or update the patched PinchBench checkout before worker containers start."""
-    created_checkout = False
-    if not (pinchbench_dir / ".git").exists():
-        pinchbench_dir.parent.mkdir(parents=True, exist_ok=True)
-        if pinchbench_dir.exists():
-            sys.exit(f"Error: {pinchbench_dir} exists but is not a pinchbench git checkout.")
-        subprocess.run(["git", "init", str(pinchbench_dir)], check=True, capture_output=True)
-        subprocess.run(
-            ["git", "-C", str(pinchbench_dir), "remote", "add", "origin", repo_url],
-            check=True, capture_output=True,
-        )
-        created_checkout = True
+    created_checkout = ensure_checkout_repository(pinchbench_dir, repo_url)
 
     git = ["git", "-C", str(pinchbench_dir)]
     if not created_checkout:
@@ -583,6 +594,31 @@ def prepare_checkout(pinchbench_dir: Path, repo_url: str, ref: str, patches_dir:
     if patches_dir.is_dir():
         for patch_file in sorted(patches_dir.glob("*.patch")):
             apply_patch(pinchbench_dir, patch_file)
+
+
+def load_pinned_task_ids(pinchbench_dir: Path, repo_url: str, ref: str) -> set[str]:
+    """Read exact task IDs from the pinned ref without changing the worktree."""
+    ensure_checkout_repository(pinchbench_dir, repo_url)
+
+    git = ["git", "-C", str(pinchbench_dir)]
+    subprocess.run(git + ["fetch", "--depth", "1", "origin", ref], check=True)
+    tree = subprocess.run(
+        git + ["ls-tree", "-r", "--name-only", "FETCH_HEAD", "--", "tasks"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    available: set[str] = set()
+    for name in tree.stdout.splitlines():
+        if not name.startswith("tasks/"):
+            continue
+        relative = name.removeprefix("tasks/")
+        if "/" in relative or not relative.startswith("task_") or not relative.endswith(".md"):
+            continue
+        task_id = relative.removesuffix(".md")
+        if task_id != "task_XX_name":
+            available.add(task_id)
+    return available
 
 
 def _manifest_item(line: str) -> str:
@@ -673,9 +709,39 @@ def _task_grading_type(task_path: Path) -> str:
     return "automated"
 
 
-def expand_suite(pinchbench_dir: Path, suite: str) -> list[str]:
-    """Expand a suite name or comma-separated task list into sorted task IDs."""
+def _validate_exact_task_ids(value: str, available: set[str]) -> list[str]:
+    requested = list(
+        dict.fromkeys(part.strip() for part in value.split(",") if part.strip())
+    )
+    if not requested:
+        sys.exit("Error: exact PinchBench selection must contain at least one task ID.")
+
+    missing = [task_id for task_id in requested if task_id not in available]
+    if missing:
+        sys.exit("Error: unknown PinchBench task(s): " + ", ".join(missing))
+    return requested
+
+
+def _expand_exact_task_ids(tasks_root: Path, value: str) -> list[str]:
+    available = {
+        path.stem
+        for path in tasks_root.glob("task_*.md")
+        if path.is_file() and path.stem != "task_XX_name"
+    }
+    return _validate_exact_task_ids(value, available)
+
+
+def expand_suite(
+    pinchbench_dir: Path,
+    suite: str,
+    *,
+    exact_task_ids: bool = False,
+) -> list[str]:
+    """Expand a suite or validate a comma-separated exact task selection."""
     tasks_root = pinchbench_dir / "tasks"
+    if exact_task_ids:
+        return _expand_exact_task_ids(tasks_root, suite)
+
     manifest = _load_task_manifest(tasks_root)
 
     if suite == "all":
@@ -1053,20 +1119,47 @@ def worker_image_build_command(config: dict[str, str], *, tracing_enabled: bool)
 def main() -> None:
     config = load_runner_config()
     args = parse_args(config)
-    validate(args, config)
     tracing_enabled = trace_to_opik_enabled(config.get("TRACE_TO_OPIK"))
+    exact_task_ids = os.environ.get("PINCHBENCH_EXACT_TASK_SELECTION") == "1"
 
     pinchbench_dir = Path(config["PINCHBENCH_DIR"])
     patches_dir = BENCH_DIR / "patches"
     repo_url = config["PINCHBENCH_REPO_URL"]
     config_base = Path(config["CONFIG_BASE"])
     workspace_base = Path(config["WORKSPACE_BASE"])
-    Path(config["PINCHBENCH_UV_CACHE_DIR"]).mkdir(parents=True, exist_ok=True)
 
-    if not tracing_enabled:
-        validate_trace_off_gateway_configs(config_base, args.instances)
+    if args.validate_tasks_only:
+        available = load_pinned_task_ids(
+            pinchbench_dir,
+            repo_url,
+            config["PINCHBENCH_REF"],
+        )
+        _validate_exact_task_ids(args.suite, available)
+        return
+
+    validate_before_checkout = not exact_task_ids
+    if validate_before_checkout:
+        validate(args, config)
+        Path(config["PINCHBENCH_UV_CACHE_DIR"]).mkdir(parents=True, exist_ok=True)
+        if not tracing_enabled:
+            validate_trace_off_gateway_configs(config_base, args.instances)
 
     prepare_checkout(pinchbench_dir, repo_url, config["PINCHBENCH_REF"], patches_dir)
+
+    suite_name = "core" if args.core else args.suite
+    task_ids = expand_suite(
+        pinchbench_dir,
+        suite_name,
+        exact_task_ids=exact_task_ids,
+    )
+    if not task_ids:
+        sys.exit(f"Error: no tasks selected for suite '{suite_name}'.")
+
+    if not validate_before_checkout:
+        validate(args, config)
+        Path(config["PINCHBENCH_UV_CACHE_DIR"]).mkdir(parents=True, exist_ok=True)
+        if not tracing_enabled:
+            validate_trace_off_gateway_configs(config_base, args.instances)
 
     image_missing = subprocess.run(
         ["docker", "image", "inspect", config["PINCHBENCH_DOCKER_IMAGE"]],
@@ -1097,11 +1190,6 @@ def main() -> None:
         "%Y%m%d-%H%M%S"
     )
     run_root_dir.mkdir()
-
-    suite_name = "core" if args.core else args.suite
-    task_ids = expand_suite(pinchbench_dir, suite_name)
-    if not task_ids:
-        sys.exit(f"Error: no tasks selected for suite '{suite_name}'.")
 
     worker_suites = shard_tasks(task_ids, args.instances)
 

--- a/Tasks/Pinchbench/tests/test_run_parallel_workers.py
+++ b/Tasks/Pinchbench/tests/test_run_parallel_workers.py
@@ -117,6 +117,72 @@ class BenchmarkCommandTests(unittest.TestCase):
 
         self.assertEqual(task_ids, ["task_b", "task_c"])
 
+    def test_expand_suite_validates_exact_ids_and_preserves_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pinchbench_dir = Path(tmp)
+            tasks_dir = pinchbench_dir / "tasks"
+            tasks_dir.mkdir()
+            for task_id in ("task_a", "task_b"):
+                self._write_task(tasks_dir, task_id)
+
+            task_ids = self.runner.expand_suite(
+                pinchbench_dir,
+                "task_b,task_a,task_b",
+                exact_task_ids=True,
+            )
+
+        self.assertEqual(task_ids, ["task_b", "task_a"])
+
+    def test_expand_suite_reports_every_unknown_exact_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pinchbench_dir = Path(tmp)
+            tasks_dir = pinchbench_dir / "tasks"
+            tasks_dir.mkdir()
+            self._write_task(tasks_dir, "task_a")
+
+            with self.assertRaisesRegex(
+                SystemExit,
+                r"unknown PinchBench task\(s\): missing-a, missing-b",
+            ):
+                self.runner.expand_suite(
+                    pinchbench_dir,
+                    "task_a,missing-a,missing-b",
+                    exact_task_ids=True,
+                )
+
+    def test_pinned_catalog_validation_does_not_checkout_the_worktree(self):
+        fetch = self.runner.subprocess.CompletedProcess([], 0)
+        tree = self.runner.subprocess.CompletedProcess(
+            [],
+            0,
+            stdout=(
+                "tasks/task_a.md\n"
+                "tasks/task_b.md\n"
+                "tasks/task_XX_name.md\n"
+                "tasks/nested/task_hidden.md\n"
+            ),
+        )
+        with mock.patch.object(
+            self.runner,
+            "ensure_checkout_repository",
+            return_value=True,
+        ), mock.patch.object(
+            self.runner.subprocess,
+            "run",
+            side_effect=(fetch, tree),
+        ) as run:
+            available = self.runner.load_pinned_task_ids(
+                Path("/tmp/pinchbench"),
+                "https://example.invalid/pinchbench.git",
+                "pinned-ref",
+            )
+
+        self.assertEqual(available, {"task_a", "task_b"})
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertTrue(any("fetch" in command for command in commands))
+        self.assertTrue(any("ls-tree" in command for command in commands))
+        self.assertFalse(any("checkout" in command for command in commands))
+
     def test_default_ref_tracks_latest_supported_pinchbench_commit(self):
         self.assertEqual(
             self.runner.DEFAULT_PINCHBENCH_REF,

--- a/Tasks/clawBio/README.md
+++ b/Tasks/clawBio/README.md
@@ -171,6 +171,10 @@ Execute the benchmark tasks:
 # Optional: override instance count / iteration count at runtime
 COUNT=20 ITERATIONS=3 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 
+# Run selected exact task IDs only
+./Tasks/clawBio/scripts/run-openclaw-clawbio.sh \
+  --tasks rnaseq-de-demo,fine-mapping-demo
+
 # Direct run-benchmark.py is for advanced/manual workflow when fleet is already
 # prepared and started by you (Step 1~3), and you only want to execute tasks.
 # Do not run it again immediately after the unified launcher unless you
@@ -181,6 +185,10 @@ COUNT=20 ITERATIONS=3 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 # With custom config
 ./Tasks/clawBio/scripts/run-benchmark.py --instances 4 --config config/tasks.json
 
+# Select exact task IDs when the fleet is already running
+./Tasks/clawBio/scripts/run-benchmark.py --instances 4 \
+  --tasks rnaseq-de-demo,fine-mapping-demo
+
 # Run 5 iterations and print per-iteration status summary
 ./Tasks/clawBio/scripts/run-benchmark.py --instances 4 -n 5
 
@@ -190,7 +198,12 @@ COUNT=20 ITERATIONS=3 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 
 ### Unified Launcher Notes
 
-`run-openclaw-clawbio.sh` is a thin orchestrator that prewarms the cache, generates and patches fleet configs, starts the fleet, and invokes `run-benchmark.py`. Run with `-h` to see all environment variables. Variable precedence: runtime env → `Agents/Openclaw/config/fleet.env` → `config.env` → script defaults.
+`run-openclaw-clawbio.sh` validates explicit task IDs before it builds an
+image, prepares caches, changes fleet configuration, or restarts containers.
+It then prewarms the cache, generates and patches fleet configs, starts the
+fleet, and invokes `run-benchmark.py`. Run with `-h` to see all environment
+variables. Variable precedence: runtime env →
+`Agents/Openclaw/config/fleet.env` → `config.env` → script defaults.
 
 Output layout is described under [Output Structure](#output-structure).
 
@@ -266,11 +279,12 @@ Flags: `--config-base DIR`, `--plugin-name NAME`, `-h/--help`
 Discovers instances from `Agents/Openclaw/.env` and workspace paths from `docker inspect`.
 
 ```
-usage: run-benchmark.py [-h] [--instances N] [--config PATH] [--output-dir DIR] [--skip-preflight] [-n N]
+usage: run-benchmark.py [-h] [--instances N] [--config PATH] [--tasks ID[,ID...]] [--output-dir DIR] [--skip-preflight] [-n N]
 
 Options:
   --instances N       Number of instances to use (default: all discovered)
   --config PATH       Task config file (default: config/tasks.json)
+  --tasks ID[,ID...]  Run only the listed exact task IDs
   --output-dir DIR    Output root (default: results/)
   --skip-preflight    Skip container health checks
   -n N, --iterations N

--- a/Tasks/clawBio/scripts/run-benchmark.py
+++ b/Tasks/clawBio/scripts/run-benchmark.py
@@ -172,6 +172,27 @@ def load_task_config(path: Path) -> dict[str, Any]:
     return {"defaults": defaults, "tasks": tasks}
 
 
+def filter_tasks(
+    tasks: list[dict[str, Any]],
+    requested_value: str | None,
+) -> list[dict[str, Any]]:
+    """Return exact requested task IDs in request order, or every task."""
+    if requested_value is None:
+        return tasks
+
+    requested = list(
+        dict.fromkeys(part.strip() for part in requested_value.split(",") if part.strip())
+    )
+    if not requested:
+        raise SystemExit("Error: --tasks must contain at least one task ID.")
+
+    tasks_by_id = {str(task["id"]): task for task in tasks}
+    missing = [task_id for task_id in requested if task_id not in tasks_by_id]
+    if missing:
+        raise SystemExit("Error: unknown ClawBio task(s): " + ", ".join(missing))
+    return [tasks_by_id[task_id] for task_id in requested]
+
+
 # ── Docker helpers ──
 
 
@@ -1200,6 +1221,17 @@ def parse_args() -> argparse.Namespace:
         help="Path to the task config file (default: config/tasks.json).",
     )
     parser.add_argument(
+        "--tasks",
+        default=None,
+        metavar="ID[,ID...]",
+        help="Run only the listed exact task IDs.",
+    )
+    parser.add_argument(
+        "--validate-tasks-only",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--output-dir",
         default=str(RESULTS_DIR),
         help="Benchmark output root (default: results/).",
@@ -1244,7 +1276,9 @@ def main() -> None:
 
     task_config = load_task_config(task_config_path)
     defaults = task_config["defaults"]
-    tasks = task_config["tasks"]
+    tasks = filter_tasks(task_config["tasks"], args.tasks)
+    if args.validate_tasks_only:
+        return
 
     instances = discover_instances()
 

--- a/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+++ b/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
@@ -16,6 +16,8 @@ COUNT="${COUNT:-}"
 ITERATIONS="${ITERATIONS:-1}"
 RUN_ROOT="${RUN_ROOT:-$BENCH_DIR/runs/$TIMESTAMP}"
 TASK_CONFIG="${TASK_CONFIG:-$BENCH_DIR/config/tasks.json}"
+SELECTED_TASKS=""
+VALIDATE_TASKS_ONLY=0
 
 # Keep model/provider config sourced from config.env or caller env.
 BASE_URL="${BASE_URL:-}"
@@ -41,7 +43,7 @@ PLUGIN_CACHE_DIR="${PLUGIN_CACHE_DIR:-$BENCH_DIR/cache}"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0")
+Usage: $(basename "$0") [--tasks <id>[,id...]]
 
 One-command launcher for ClawBio benchmark:
 1) optionally build/reuse OpenClaw image
@@ -61,10 +63,32 @@ Provider/fleet vars are read from environment or the repo-root config.env:
 EOF
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-  usage
-  exit 0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tasks)
+      [[ $# -ge 2 && -n "$2" ]] || {
+        echo "Error: --tasks requires a non-empty value." >&2
+        exit 2
+      }
+      SELECTED_TASKS="$2"
+      shift 2
+      ;;
+    --validate-tasks-only)
+      VALIDATE_TASKS_ONLY=1
+      shift
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+if (( VALIDATE_TASKS_ONLY )) && [[ -z "$SELECTED_TASKS" ]]; then
+  echo "Error: --validate-tasks-only requires --tasks." >&2
+  exit 2
 fi
+readonly CLI_SELECTED_TASKS="$SELECTED_TASKS"
 
 # Load shared site config (config.env), then private overrides/secrets
 # (config.local.env, git-ignored), then OpenClaw fleet defaults, so
@@ -96,6 +120,15 @@ fi
 # Caller-provided env wins over all the config files above.
 eval "$__caller_env"
 unset __caller_env
+SELECTED_TASKS="$CLI_SELECTED_TASKS"
+
+if [[ -n "$SELECTED_TASKS" ]]; then
+  python3 "$BENCH_DIR/scripts/run-benchmark.py" \
+    --config "$TASK_CONFIG" \
+    --tasks "$SELECTED_TASKS" \
+    --validate-tasks-only
+fi
+(( VALIDATE_TASKS_ONLY == 0 )) || exit 0
 
 # TRACE_TO_OPIK is the authoritative switch documented in the root README:
 # tracing off forces the plugin off, even over an explicit
@@ -211,6 +244,9 @@ docker compose -f "$OPENCLAW_DIR/docker-compose.yml" up -d
 "$OPENCLAW_DIR/scripts/openclaw-fleet.sh" status
 
 run_cmd=("$BENCH_DIR/scripts/run-benchmark.py" --config "$TASK_CONFIG" --output-dir "$(dirname "$RUN_ROOT")" -n "$ITERATIONS" --run-id "$(basename "$RUN_ROOT")")
+if [[ -n "$SELECTED_TASKS" ]]; then
+  run_cmd+=(--tasks "$SELECTED_TASKS")
+fi
 if [[ -n "$COUNT" ]]; then
   run_cmd+=(--instances "$COUNT")
 fi

--- a/Tasks/clawBio/tests/test_run_benchmark.py
+++ b/Tasks/clawBio/tests/test_run_benchmark.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -7,6 +8,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "run-benchmark.py"
+WRAPPER_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "run-openclaw-clawbio.sh"
+)
 SPEC = importlib.util.spec_from_file_location("clawbio_run_benchmark", MODULE_PATH)
 run_benchmark = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -15,6 +19,65 @@ SPEC.loader.exec_module(run_benchmark)
 
 
 class ClawBioRunnerTest(unittest.TestCase):
+    @staticmethod
+    def sample_tasks() -> list[dict[str, str]]:
+        return [
+            {"id": "task-a", "prompt": "A"},
+            {"id": "task-b", "prompt": "B"},
+            {"id": "task-c", "prompt": "C"},
+        ]
+
+    def test_filter_tasks_validates_exact_ids_and_preserves_order(self) -> None:
+        selected = run_benchmark.filter_tasks(
+            self.sample_tasks(),
+            " task-c,task-a,task-c ",
+        )
+
+        self.assertEqual([task["id"] for task in selected], ["task-c", "task-a"])
+
+    def test_filter_tasks_reports_every_missing_id(self) -> None:
+        with self.assertRaisesRegex(
+            SystemExit,
+            r"unknown ClawBio task\(s\): missing-a, missing-b",
+        ):
+            run_benchmark.filter_tasks(
+                self.sample_tasks(),
+                "task-a,missing-a,missing-b",
+            )
+
+    def test_wrapper_rejects_unknown_tasks_without_creating_run_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / "tasks.json"
+            run_root = root / "run"
+            config.write_text(
+                '{"defaults":{},"tasks":[{"id":"task-a","prompt":"A"}]}',
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "TASK_CONFIG": str(config),
+                    "RUN_ROOT": str(run_root),
+                    "TRACE_TO_OPIK": "false",
+                }
+            )
+
+            result = subprocess.run(
+                [str(WRAPPER_PATH), "--tasks", "missing-a,missing-b"],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "unknown ClawBio task(s): missing-a, missing-b",
+                result.stderr,
+            )
+            self.assertFalse(run_root.exists())
+
     def test_clear_artifact_paths_removes_declared_outputs_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -134,7 +134,7 @@ Docker containers are checked by their own deployment/runtime paths.
 | Option | Description |
 | --- | --- |
 | `-t, --taskset <value>` | Built-in alias (`seta`, `smith`, `terminalbench21`, `sweverify`), registry ID, explicit local path, `pinchbench`, or `clawbio` |
-| `--task <name>[,name...]` | Run exact task names for supported Harbor tasksets; repeat the flag to append more names, or use `--task=<name>` when an ID begins with `-` |
+| `--task <name>[,name...]` | Run exact task names only; repeat the flag to append more names, or use `--task=<name>` when an ID begins with `-` |
 | `-a, --agent <name>` | Optional Harbor agent override; `openclaw` is accepted for consistent OpenClaw commands |
 | `-n, --workers <n>` | Harbor workers or OpenClaw fleet instances |
 | `-s, --spec <file|-> [files...]` | Read one or more FleetSpec v1 objects or arrays; multiple runs are detected automatically |
@@ -171,8 +171,8 @@ Examples:
 ./scripts/run_fleet.sh --taskset terminalbench21 \
   --task fix-git,break-filter-js-from-html --workers 2
 ./scripts/run_fleet.sh --taskset ./my-taskset --agent opencode --workers 2
-./scripts/run_fleet.sh --taskset pinchbench --agent openclaw --workers 10
-./scripts/run_fleet.sh --taskset clawbio --agent openclaw --workers 10
+./scripts/run_fleet.sh --taskset pinchbench --task task_sanity --workers 1
+./scripts/run_fleet.sh --taskset clawbio --task rnaseq-de-demo --workers 1
 ./scripts/run_fleet.sh --taskset terminal-bench/terminal-bench-2-1 \
   --agent claude-code --workers 10 --output fleet-spec.json --dry-run
 ```
@@ -205,7 +205,7 @@ Create `fleet-spec.json` with any text editor, for example
 | --- | --- | --- |
 | `schema_version` | Yes | Must be `1` |
 | `taskset` | Yes | Built-in alias (`seta`, `smith`, `terminalbench21`, `sweverify`), registry ID, explicit local path, `pinchbench`, or `clawbio` |
-| `task` | No | Exact task names for supported Harbor tasksets in one comma-separated string |
+| `task` | No | Exact task names in one comma-separated string |
 | `agent` | No | Agent passed to the selected runner |
 | `workers` | No | Integer from 1 to 4096 |
 
@@ -392,12 +392,12 @@ In `--taskset` mode and single-spec `--spec` mode, `run_fleet.sh` only parses
 the input, maps it to the selected runner, and replaces itself with that
 runner. It does not generate run IDs, create output directories, create or
 monitor sessions, inspect task catalogs, run preflight checks, or translate
-downstream errors. For supported Harbor tasksets, it normalizes task names and
-passes the selection to Harbor, which owns exact catalog validation and
-filtering. Multi-run `--spec` input is the documented exception: it dispatches
-through Batch, which validates every exact task selection before creating
-artifacts or starting children, then generates per-run `RUN_ID`s, writes launch
-artifacts and logs, and starts detached Harbor sessions as described above.
+downstream errors. It normalizes task names and passes the selection to the
+selected runner, which owns exact catalog validation and filtering. Multi-run
+`--spec` input is the documented exception: it dispatches through Batch, which
+validates every exact task selection before creating artifacts or starting
+children, then generates per-run `RUN_ID`s, writes launch artifacts and logs,
+and starts detached Harbor sessions as described above.
 
 Harbor tasksets call `Agents/utils/common/Harbor/start.sh`. Local tasksets must
 use an explicit path beginning with `./`, `../`, `/`, or `~/`. Harbor owns its
@@ -409,12 +409,14 @@ When reusing a local Harbor `RUN_ID`, omitting `--task` resumes the task list
 already recorded in `tasks.txt`. A different explicit selection is rejected;
 use `RESET_RUN=1` or a new `RUN_ID` to redefine the task list.
 
-The `pinchbench` taskset calls the existing PinchBench parallel
-runner and maps workers to `--instances`; the OpenClaw fleet must already be
-configured and running. The `clawbio` taskset calls the existing
-ClawBio unified launcher and maps workers to `COUNT`. Those runners own setup,
-validation, execution, outputs, and failures. If `--agent` conflicts with an
-OpenClaw taskset, the router prints the requested and actual agents, ignores the
+The `pinchbench` taskset calls the existing PinchBench parallel runner, maps
+workers to `--instances`, and validates selected IDs against the pinned
+`task_*.md` checkout before image or result creation; the OpenClaw fleet must
+already be configured and running. The `clawbio` taskset calls the existing
+ClawBio unified launcher, maps workers to `COUNT`, and validates selected IDs
+against its task config before setup or fleet restart. Those runners own setup,
+execution, outputs, and failures. If `--agent` conflicts with an OpenClaw
+taskset, the router prints the requested and actual agents, ignores the
 conflicting value, and continues with OpenClaw. OpenClaw runners remain in the
 foreground; `--detach` is ignored with a warning.
 
@@ -427,10 +429,10 @@ interfaces:
   `agent`, and `workers`. Unknown fields and invalid values are rejected.
   `task` is a normalized comma-separated string; arrays, glob matching,
   taskset inference, task files, and fuzzy matching are not supported.
-- `--task` supports `seta`, `smith`, `terminalbench21`, `sweverify`, and
-  explicit local dataset paths. OpenClaw tasksets and arbitrary Harbor registry
-  IDs are rejected because this PR does not add their task-selection adapters.
-  `--task` is also rejected with `ROLLOUT=1`.
+- `--task` supports `seta`, `smith`, `terminalbench21`, `sweverify`, explicit
+  local dataset paths, `pinchbench`, and `clawbio`. TMax and other arbitrary
+  Harbor registry IDs are rejected because this MVP has no pinned local task
+  catalog for them. `--task` is also rejected with `ROLLOUT=1`.
 - FleetSpec cannot set a per-run model, timeout, retry policy, or environment
   variables; configure those in the caller environment, where they apply to
   every spec of the invocation and cannot vary between specs.

--- a/scripts/fleet_prompt.sh
+++ b/scripts/fleet_prompt.sh
@@ -117,8 +117,8 @@ Preserve explicit registry ids and local paths exactly.
 Copy task names exactly as written. Join multiple explicit names with commas.
 Never invent or complete a task name, and never infer a taskset from task names.
 Task selection is supported only for seta, smith, terminalbench21, sweverify,
-and explicit local paths. If exact tasks are requested for another taskset,
-including registry ids and OpenClaw tasksets, return ready=false.
+explicit local paths, pinchbench, and clawbio. If exact tasks are requested for
+another registry id, return ready=false.
 
 Return one specs element for each explicitly requested run. For example, a run
 requested once with claude-code and once with opencode becomes two specs. Do not

--- a/scripts/fleet_spec_validate.jq
+++ b/scripts/fleet_spec_validate.jq
@@ -13,6 +13,8 @@ def fleet_taskset_supports_task_v1:
   . == "smith" or
   . == "terminalbench21" or
   . == "sweverify" or
+  . == "pinchbench" or
+  . == "clawbio" or
   . == "." or
   . == ".." or
   startswith("/") or

--- a/scripts/run_fleet.sh
+++ b/scripts/run_fleet.sh
@@ -181,11 +181,7 @@ fi
 [[ -n "$TASKSET" ]] || { usage >&2; exit 2; }
 if [[ -n "$FLEET_TASK" ]]; then
   case "$TASKSET" in
-    seta|smith|terminalbench21|sweverify|/*|./*|../*|.|..|\~/*) ;;
-    pinchbench|clawbio)
-      printf '[ERROR] --task is unsupported for OpenClaw taskset: %s\n' "$TASKSET" >&2
-      exit 2
-      ;;
+    seta|smith|terminalbench21|sweverify|pinchbench|clawbio|/*|./*|../*|.|..|\~/*) ;;
     *)
       printf '[ERROR] --task is unsupported for Harbor registry taskset: %s\n' "$TASKSET" >&2
       exit 2
@@ -226,12 +222,21 @@ fi
 
 case "$TASKSET" in
   pinchbench)
-    cmd=(python3 "$REPO_DIR/Tasks/Pinchbench/scripts/run-parallel-workers.py")
+    pinchbench_exact_task_selection=0
+    [[ -z "$FLEET_TASK" ]] || pinchbench_exact_task_selection=1
+    cmd=(
+      env "PINCHBENCH_EXACT_TASK_SELECTION=$pinchbench_exact_task_selection"
+      python3 "$REPO_DIR/Tasks/Pinchbench/scripts/run-parallel-workers.py"
+    )
+    [[ -z "$FLEET_TASK" ]] || cmd+=(--suite "$FLEET_TASK")
     [[ -z "$WORKERS" ]] || cmd+=(--instances "$WORKERS")
+    (( VALIDATE_TASK_SELECTION == 0 )) || cmd+=(--validate-tasks-only)
     run_command "${cmd[@]}"
     ;;
   clawbio)
     cmd=(bash "$REPO_DIR/Tasks/clawBio/scripts/run-openclaw-clawbio.sh")
+    [[ -z "$FLEET_TASK" ]] || cmd+=(--tasks "$FLEET_TASK")
+    (( VALIDATE_TASK_SELECTION == 0 )) || cmd+=(--validate-tasks-only)
     [[ -z "$WORKERS" ]] || cmd=(env "COUNT=$WORKERS" "${cmd[@]}")
     run_command "${cmd[@]}"
     ;;

--- a/scripts/tests/test_fleet_batch.py
+++ b/scripts/tests/test_fleet_batch.py
@@ -78,8 +78,15 @@ printf 'args=%s\\n' "$*"
         pinchbench.write_text(
             """import os
 import signal
+import sys
 import time
 from pathlib import Path
+
+if "--validate-tasks-only" in sys.argv:
+    if "missing-task" in sys.argv:
+        print("unknown PinchBench task(s): missing-task", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(0)
 
 pid_file = os.environ.get("STUB_CHILD_PID_FILE")
 if pid_file:
@@ -102,6 +109,13 @@ print("runner=pinchbench")
         clawbio.parent.mkdir(parents=True)
         clawbio.write_text(
             """#!/usr/bin/env bash
+if [[ "$*" == *"--validate-tasks-only"* ]]; then
+  if [[ "$*" == *"missing-task"* ]]; then
+    printf 'unknown ClawBio task(s): missing-task\\n' >&2
+    exit 2
+  fi
+  exit 0
+fi
 printf 'runner=clawbio\\n'
 if [[ -n "${STUB_GRANDCHILD_PID_FILE:-}" ]]; then
   # Mirror the real launcher shape: the benchmark work runs in a foreground
@@ -246,20 +260,26 @@ fi
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(len(self.calls.read_text(encoding="utf-8").splitlines()), 2)
 
-    def test_unsupported_task_selection_starts_nothing(self):
+    def test_unknown_openclaw_task_starts_nothing(self):
         valid = self.write_spec("valid.json", "owner/valid")
-        invalid = self.write_spec(
-            "invalid.json",
-            "pinchbench",
-            task="task_sanity",
-        )
+        for taskset in ("pinchbench", "clawbio"):
+            with self.subTest(taskset=taskset):
+                invalid = self.write_spec(
+                    "invalid.json",
+                    taskset,
+                    task="missing-task",
+                )
 
-        result = self.run_batch("--spec", str(valid), str(invalid))
+                result = self.run_batch("--spec", str(valid), str(invalid))
 
-        self.assertEqual(result.returncode, 2)
-        self.assertIn("invalid FleetSpec", result.stderr)
-        self.assertFalse(self.calls.exists())
-        self.assertFalse(self.artifact_root.exists())
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("missing-task", result.stderr)
+                self.assertIn(
+                    "task selection preflight failed for spec 2",
+                    result.stderr,
+                )
+                self.assertFalse(self.calls.exists())
+                self.assertFalse(self.artifact_root.exists())
 
     def test_unknown_exact_task_starts_nothing(self):
         valid = self.write_spec("valid.json", "owner/valid")

--- a/scripts/tests/test_fleet_prompt.py
+++ b/scripts/tests/test_fleet_prompt.py
@@ -106,6 +106,7 @@ raise SystemExit(int(os.environ.get("STUB_EXIT", "0")))
             """#!/usr/bin/env bash
 printf 'runner=clawbio\\n'
 printf 'COUNT=%s\\n' "${COUNT-}"
+printf 'args=%s\\n' "$*"
 exit "${STUB_EXIT:-0}"
 """,
             encoding="utf-8",
@@ -245,6 +246,22 @@ exit "${STUB_EXIT:-0}"
             },
         )
 
+    def test_prompt_routes_openclaw_task_selection(self):
+        result = self.run_goal(
+            "--prompt",
+            "Run rnaseq-de-demo from clawbio",
+            response=self.response(
+                spec={
+                    "schema_version": 1,
+                    "taskset": "clawbio",
+                    "task": "rnaseq-de-demo",
+                }
+            ),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("args=--tasks rnaseq-de-demo", result.stdout)
+
     def test_prompt_prefers_managed_pi_over_path_shadow(self):
         managed_bin = self.root / "managed-npm-bin"
         managed_bin.mkdir()
@@ -329,7 +346,7 @@ exec {shlex.quote(str(self.bin_dir / "pi"))} "$@"
         self.assertIn("Terminus-2", captured)
         self.assertIn("return ready=false", captured)
         self.assertIn("never infer a taskset", captured)
-        self.assertIn("OpenClaw tasksets", captured)
+        self.assertIn("another registry id", captured)
         self.assertIn('"specs"', captured)
         self.assertIn('"maxItems": 16', captured)
 

--- a/scripts/tests/test_run_fleet.py
+++ b/scripts/tests/test_run_fleet.py
@@ -43,6 +43,7 @@ exit "${STUB_EXIT:-0}"
 import sys
 print("runner=pinchbench")
 print("args=" + " ".join(sys.argv[1:]))
+print("PINCHBENCH_EXACT_TASK_SELECTION=" + os.environ.get("PINCHBENCH_EXACT_TASK_SELECTION", ""))
 print("RUN_ID=" + os.environ.get("RUN_ID", ""))
 raise SystemExit(int(os.environ.get("STUB_EXIT", "0")))
 """,
@@ -55,6 +56,7 @@ raise SystemExit(int(os.environ.get("STUB_EXIT", "0")))
             """#!/usr/bin/env bash
 printf 'runner=clawbio\\n'
 printf 'COUNT=%s\\n' "${COUNT-}"
+printf 'args=%s\\n' "$*"
 printf 'RUN_ID=%s\\n' "${RUN_ID-}"
 exit "${STUB_EXIT:-0}"
 """,
@@ -139,6 +141,7 @@ exit "${STUB_EXIT:-0}"
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("runner=pinchbench", result.stdout)
         self.assertIn("args=--instances 4", result.stdout)
+        self.assertIn("PINCHBENCH_EXACT_TASK_SELECTION=0", result.stdout)
         self.assertIn("RUN_ID=\n", result.stdout)
 
     def test_task_selection_is_normalized_once_and_routed(self):
@@ -156,6 +159,36 @@ exit "${STUB_EXIT:-0}"
             "FLEET_TASKS=fix-git,break-filter-js-from-html,build-cython-ext",
             result.stdout,
         )
+
+    def test_openclaw_task_selection_uses_exact_runner_modes(self):
+        pinchbench = self.run_fleet(
+            "--taskset", "pinchbench", "--task", "task_sanity,task_weather"
+        )
+        self.assertEqual(pinchbench.returncode, 0, pinchbench.stderr)
+        self.assertIn("--suite task_sanity,task_weather", pinchbench.stdout)
+        self.assertIn("PINCHBENCH_EXACT_TASK_SELECTION=1", pinchbench.stdout)
+
+        clawbio = self.run_fleet(
+            "--taskset", "clawbio", "--task", "rnaseq-de-demo,fine-mapping-demo"
+        )
+        self.assertEqual(clawbio.returncode, 0, clawbio.stderr)
+        self.assertIn(
+            "args=--tasks rnaseq-de-demo,fine-mapping-demo",
+            clawbio.stdout,
+        )
+
+    def test_openclaw_task_preflight_uses_validation_only_mode(self):
+        for taskset in ("pinchbench", "clawbio"):
+            with self.subTest(taskset=taskset):
+                result = self.run_fleet(
+                    "--taskset",
+                    taskset,
+                    "--task",
+                    "selected-task",
+                    "--validate-task-selection",
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("--validate-tasks-only", result.stdout)
 
     def test_harbor_clears_inherited_task_selection_when_task_is_omitted(self):
         result = self.run_fleet(
@@ -230,17 +263,12 @@ exit "${STUB_EXIT:-0}"
         self.assertIn("--task requires --taskset", missing_taskset.stderr)
         self.assertNotIn("missing required configuration", missing_taskset.stderr)
 
-        for taskset in ("publisher/private-registry", "pinchbench", "clawbio"):
-            with self.subTest(taskset=taskset):
-                unsupported = self.run_fleet(
-                    "--taskset", taskset, "--task", "task_sanity"
-                )
-                self.assertEqual(unsupported.returncode, 2)
-                self.assertIn("--task is unsupported", unsupported.stderr)
-                self.assertNotIn(
-                    "missing required configuration",
-                    unsupported.stderr,
-                )
+        unsupported = self.run_fleet(
+            "--taskset", "publisher/private-registry", "--task", "task_sanity"
+        )
+        self.assertEqual(unsupported.returncode, 2)
+        self.assertIn("--task is unsupported", unsupported.stderr)
+        self.assertNotIn("missing required configuration", unsupported.stderr)
 
     def test_task_rejects_empty_and_control_character_values(self):
         for task in (" , , ", "task-one\n task-two"):
@@ -581,8 +609,6 @@ exit "${STUB_EXIT:-0}"
             {"schema_version": 1, "taskset": "terminalbench21", "task": 1},
             {"schema_version": 1, "taskset": "terminalbench21", "task": ""},
             {"schema_version": 1, "taskset": "terminalbench21", "task": " , , "},
-            {"schema_version": 1, "taskset": "pinchbench", "task": "task_sanity"},
-            {"schema_version": 1, "taskset": "clawbio", "task": "rnaseq-de-demo"},
             {"schema_version": 1, "taskset": "owner/tasks", "task": "task-one"},
             {
                 "schema_version": 1,
@@ -664,7 +690,10 @@ exit "${STUB_EXIT:-0}"
             "--dry-run",
         )
         self.assertEqual(pinchbench.returncode, 0, pinchbench.stderr)
-        self.assertIn("Command: python3", pinchbench.stdout)
+        self.assertIn(
+            "Command: env PINCHBENCH_EXACT_TASK_SELECTION=0 python3",
+            pinchbench.stdout,
+        )
         self.assertIn("run-parallel-workers.py --instances 4", pinchbench.stdout)
         self.assertNotIn("runner=pinchbench", pinchbench.stdout)
 


### PR DESCRIPTION
## 1. Why the change?

PR #38 added exact task selection for the Harbor-backed tasksets, but the OpenClaw tasksets still could not consume FleetSpec `task` selections. This completes the remaining PinchBench and ClawBio scope from #21 while preserving the existing full-taskset behavior when `--task` is omitted.

Closes #21.

## 2. Summary of the change

- Allow exact `task` selection for `pinchbench` and `clawbio` through direct CLI, FleetSpec, batch, and prompt entry points.
- Route PinchBench selections through its existing suite path in an explicit exact-ID mode, validating against the pinned ref without changing the checkout during batch preflight.
- Add ClawBio `--tasks` filtering and validate selections before cache, image, fleet setup, or container restart side effects.
- Preserve request order, deduplicate IDs, and report all unknown IDs together.
- Update user documentation and focused runner/router tests.

## 3. Other details

Behavior without `--task` is unchanged. Arbitrary Harbor registry tasksets remain unsupported for exact selection because the MVP has no pinned local catalog for them.

ClawBio's broader execution-security configuration is intentionally outside this task-selection change and is tracked in #41; this PR does not weaken the general OpenClaw defaults.

Validation:

- `python3 -m unittest discover -s scripts/tests` — 113 passed
- `python3 -m unittest discover -s Tasks/Pinchbench/tests` — 31 passed
- `python3 -m unittest discover -s Tasks/clawBio/tests` — 8 passed
- `uvx --offline ruff==0.16.0 check --config .github/ruff.toml`
- Bash syntax and `git diff --check`
- Real one-task canaries: PinchBench `task_sanity` and ClawBio `rnaseq-de-demo`