### PR TITLE
Fail fast on incompatible ClawBio security settings

### DIFF
--- a/Tasks/AGENTS.md
+++ b/Tasks/AGENTS.md
@@ -73,9 +73,7 @@ Five-phase pipeline (prewarm plugin cache → fleet `setup.sh` with
 `run-benchmark.py`). The unified launcher runs all of it:
 
 ```bash
-SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
-  ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
-SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 COUNT=20 ITERATIONS=3 \
   ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 ```
@@ -83,6 +81,8 @@ COUNT=20 ITERATIONS=3 \
 `patch-plugin-config.sh` must run after `setup.sh` and before
 `docker compose up`. The phase-by-phase manual flow with the full
 environment-variable example: [clawBio/README.md](clawBio/README.md).
+The launcher loads and warns about the dedicated execution profile in
+`clawBio/config/benchmark.env`.
 The unified launcher leaves the benchmark fleet running with its run-specific
 execution profile; stop or regenerate it before using OpenClaw for another
 purpose.

--- a/Tasks/AGENTS.md
+++ b/Tasks/AGENTS.md
@@ -73,9 +73,9 @@ Five-phase pipeline (prewarm plugin cache → fleet `setup.sh` with
 `run-benchmark.py`). The unified launcher runs all of it:
 
 ```bash
-EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
   ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
-EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
 COUNT=20 ITERATIONS=3 \
   ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 ```
@@ -83,6 +83,9 @@ COUNT=20 ITERATIONS=3 \
 `patch-plugin-config.sh` must run after `setup.sh` and before
 `docker compose up`. The phase-by-phase manual flow with the full
 environment-variable example: [clawBio/README.md](clawBio/README.md).
+The unified launcher leaves the benchmark fleet running with its run-specific
+execution profile; stop or regenerate it before using OpenClaw for another
+purpose.
 
 Outputs: `Tasks/clawBio/results/latest/` →
 `iterations-summary.{json,md}`, `iteration-NNN/results.{json,md}`, and

--- a/Tasks/AGENTS.md
+++ b/Tasks/AGENTS.md
@@ -73,8 +73,11 @@ Five-phase pipeline (prewarm plugin cache → fleet `setup.sh` with
 `run-benchmark.py`). The unified launcher runs all of it:
 
 ```bash
-./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
-COUNT=20 ITERATIONS=3 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh   # overrides
+EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+  ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+COUNT=20 ITERATIONS=3 \
+  ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 ```
 
 `patch-plugin-config.sh` must run after `setup.sh` and before

--- a/Tasks/clawBio/README.md
+++ b/Tasks/clawBio/README.md
@@ -124,19 +124,21 @@ Generate and start the OpenClaw fleet with plugin cache mounted:
 
 ```bash
 # From repo root
+set -a
+. ./Tasks/clawBio/config/benchmark.env
+set +a
 PLUGIN_CACHE_DIR=$(pwd)/Tasks/clawBio/cache \
 TRACE_TO_OPIK=false \
 BASE_URL="https://api.example.com/v1" \
 API_KEY="sk-xxx" \
 MODEL="your-model" \
-SANDBOX_MODE=off \
-EXEC_SECURITY=full \
-EXEC_ASK=off \
-WORKSPACE_ONLY=false \
 ./Agents/Openclaw/scripts/setup.sh 4
 ```
 
 > **Required:** `BASE_URL` and `API_KEY` must be set via the repo-root `config.env`, environment variables, or CLI. See [Configuration Reference](#configuration-reference) for all options.
+>
+> **Security:** `config/benchmark.env` is permissive. Source it only for a
+> dedicated ClawBio fleet, then stop or regenerate that fleet before other use.
 
 ### Step 2: Patch Plugin Config
 
@@ -164,12 +166,6 @@ docker compose -f Agents/Openclaw/docker-compose.yml up -d
 Execute the benchmark tasks:
 
 ```bash
-# Required explicit opt-in for the dedicated ClawBio fleet
-export SANDBOX_MODE=off
-export EXEC_SECURITY=full
-export EXEC_ASK=off
-export WORKSPACE_ONLY=false
-
 # One-command launcher (setup + patch + start + benchmark)
 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 
@@ -210,7 +206,8 @@ directories or making any of those changes. It then prewarms the cache,
 generates and patches fleet configs, starts the fleet, and invokes
 `run-benchmark.py`. Run with `-h` to see all environment variables. Variable
 precedence: runtime env →
-`Agents/Openclaw/config/fleet.env` → `config.env` → script defaults.
+`Tasks/clawBio/config/benchmark.env` → `Agents/Openclaw/config/fleet.env` →
+`config.local.env` → `config.env` → script defaults.
 
 Output layout is described under [Output Structure](#output-structure).
 
@@ -218,26 +215,26 @@ Output layout is described under [Output Structure](#output-structure).
 
 ClawBio needs to load its skill from the mounted plugin cache, outside the
 instance workspace, and execute unattended shell, Python, and R commands. The
-unified launcher therefore requires an explicit benchmark configuration:
+unified launcher therefore loads a dedicated benchmark configuration:
 
 ```bash
-SANDBOX_MODE=off \
-EXEC_SECURITY=full \
-EXEC_ASK=off \
-WORKSPACE_ONLY=false \
 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 ```
 
-If a value is omitted, the launcher evaluates the normal OpenClaw setup
-default (`off`, `deny`, `always`, or `true`) and exits before creating the run
-root, building images, preparing caches, or changing the fleet. It lists every
-incompatible setting in one error. The launcher does not change the general
-OpenClaw defaults, but `setup.sh` writes this profile into the run-specific
-generated configs and leaves that fleet running after the benchmark. Stop it
-before using OpenClaw for another purpose, or regenerate the fleet with the
-desired restrictive settings. The container root filesystem remains read-only
-by default; ClawBio writes through its dedicated state and workspace mounts
-plus the `/tmp` tmpfs.
+The committed, public-safe `config/benchmark.env` supplies
+`SANDBOX_MODE=off`, `EXEC_SECURITY=full`, `EXEC_ASK=off`, and
+`WORKSPACE_ONLY=false`. The launcher warns before applying this permissive
+profile to the generated fleet. Runtime environment variables still take
+precedence; if they conflict, the launcher lists every incompatible setting and
+exits before creating the run root, building images, preparing caches, or
+changing the fleet.
+
+The launcher does not change the general OpenClaw defaults, but `setup.sh`
+writes this profile into the run-specific generated configs and leaves that
+fleet running after the benchmark. Stop it before using OpenClaw for another
+purpose, or regenerate the fleet with the desired restrictive settings. The
+container root filesystem remains read-only by default; ClawBio writes through
+its dedicated state and workspace mounts plus the `/tmp` tmpfs.
 
 ```bash
 docker compose -f Agents/Openclaw/docker-compose.yml down

--- a/Tasks/clawBio/README.md
+++ b/Tasks/clawBio/README.md
@@ -165,6 +165,7 @@ Execute the benchmark tasks:
 
 ```bash
 # Required explicit opt-in for the dedicated ClawBio fleet
+export SANDBOX_MODE=off
 export EXEC_SECURITY=full
 export EXEC_ASK=off
 export WORKSPACE_ONLY=false
@@ -220,6 +221,7 @@ instance workspace, and execute unattended shell, Python, and R commands. The
 unified launcher therefore requires an explicit benchmark configuration:
 
 ```bash
+SANDBOX_MODE=off \
 EXEC_SECURITY=full \
 EXEC_ASK=off \
 WORKSPACE_ONLY=false \
@@ -227,13 +229,19 @@ WORKSPACE_ONLY=false \
 ```
 
 If a value is omitted, the launcher evaluates the normal OpenClaw setup
-default (`deny`, `always`, or `true`) and exits before creating the run root,
-building images, preparing caches, or changing the fleet. It lists every
+default (`off`, `deny`, `always`, or `true`) and exits before creating the run
+root, building images, preparing caches, or changing the fleet. It lists every
 incompatible setting in one error. The launcher does not change the general
-OpenClaw defaults or persist a relaxed profile; configure these values only for
-the dedicated ClawBio fleet. The container root filesystem remains read-only by
-default; ClawBio writes through its dedicated state and workspace mounts plus
-the `/tmp` tmpfs.
+OpenClaw defaults, but `setup.sh` writes this profile into the run-specific
+generated configs and leaves that fleet running after the benchmark. Stop it
+before using OpenClaw for another purpose, or regenerate the fleet with the
+desired restrictive settings. The container root filesystem remains read-only
+by default; ClawBio writes through its dedicated state and workspace mounts
+plus the `/tmp` tmpfs.
+
+```bash
+docker compose -f Agents/Openclaw/docker-compose.yml down
+```
 
 ---
 

--- a/Tasks/clawBio/README.md
+++ b/Tasks/clawBio/README.md
@@ -133,7 +133,6 @@ SANDBOX_MODE=off \
 EXEC_SECURITY=full \
 EXEC_ASK=off \
 WORKSPACE_ONLY=false \
-DOCKER_COMPOSE_READ_ONLY=false \
 ./Agents/Openclaw/scripts/setup.sh 4
 ```
 
@@ -165,6 +164,11 @@ docker compose -f Agents/Openclaw/docker-compose.yml up -d
 Execute the benchmark tasks:
 
 ```bash
+# Required explicit opt-in for the dedicated ClawBio fleet
+export EXEC_SECURITY=full
+export EXEC_ASK=off
+export WORKSPACE_ONLY=false
+
 # One-command launcher (setup + patch + start + benchmark)
 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 
@@ -200,12 +204,36 @@ COUNT=20 ITERATIONS=3 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 
 `run-openclaw-clawbio.sh` validates explicit task IDs before it builds an
 image, prepares caches, changes fleet configuration, or restarts containers.
-It then prewarms the cache, generates and patches fleet configs, starts the
-fleet, and invokes `run-benchmark.py`. Run with `-h` to see all environment
-variables. Variable precedence: runtime env →
+It also validates the ClawBio benchmark security settings before creating run
+directories or making any of those changes. It then prewarms the cache,
+generates and patches fleet configs, starts the fleet, and invokes
+`run-benchmark.py`. Run with `-h` to see all environment variables. Variable
+precedence: runtime env →
 `Agents/Openclaw/config/fleet.env` → `config.env` → script defaults.
 
 Output layout is described under [Output Structure](#output-structure).
+
+### ClawBio Benchmark Security
+
+ClawBio needs to load its skill from the mounted plugin cache, outside the
+instance workspace, and execute unattended shell, Python, and R commands. The
+unified launcher therefore requires an explicit benchmark configuration:
+
+```bash
+EXEC_SECURITY=full \
+EXEC_ASK=off \
+WORKSPACE_ONLY=false \
+./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+```
+
+If a value is omitted, the launcher evaluates the normal OpenClaw setup
+default (`deny`, `always`, or `true`) and exits before creating the run root,
+building images, preparing caches, or changing the fleet. It lists every
+incompatible setting in one error. The launcher does not change the general
+OpenClaw defaults or persist a relaxed profile; configure these values only for
+the dedicated ClawBio fleet. The container root filesystem remains read-only by
+default; ClawBio writes through its dedicated state and workspace mounts plus
+the `/tmp` tmpfs.
 
 ---
 
@@ -356,7 +384,11 @@ Run prewarm-cache.sh before setup:
 
 ### Sandbox errors blocking skill execution
 
-If you see errors like "path escapes sandbox" or "workspaceOnly", set `WORKSPACE_ONLY=false` when running `Agents/Openclaw/scripts/setup.sh`.
+The unified launcher now rejects incompatible settings before fleet setup. If
+you use the manual setup flow and see errors such as "path escapes sandbox",
+`workspaceOnly`, or `exec denied`, apply all settings from
+[ClawBio Benchmark Security](#clawbio-benchmark-security), regenerate the
+fleet, and restart it.
 
 ### Artifacts directory is empty
 

--- a/Tasks/clawBio/config/benchmark.env
+++ b/Tasks/clawBio/config/benchmark.env
@@ -1,0 +1,9 @@
+# ClawBio benchmark-only OpenClaw execution profile.
+#
+# The unified launcher loads this after the general OpenClaw defaults. Keep
+# credentials out of this committed file. Runtime overrides still win, but
+# incompatible values are rejected before the launcher changes the fleet.
+SANDBOX_MODE=off
+EXEC_SECURITY=full
+EXEC_ASK=off
+WORKSPACE_ONLY=false

--- a/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+++ b/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
@@ -62,6 +62,7 @@ Provider/fleet vars are read from environment or the repo-root config.env:
   BASE_URL, API_KEY, MODEL
 
 Required ClawBio benchmark security settings:
+  Loaded from Tasks/clawBio/config/benchmark.env:
   SANDBOX_MODE=off, EXEC_SECURITY=full, EXEC_ASK=off
   WORKSPACE_ONLY=false
 EOF
@@ -94,11 +95,10 @@ if (( VALIDATE_TASKS_ONLY )) && [[ -z "$SELECTED_TASKS" ]]; then
 fi
 readonly CLI_SELECTED_TASKS="$SELECTED_TASKS"
 
-# Load shared site config (config.env), then private overrides/secrets
-# (config.local.env, git-ignored), then OpenClaw fleet defaults, so
-# launcher-side validation can see values from any of them. fleet.env overrides
-# config.local.env, which overrides config.env; caller-provided env wins over
-# all of them, so snapshot it now and re-apply after sourcing.
+# Load shared site config (config.env), private overrides/secrets
+# (config.local.env, git-ignored), OpenClaw fleet defaults, and finally the
+# committed ClawBio benchmark profile. Caller-provided env wins over all config
+# files, so snapshot it now and re-apply after sourcing.
 __caller_env="$(export -p)"
 root_cfg="$REPO_ROOT/config.env"
 if [[ -f "$root_cfg" ]]; then
@@ -121,6 +121,13 @@ if [[ -f "$fleet_env" ]]; then
   . "$fleet_env"
   set +a
 fi
+clawbio_profile="$BENCH_DIR/config/benchmark.env"
+if [[ -f "$clawbio_profile" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$clawbio_profile"
+  set +a
+fi
 # Caller-provided env wins over all the config files above.
 eval "$__caller_env"
 unset __caller_env
@@ -133,6 +140,11 @@ if [[ -n "$SELECTED_TASKS" ]]; then
     --validate-tasks-only
 fi
 (( VALIDATE_TASKS_ONLY == 0 )) || exit 0
+
+if [[ ! -f "$clawbio_profile" ]]; then
+  echo "Error: missing ClawBio benchmark profile: $clawbio_profile" >&2
+  exit 2
+fi
 
 # ClawBio loads its skill outside the instance workspace, executes unattended
 # shell/Python/R commands, and writes benchmark artifacts. Resolve the same
@@ -168,14 +180,22 @@ if (( ${#security_mismatches[@]} > 0 )); then
     printf '  %s=%q (required: %q)\n' "$setting" "${!setting}" "$required" >&2
   done
   cat >&2 <<EOF
-Set these values explicitly for the ClawBio launch:
-  SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \\
-    ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+The dedicated profile is defined in Tasks/clawBio/config/benchmark.env.
+Remove conflicting runtime overrides or restore these profile values:
+  SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false
 See Tasks/clawBio/README.md#clawbio-benchmark-security.
 The general OpenClaw security defaults were not changed.
 EOF
   exit 2
 fi
+
+cat >&2 <<EOF
+Warning: applying the permissive ClawBio benchmark profile from
+  Tasks/clawBio/config/benchmark.env
+  SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false
+Use it only for the generated ClawBio fleet. The profile remains active until
+that fleet is stopped or regenerated.
+EOF
 
 # TRACE_TO_OPIK is the authoritative switch documented in the root README:
 # tracing off forces the plugin off, even over an explicit

--- a/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+++ b/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
@@ -62,7 +62,8 @@ Provider/fleet vars are read from environment or the repo-root config.env:
   BASE_URL, API_KEY, MODEL
 
 Required ClawBio benchmark security settings:
-  EXEC_SECURITY=full, EXEC_ASK=off, WORKSPACE_ONLY=false
+  SANDBOX_MODE=off, EXEC_SECURITY=full, EXEC_ASK=off
+  WORKSPACE_ONLY=false
 EOF
 }
 
@@ -137,12 +138,15 @@ fi
 # shell/Python/R commands, and writes benchmark artifacts. Resolve the same
 # defaults as setup.py, then reject incompatible settings before creating run
 # directories, building images, preparing caches, or changing the fleet.
+SANDBOX_MODE="${SANDBOX_MODE:-off}"
 EXEC_SECURITY="${EXEC_SECURITY:-deny}"
 EXEC_ASK="${EXEC_ASK:-always}"
 WORKSPACE_ONLY="${WORKSPACE_ONLY:-true}"
 DOCKER_COMPOSE_READ_ONLY="${DOCKER_COMPOSE_READ_ONLY:-true}"
 
 security_mismatches=()
+[[ "$SANDBOX_MODE" == "off" ]] ||
+  security_mismatches+=("SANDBOX_MODE")
 [[ "$EXEC_SECURITY" == "full" ]] ||
   security_mismatches+=("EXEC_SECURITY")
 [[ "$EXEC_ASK" == "off" ]] ||
@@ -156,6 +160,7 @@ if (( ${#security_mismatches[@]} > 0 )); then
   echo "Incompatible settings:" >&2
   for setting in "${security_mismatches[@]}"; do
     case "$setting" in
+      SANDBOX_MODE) required="off" ;;
       EXEC_SECURITY) required="full" ;;
       EXEC_ASK) required="off" ;;
       WORKSPACE_ONLY) required="false" ;;
@@ -164,7 +169,7 @@ if (( ${#security_mismatches[@]} > 0 )); then
   done
   cat >&2 <<EOF
 Set these values explicitly for the ClawBio launch:
-  EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \\
+  SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \\
     ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 See Tasks/clawBio/README.md#clawbio-benchmark-security.
 The general OpenClaw security defaults were not changed.
@@ -269,8 +274,8 @@ if [[ -n "$BASE_URL" ]]; then env_args+=("BASE_URL=$BASE_URL"); fi
 if [[ -n "$API_KEY" ]]; then env_args+=("API_KEY=$API_KEY"); fi
 if [[ -n "$MODEL" ]]; then env_args+=("MODEL=$MODEL"); fi
 if [[ -n "$COUNT" ]]; then env_args+=("COUNT=$COUNT"); fi
-if [[ -n "${SANDBOX_MODE:-}" ]]; then env_args+=("SANDBOX_MODE=$SANDBOX_MODE"); fi
 env_args+=(
+  "SANDBOX_MODE=$SANDBOX_MODE"
   "EXEC_SECURITY=$EXEC_SECURITY"
   "EXEC_ASK=$EXEC_ASK"
   "WORKSPACE_ONLY=$WORKSPACE_ONLY"

--- a/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+++ b/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
@@ -60,6 +60,9 @@ Optional env vars:
 
 Provider/fleet vars are read from environment or the repo-root config.env:
   BASE_URL, API_KEY, MODEL
+
+Required ClawBio benchmark security settings:
+  EXEC_SECURITY=full, EXEC_ASK=off, WORKSPACE_ONLY=false
 EOF
 }
 
@@ -129,6 +132,45 @@ if [[ -n "$SELECTED_TASKS" ]]; then
     --validate-tasks-only
 fi
 (( VALIDATE_TASKS_ONLY == 0 )) || exit 0
+
+# ClawBio loads its skill outside the instance workspace, executes unattended
+# shell/Python/R commands, and writes benchmark artifacts. Resolve the same
+# defaults as setup.py, then reject incompatible settings before creating run
+# directories, building images, preparing caches, or changing the fleet.
+EXEC_SECURITY="${EXEC_SECURITY:-deny}"
+EXEC_ASK="${EXEC_ASK:-always}"
+WORKSPACE_ONLY="${WORKSPACE_ONLY:-true}"
+DOCKER_COMPOSE_READ_ONLY="${DOCKER_COMPOSE_READ_ONLY:-true}"
+
+security_mismatches=()
+[[ "$EXEC_SECURITY" == "full" ]] ||
+  security_mismatches+=("EXEC_SECURITY")
+[[ "$EXEC_ASK" == "off" ]] ||
+  security_mismatches+=("EXEC_ASK")
+[[ "$WORKSPACE_ONLY" == "false" ]] ||
+  security_mismatches+=("WORKSPACE_ONLY")
+
+if (( ${#security_mismatches[@]} > 0 )); then
+  echo "Error: ClawBio benchmark security preflight failed before fleet setup." >&2
+  echo "ClawBio loads its skill outside the workspace and executes unattended commands." >&2
+  echo "Incompatible settings:" >&2
+  for setting in "${security_mismatches[@]}"; do
+    case "$setting" in
+      EXEC_SECURITY) required="full" ;;
+      EXEC_ASK) required="off" ;;
+      WORKSPACE_ONLY) required="false" ;;
+    esac
+    printf '  %s=%q (required: %q)\n' "$setting" "${!setting}" "$required" >&2
+  done
+  cat >&2 <<EOF
+Set these values explicitly for the ClawBio launch:
+  EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \\
+    ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+See Tasks/clawBio/README.md#clawbio-benchmark-security.
+The general OpenClaw security defaults were not changed.
+EOF
+  exit 2
+fi
 
 # TRACE_TO_OPIK is the authoritative switch documented in the root README:
 # tracing off forces the plugin off, even over an explicit
@@ -228,10 +270,12 @@ if [[ -n "$API_KEY" ]]; then env_args+=("API_KEY=$API_KEY"); fi
 if [[ -n "$MODEL" ]]; then env_args+=("MODEL=$MODEL"); fi
 if [[ -n "$COUNT" ]]; then env_args+=("COUNT=$COUNT"); fi
 if [[ -n "${SANDBOX_MODE:-}" ]]; then env_args+=("SANDBOX_MODE=$SANDBOX_MODE"); fi
-if [[ -n "${EXEC_SECURITY:-}" ]]; then env_args+=("EXEC_SECURITY=$EXEC_SECURITY"); fi
-if [[ -n "${EXEC_ASK:-}" ]]; then env_args+=("EXEC_ASK=$EXEC_ASK"); fi
-if [[ -n "${WORKSPACE_ONLY:-}" ]]; then env_args+=("WORKSPACE_ONLY=$WORKSPACE_ONLY"); fi
-if [[ -n "${DOCKER_COMPOSE_READ_ONLY:-}" ]]; then env_args+=("DOCKER_COMPOSE_READ_ONLY=$DOCKER_COMPOSE_READ_ONLY"); fi
+env_args+=(
+  "EXEC_SECURITY=$EXEC_SECURITY"
+  "EXEC_ASK=$EXEC_ASK"
+  "WORKSPACE_ONLY=$WORKSPACE_ONLY"
+  "DOCKER_COMPOSE_READ_ONLY=$DOCKER_COMPOSE_READ_ONLY"
+)
 
 if [[ -n "$COUNT" ]]; then
   env "${env_args[@]}" "$OPENCLAW_DIR/scripts/setup.sh" "$COUNT"

--- a/Tasks/clawBio/tests/test_run_benchmark.py
+++ b/Tasks/clawBio/tests/test_run_benchmark.py
@@ -90,6 +90,7 @@ class ClawBioRunnerTest(unittest.TestCase):
                 {
                     "TASK_CONFIG": str(config),
                     "RUN_ROOT": str(run_root),
+                    "SANDBOX_MODE": "all",
                     "EXEC_SECURITY": "deny",
                     "EXEC_ASK": "always",
                     "WORKSPACE_ONLY": "true",
@@ -108,6 +109,7 @@ class ClawBioRunnerTest(unittest.TestCase):
                 {
                     "RUN_ROOT": str(run_root),
                     "TRACE_TO_OPIK": "false",
+                    "SANDBOX_MODE": "non-main",
                     "EXEC_SECURITY": "deny",
                     "EXEC_ASK": "always",
                     "WORKSPACE_ONLY": "true",
@@ -117,6 +119,7 @@ class ClawBioRunnerTest(unittest.TestCase):
             self.assertEqual(result.returncode, 2)
             self.assertIn("security preflight failed before fleet setup", result.stderr)
             for setting in (
+                "SANDBOX_MODE",
                 "EXEC_SECURITY",
                 "EXEC_ASK",
                 "WORKSPACE_ONLY",
@@ -133,6 +136,7 @@ class ClawBioRunnerTest(unittest.TestCase):
                     "TRACE_TO_OPIK": "true",
                     "OPIK_PLUGIN": "enabled",
                     "OPIK_URL": "",
+                    "SANDBOX_MODE": "off",
                     "EXEC_SECURITY": "full",
                     "EXEC_ASK": "off",
                     "WORKSPACE_ONLY": "false",

--- a/Tasks/clawBio/tests/test_run_benchmark.py
+++ b/Tasks/clawBio/tests/test_run_benchmark.py
@@ -25,6 +25,13 @@ class ClawBioRunnerTest(unittest.TestCase):
         *args: str,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
+        for setting in (
+            "SANDBOX_MODE",
+            "EXEC_SECURITY",
+            "EXEC_ASK",
+            "WORKSPACE_ONLY",
+        ):
+            env.pop(setting, None)
         env.update(env_overrides)
         return subprocess.run(
             [str(WRAPPER_PATH), *args],
@@ -127,7 +134,7 @@ class ClawBioRunnerTest(unittest.TestCase):
                 self.assertIn(setting, result.stderr)
             self.assertFalse(run_root.exists())
 
-    def test_wrapper_accepts_explicit_benchmark_security(self) -> None:
+    def test_wrapper_loads_dedicated_benchmark_security(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             run_root = Path(tmp) / "run"
             result = self.run_wrapper(
@@ -136,16 +143,16 @@ class ClawBioRunnerTest(unittest.TestCase):
                     "TRACE_TO_OPIK": "true",
                     "OPIK_PLUGIN": "enabled",
                     "OPIK_URL": "",
-                    "SANDBOX_MODE": "off",
-                    "EXEC_SECURITY": "full",
-                    "EXEC_ASK": "off",
-                    "WORKSPACE_ONLY": "false",
                     "DOCKER_COMPOSE_READ_ONLY": "true",
                 }
             )
 
             self.assertEqual(result.returncode, 1)
             self.assertIn("OPIK_PLUGIN=enabled requires OPIK_URL", result.stderr)
+            self.assertIn(
+                "applying the permissive ClawBio benchmark profile",
+                result.stderr,
+            )
             self.assertNotIn("security preflight failed", result.stderr)
             self.assertFalse(run_root.exists())
 

--- a/Tasks/clawBio/tests/test_run_benchmark.py
+++ b/Tasks/clawBio/tests/test_run_benchmark.py
@@ -20,6 +20,21 @@ SPEC.loader.exec_module(run_benchmark)
 
 class ClawBioRunnerTest(unittest.TestCase):
     @staticmethod
+    def run_wrapper(
+        env_overrides: dict[str, str],
+        *args: str,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(env_overrides)
+        return subprocess.run(
+            [str(WRAPPER_PATH), *args],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    @staticmethod
     def sample_tasks() -> list[dict[str, str]]:
         return [
             {"id": "task-a", "prompt": "A"},
@@ -54,21 +69,14 @@ class ClawBioRunnerTest(unittest.TestCase):
                 '{"defaults":{},"tasks":[{"id":"task-a","prompt":"A"}]}',
                 encoding="utf-8",
             )
-            env = os.environ.copy()
-            env.update(
+            result = self.run_wrapper(
                 {
                     "TASK_CONFIG": str(config),
                     "RUN_ROOT": str(run_root),
                     "TRACE_TO_OPIK": "false",
-                }
-            )
-
-            result = subprocess.run(
-                [str(WRAPPER_PATH), "--tasks", "missing-a,missing-b"],
-                env=env,
-                text=True,
-                capture_output=True,
-                check=False,
+                },
+                "--tasks",
+                "missing-a,missing-b",
             )
 
             self.assertNotEqual(result.returncode, 0)
@@ -76,6 +84,65 @@ class ClawBioRunnerTest(unittest.TestCase):
                 "unknown ClawBio task(s): missing-a, missing-b",
                 result.stderr,
             )
+            self.assertFalse(run_root.exists())
+
+            valid = self.run_wrapper(
+                {
+                    "TASK_CONFIG": str(config),
+                    "RUN_ROOT": str(run_root),
+                    "EXEC_SECURITY": "deny",
+                    "EXEC_ASK": "always",
+                    "WORKSPACE_ONLY": "true",
+                },
+                "--tasks",
+                "task-a",
+                "--validate-tasks-only",
+            )
+            self.assertEqual(valid.returncode, 0, valid.stderr)
+            self.assertFalse(run_root.exists())
+
+    def test_wrapper_rejects_restrictive_security_before_run_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run_root = Path(tmp) / "run"
+            result = self.run_wrapper(
+                {
+                    "RUN_ROOT": str(run_root),
+                    "TRACE_TO_OPIK": "false",
+                    "EXEC_SECURITY": "deny",
+                    "EXEC_ASK": "always",
+                    "WORKSPACE_ONLY": "true",
+                }
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("security preflight failed before fleet setup", result.stderr)
+            for setting in (
+                "EXEC_SECURITY",
+                "EXEC_ASK",
+                "WORKSPACE_ONLY",
+            ):
+                self.assertIn(setting, result.stderr)
+            self.assertFalse(run_root.exists())
+
+    def test_wrapper_accepts_explicit_benchmark_security(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run_root = Path(tmp) / "run"
+            result = self.run_wrapper(
+                {
+                    "RUN_ROOT": str(run_root),
+                    "TRACE_TO_OPIK": "true",
+                    "OPIK_PLUGIN": "enabled",
+                    "OPIK_URL": "",
+                    "EXEC_SECURITY": "full",
+                    "EXEC_ASK": "off",
+                    "WORKSPACE_ONLY": "false",
+                    "DOCKER_COMPOSE_READ_ONLY": "true",
+                }
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("OPIK_PLUGIN=enabled requires OPIK_URL", result.stderr)
+            self.assertNotIn("security preflight failed", result.stderr)
             self.assertFalse(run_root.exists())
 
     def test_clear_artifact_paths_removes_declared_outputs_only(self) -> None:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -172,7 +172,8 @@ Examples:
   --task fix-git,break-filter-js-from-html --workers 2
 ./scripts/run_fleet.sh --taskset ./my-taskset --agent opencode --workers 2
 ./scripts/run_fleet.sh --taskset pinchbench --task task_sanity --workers 1
-./scripts/run_fleet.sh --taskset clawbio --task rnaseq-de-demo --workers 1
+EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+  ./scripts/run_fleet.sh --taskset clawbio --task rnaseq-de-demo --workers 1
 ./scripts/run_fleet.sh --taskset terminal-bench/terminal-bench-2-1 \
   --agent claude-code --workers 10 --output fleet-spec.json --dry-run
 ```
@@ -414,11 +415,13 @@ workers to `--instances`, and validates selected IDs against the pinned
 `task_*.md` checkout before image or result creation; the OpenClaw fleet must
 already be configured and running. The `clawbio` taskset calls the existing
 ClawBio unified launcher, maps workers to `COUNT`, and validates selected IDs
-against its task config before setup or fleet restart. Those runners own setup,
-execution, outputs, and failures. If `--agent` conflicts with an OpenClaw
-taskset, the router prints the requested and actual agents, ignores the
-conflicting value, and continues with OpenClaw. OpenClaw runners remain in the
-foreground; `--detach` is ignored with a warning.
+against its task config before setup or fleet restart. The launcher also
+requires the explicit ClawBio benchmark security settings documented in
+`Tasks/clawBio/README.md`; FleetSpec does not store environment variables.
+Those runners own setup, execution, outputs, and failures. If `--agent`
+conflicts with an OpenClaw taskset, the router prints the requested and actual
+agents, ignores the conflicting value, and continues with OpenClaw. OpenClaw
+runners remain in the foreground; `--detach` is ignored with a warning.
 
 ### Current limitations
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -172,8 +172,7 @@ Examples:
   --task fix-git,break-filter-js-from-html --workers 2
 ./scripts/run_fleet.sh --taskset ./my-taskset --agent opencode --workers 2
 ./scripts/run_fleet.sh --taskset pinchbench --task task_sanity --workers 1
-SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
-  ./scripts/run_fleet.sh --taskset clawbio --task rnaseq-de-demo --workers 1
+./scripts/run_fleet.sh --taskset clawbio --task rnaseq-de-demo --workers 1
 ./scripts/run_fleet.sh --taskset terminal-bench/terminal-bench-2-1 \
   --agent claude-code --workers 10 --output fleet-spec.json --dry-run
 ```
@@ -416,8 +415,9 @@ workers to `--instances`, and validates selected IDs against the pinned
 already be configured and running. The `clawbio` taskset calls the existing
 ClawBio unified launcher, maps workers to `COUNT`, and validates selected IDs
 against its task config before setup or fleet restart. The launcher also
-requires the explicit ClawBio benchmark security settings documented in
-`Tasks/clawBio/README.md`; FleetSpec does not store environment variables.
+loads and warns about the dedicated execution profile in
+`Tasks/clawBio/config/benchmark.env`; FleetSpec does not store environment
+variables.
 The ClawBio fleet remains running with that run-specific profile until it is
 stopped or regenerated. Those runners own setup, execution, outputs, and
 failures. If `--agent` conflicts with an OpenClaw taskset, the router prints the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -172,7 +172,7 @@ Examples:
   --task fix-git,break-filter-js-from-html --workers 2
 ./scripts/run_fleet.sh --taskset ./my-taskset --agent opencode --workers 2
 ./scripts/run_fleet.sh --taskset pinchbench --task task_sanity --workers 1
-EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
   ./scripts/run_fleet.sh --taskset clawbio --task rnaseq-de-demo --workers 1
 ./scripts/run_fleet.sh --taskset terminal-bench/terminal-bench-2-1 \
   --agent claude-code --workers 10 --output fleet-spec.json --dry-run
@@ -418,10 +418,12 @@ ClawBio unified launcher, maps workers to `COUNT`, and validates selected IDs
 against its task config before setup or fleet restart. The launcher also
 requires the explicit ClawBio benchmark security settings documented in
 `Tasks/clawBio/README.md`; FleetSpec does not store environment variables.
-Those runners own setup, execution, outputs, and failures. If `--agent`
-conflicts with an OpenClaw taskset, the router prints the requested and actual
-agents, ignores the conflicting value, and continues with OpenClaw. OpenClaw
-runners remain in the foreground; `--detach` is ignored with a warning.
+The ClawBio fleet remains running with that run-specific profile until it is
+stopped or regenerated. Those runners own setup, execution, outputs, and
+failures. If `--agent` conflicts with an OpenClaw taskset, the router prints the
+requested and actual agents, ignores the conflicting value, and continues with
+OpenClaw. OpenClaw runners remain in the foreground; `--detach` is ignored with
+a warning.
 
 ### Current limitations
 

--- a/skills/openclaw-benchmark-runners/SKILL.md
+++ b/skills/openclaw-benchmark-runners/SKILL.md
@@ -68,9 +68,7 @@ Use ClawBio for the bioinformatics benchmark in `Tasks/clawBio/`.
 Normal flow:
 
 ```bash
-SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
-  ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
-SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 COUNT=20 ITERATIONS=3 \
   ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 ```
@@ -79,8 +77,10 @@ Manual flow, when debugging phases:
 
 ```bash
 ./Tasks/clawBio/scripts/prewarm-cache.sh
+set -a
+. ./Tasks/clawBio/config/benchmark.env
+set +a
 PLUGIN_CACHE_DIR=$(pwd)/Tasks/clawBio/cache \
-SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
   ./Agents/Openclaw/scripts/setup.sh 4
 ./Tasks/clawBio/scripts/patch-plugin-config.sh
 docker compose -f Agents/Openclaw/docker-compose.yml up -d
@@ -89,9 +89,10 @@ docker compose -f Agents/Openclaw/docker-compose.yml up -d
 
 `patch-plugin-config.sh` must run after `setup.sh` and before Compose starts
 the fleet. Do not run `run-benchmark.py` immediately after the unified
-launcher unless an additional benchmark run is intentional. The launcher
-leaves the benchmark fleet running with its run-specific execution profile;
-stop or regenerate it before using OpenClaw for another purpose.
+launcher unless an additional benchmark run is intentional. The profile is
+permissive: the launcher loads it with a warning, and the manual flow sources
+it directly. Use it only for a dedicated ClawBio fleet, then stop or regenerate
+that fleet before using OpenClaw for another purpose.
 
 ## Debugging
 
@@ -101,9 +102,8 @@ stop or regenerate it before using OpenClaw for another purpose.
   `PINCHBENCH_MODEL_PROVIDER` in `Tasks/Pinchbench/config/pinchbench.env`.
 - For ClawBio plugin failures, verify the cache path, generated Compose mount,
   and patched `plugins.load.paths` in the generated config.
-- For ClawBio sandbox or exec errors, regenerate the fleet with
-  `SANDBOX_MODE=off`, `EXEC_SECURITY=full`, `EXEC_ASK=off`, and
-  `WORKSPACE_ONLY=false`.
+- For ClawBio sandbox or exec errors, verify
+  `Tasks/clawBio/config/benchmark.env`, then regenerate the fleet.
 - For missing result rows, inspect per-instance logs before changing sharding
   or merge behavior.
 

--- a/skills/openclaw-benchmark-runners/SKILL.md
+++ b/skills/openclaw-benchmark-runners/SKILL.md
@@ -68,15 +68,20 @@ Use ClawBio for the bioinformatics benchmark in `Tasks/clawBio/`.
 Normal flow:
 
 ```bash
-./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
-COUNT=20 ITERATIONS=3 ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+  ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+COUNT=20 ITERATIONS=3 \
+  ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 ```
 
 Manual flow, when debugging phases:
 
 ```bash
 ./Tasks/clawBio/scripts/prewarm-cache.sh
-PLUGIN_CACHE_DIR=$(pwd)/Tasks/clawBio/cache ./Agents/Openclaw/scripts/setup.sh 4
+PLUGIN_CACHE_DIR=$(pwd)/Tasks/clawBio/cache \
+SANDBOX_MODE=off EXEC_SECURITY=full EXEC_ASK=off WORKSPACE_ONLY=false \
+  ./Agents/Openclaw/scripts/setup.sh 4
 ./Tasks/clawBio/scripts/patch-plugin-config.sh
 docker compose -f Agents/Openclaw/docker-compose.yml up -d
 ./Tasks/clawBio/scripts/run-benchmark.py --instances 4
@@ -84,7 +89,9 @@ docker compose -f Agents/Openclaw/docker-compose.yml up -d
 
 `patch-plugin-config.sh` must run after `setup.sh` and before Compose starts
 the fleet. Do not run `run-benchmark.py` immediately after the unified
-launcher unless an additional benchmark run is intentional.
+launcher unless an additional benchmark run is intentional. The launcher
+leaves the benchmark fleet running with its run-specific execution profile;
+stop or regenerate it before using OpenClaw for another purpose.
 
 ## Debugging
 
@@ -94,7 +101,8 @@ launcher unless an additional benchmark run is intentional.
   `PINCHBENCH_MODEL_PROVIDER` in `Tasks/Pinchbench/config/pinchbench.env`.
 - For ClawBio plugin failures, verify the cache path, generated Compose mount,
   and patched `plugins.load.paths` in the generated config.
-- For ClawBio sandbox errors such as path escapes, regenerate the fleet with
+- For ClawBio sandbox or exec errors, regenerate the fleet with
+  `SANDBOX_MODE=off`, `EXEC_SECURITY=full`, `EXEC_ASK=off`, and
   `WORKSPACE_ONLY=false`.
 - For missing result rows, inspect per-instance logs before changing sharding
   or merge behavior.


### PR DESCRIPTION
## 1. Why the change?

The ClawBio unified launcher could inherit incompatible OpenClaw execution settings, prepare caches and images, regenerate and restart the fleet, and only then fail during task execution with errors such as `exec denied` or `path escapes sandbox`. Users received the actionable configuration error after expensive work and fleet side effects had already occurred.

Closes #41.

## 2. Summary of the change

- Add a committed, public-safe `Tasks/clawBio/config/benchmark.env` with the four settings ClawBio requires: `SANDBOX_MODE=off`, `EXEC_SECURITY=full`, `EXEC_ASK=off`, and `WORKSPACE_ONLY=false`.
- Load that dedicated profile after shared and fleet defaults, while keeping runtime environment variables as the highest-precedence overrides.
- Warn users that the profile is permissive and remains active in the generated fleet until it is stopped or regenerated.
- Reject conflicting overrides before run-root creation, image build, cache prewarm, setup, or fleet restart.
- Keep task-selection-only validation side-effect free and independent of runtime security setup.
- Use the simple ClawBio and FleetSpec launch commands in documentation and source the same profile for manual setup.

## 3. Other details

The general OpenClaw defaults remain restrictive and unchanged. ClawBio setup writes the benchmark-only profile into its run-specific generated configs and leaves that fleet running; the launcher and documentation explicitly tell users to stop or regenerate it before other use.

A real `rnaseq-de-demo` canary completed successfully with 11 artifacts while Docker reported `ReadonlyRootfs=true`. Therefore `DOCKER_COMPOSE_READ_ONLY=false` is not required: the container root filesystem remains read-only by default, while ClawBio writes through its dedicated state/workspace mounts and `/tmp` tmpfs.

Validation:

- `python3 -m unittest discover -s Tasks/clawBio/tests` — 10 passed
- `python3 -m unittest discover -s scripts/tests` — 113 passed
- `uvx --offline ruff==0.16.0 check --config .github/ruff.toml`
- Bash syntax and `git diff --check`
- Direct profile-loading smoke check: warning emitted, no run root created before the later Opik preflight
- Real ClawBio canary: `rnaseq-de-demo`, 1/1 success, 11 artifacts, read-only root filesystem