### PR TITLE
Add a manual Pi review canary

### DIFF
--- a/.github/scripts/tests/test_llm_pr_review_workflow.py
+++ b/.github/scripts/tests/test_llm_pr_review_workflow.py
@@ -56,7 +56,7 @@ class LlmPrReviewWorkflowTest(unittest.TestCase):
                 "group: self-hosted-llm-pr-review-"
                 "${{ github.event.pull_request.number }}"
             ),
-            "runs-on: [self-hosted, Linux, X64]",
+            "runs-on: [self-hosted, Linux, X64, container, code-review]",
             "environment: self-hosted-env",
             "LLM_REVIEW_ID: self-hosted-pi-pr-review",
         )

--- a/.github/scripts/tests/test_pi_review_canary_workflow.py
+++ b/.github/scripts/tests/test_pi_review_canary_workflow.py
@@ -47,13 +47,8 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
             self.workflow,
         )
 
-    def test_starts_review_budget_before_target_setup(self) -> None:
-        budget = self.workflow.index("- name: Start review budget")
-        target = self.workflow.index("- name: Resolve review target")
-
-        self.assertLess(budget, target)
-        self.assertIn("PI_REVIEW_DEADLINE_EPOCH", self.workflow)
-        self.assertIn("$(date +%s) + 900", self.workflow)
+    def test_does_not_define_an_unenforced_review_deadline(self) -> None:
+        self.assertNotIn("PI_REVIEW_DEADLINE_EPOCH", self.workflow)
 
     def test_requires_a_containerized_code_review_runner(self) -> None:
         self.assertIn(

--- a/.github/scripts/tests/test_pi_review_canary_workflow.py
+++ b/.github/scripts/tests/test_pi_review_canary_workflow.py
@@ -44,6 +44,14 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
             self.workflow,
         )
 
+    def test_starts_review_budget_before_target_setup(self) -> None:
+        budget = self.workflow.index("- name: Start review budget")
+        target = self.workflow.index("- name: Resolve review target")
+
+        self.assertLess(budget, target)
+        self.assertIn("PI_REVIEW_DEADLINE_EPOCH", self.workflow)
+        self.assertIn("$(date +%s) + 900", self.workflow)
+
     def test_requires_a_containerized_code_review_runner(self) -> None:
         self.assertIn(
             "runs-on: [self-hosted, Linux, X64, container, code-review]",

--- a/.github/scripts/tests/test_pi_review_canary_workflow.py
+++ b/.github/scripts/tests/test_pi_review_canary_workflow.py
@@ -19,7 +19,7 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
                 r"pr_number:\n"
                 r"\s+description: Open pull request number to review\n"
                 r"\s+required: true\n"
-                r"\s+type: string"
+                r"\s+type: number"
             ),
         )
 
@@ -56,9 +56,12 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
             self.workflow,
         )
 
-    def test_canary_has_a_separate_review_id_and_concurrency_group(self) -> None:
+    def test_canary_has_a_unique_review_id_and_concurrency_group(self) -> None:
         self.assertIn("self-hosted-pi-pr-review${{", self.workflow)
-        self.assertIn("'-canary'", self.workflow)
+        self.assertIn(
+            "format('-canary-{0}-{1}', github.run_id, github.run_attempt)",
+            self.workflow,
+        )
         self.assertIn(
             "${{ github.event.pull_request.number }}-${{ github.event_name }}-",
             self.workflow,

--- a/.github/scripts/tests/test_pi_review_canary_workflow.py
+++ b/.github/scripts/tests/test_pi_review_canary_workflow.py
@@ -44,6 +44,12 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
             self.workflow,
         )
 
+    def test_requires_a_containerized_code_review_runner(self) -> None:
+        self.assertIn(
+            "runs-on: [self-hosted, Linux, X64, container, code-review]",
+            self.workflow,
+        )
+
     def test_canary_has_a_separate_review_id_and_concurrency_group(self) -> None:
         self.assertIn("self-hosted-pi-pr-review${{", self.workflow)
         self.assertIn("'-canary'", self.workflow)

--- a/.github/scripts/tests/test_pi_review_canary_workflow.py
+++ b/.github/scripts/tests/test_pi_review_canary_workflow.py
@@ -1,0 +1,58 @@
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "self-hosted-llm-pr-review.yml"
+
+
+class PiReviewCanaryWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_accepts_a_required_pull_request_number(self) -> None:
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertRegex(
+            self.workflow,
+            re.compile(
+                r"pr_number:\n"
+                r"\s+description: Open pull request number to review\n"
+                r"\s+required: true\n"
+                r"\s+type: string"
+            ),
+        )
+
+    def test_resolves_and_validates_the_manual_target(self) -> None:
+        expected = (
+            "name: Resolve review target",
+            "inputs.pr_number",
+            "api.github.com/repos",
+            'pull.get("state") != "open"',
+            'pull["base"]["repo"]["full_name"]',
+            're.fullmatch(r"[0-9a-f]{40}", value)',
+        )
+        for value in expected:
+            with self.subTest(value=value):
+                self.assertIn(value, self.workflow)
+
+    def test_checks_out_the_resolved_trusted_base(self) -> None:
+        self.assertIn("ref: ${{ steps.target.outputs.base_sha", self.workflow)
+        self.assertIn("persist-credentials: false", self.workflow)
+        self.assertIn(
+            '--event-path "${{ steps.target.outputs.event_path }}"',
+            self.workflow,
+        )
+
+    def test_canary_has_a_separate_review_id_and_concurrency_group(self) -> None:
+        self.assertIn("self-hosted-pi-pr-review${{", self.workflow)
+        self.assertIn("'-canary'", self.workflow)
+        self.assertIn(
+            "${{ github.event.pull_request.number }}-${{ github.event_name }}-",
+            self.workflow,
+        )
+        self.assertIn("${{ inputs.pr_number }}", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_pi_review_canary_workflow.py
+++ b/.github/scripts/tests/test_pi_review_canary_workflow.py
@@ -36,6 +36,9 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertIn(value, self.workflow)
 
+    def test_resolves_target_with_isolated_python(self) -> None:
+        self.assertIn("python3 -I - <<'PY'", self.workflow)
+
     def test_checks_out_the_resolved_trusted_base(self) -> None:
         self.assertIn("ref: ${{ steps.target.outputs.base_sha", self.workflow)
         self.assertIn("persist-credentials: false", self.workflow)

--- a/.github/workflows/self-hosted-llm-pr-review.yml
+++ b/.github/workflows/self-hosted-llm-pr-review.yml
@@ -25,11 +25,6 @@ jobs:
     environment: self-hosted-env
     timeout-minutes: 20
     steps:
-      - name: Start review budget
-        run: |
-          set -euo pipefail
-          echo "PI_REVIEW_DEADLINE_EPOCH=$(($(date +%s) + 900))" >> "$GITHUB_ENV"
-
       - name: Resolve review target
         id: target
         env:

--- a/.github/workflows/self-hosted-llm-pr-review.yml
+++ b/.github/workflows/self-hosted-llm-pr-review.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   review:
     name: Self-hosted review
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, container, code-review]
     environment: self-hosted-env
     timeout-minutes: 20
     steps:

--- a/.github/workflows/self-hosted-llm-pr-review.yml
+++ b/.github/workflows/self-hosted-llm-pr-review.yml
@@ -25,6 +25,11 @@ jobs:
     environment: self-hosted-env
     timeout-minutes: 20
     steps:
+      - name: Start review budget
+        run: |
+          set -euo pipefail
+          echo "PI_REVIEW_DEADLINE_EPOCH=$(($(date +%s) + 900))" >> "$GITHUB_ENV"
+
       - name: Resolve review target
         id: target
         env:

--- a/.github/workflows/self-hosted-llm-pr-review.yml
+++ b/.github/workflows/self-hosted-llm-pr-review.yml
@@ -8,7 +8,7 @@ name: Self-Hosted LLM PR Review
       pr_number:
         description: Open pull request number to review
         required: true
-        type: string
+        type: number
 
 permissions:
   contents: read
@@ -110,7 +110,7 @@ jobs:
           LLM_REVIEW_API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
           LLM_REVIEW_BASE_URL: ${{ vars.LLM_REVIEW_BASE_URL }}
           LLM_REVIEW_MODEL: ${{ vars.LLM_REVIEW_MODEL }}
-          LLM_REVIEW_ID: self-hosted-pi-pr-review${{ github.event_name == 'workflow_dispatch' && '-canary' || '' }}
+          LLM_REVIEW_ID: self-hosted-pi-pr-review${{ github.event_name == 'workflow_dispatch' && format('-canary-{0}-{1}', github.run_id, github.run_attempt) || '' }}
         run: >-
           python3 .github/scripts/pi_pr_review.py
           --event-path "${{ steps.target.outputs.event_path }}"

--- a/.github/workflows/self-hosted-llm-pr-review.yml
+++ b/.github/workflows/self-hosted-llm-pr-review.yml
@@ -41,7 +41,7 @@ jobs:
           TEMPORARY_DIRECTORY: ${{ runner.temp }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
+          python3 -I - <<'PY'
           import json
           import os
           import re

--- a/.github/workflows/self-hosted-llm-pr-review.yml
+++ b/.github/workflows/self-hosted-llm-pr-review.yml
@@ -3,13 +3,19 @@ name: Self-Hosted LLM PR Review
 "on":
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open pull request number to review
+        required: true
+        type: string
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: self-hosted-llm-pr-review-${{ github.event.pull_request.number }}
+  group: self-hosted-llm-pr-review-${{ github.event.pull_request.number }}-${{ github.event_name }}-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -19,10 +25,72 @@ jobs:
     environment: self-hosted-env
     timeout-minutes: 20
     steps:
+      - name: Resolve review target
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PATH: ${{ github.event_path }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          TEMPORARY_DIRECTORY: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+          from urllib.request import Request, urlopen
+
+          if os.environ["EVENT_NAME"] == "pull_request_target":
+              event_path = Path(os.environ["EVENT_PATH"])
+              event = json.loads(event_path.read_text(encoding="utf-8"))
+          else:
+              number = int(os.environ["INPUT_PR_NUMBER"])
+              if number < 1:
+                  raise ValueError("pr_number must be positive")
+              request = Request(
+                  (
+                      "https://api.github.com/repos/"
+                      f"{os.environ['REPOSITORY']}/pulls/{number}"
+                  ),
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urlopen(request, timeout=30) as response:
+                  pull = json.loads(response.read())
+              if pull.get("state") != "open":
+                  raise ValueError("pr_number must identify an open pull request")
+              if pull["base"]["repo"]["full_name"] != os.environ["REPOSITORY"]:
+                  raise ValueError("pull request base repository does not match")
+              event = {"pull_request": pull}
+              event_path = (
+                  Path(os.environ["TEMPORARY_DIRECTORY"])
+                  / "pr-review-event.json"
+              )
+              event_path.write_text(json.dumps(event), encoding="utf-8")
+
+          pull = event["pull_request"]
+          base_sha = pull["base"]["sha"]
+          head_sha = pull["head"]["sha"]
+          if not all(
+              re.fullmatch(r"[0-9a-f]{40}", value)
+              for value in (base_sha, head_sha)
+          ):
+              raise ValueError("pull request revisions must be full SHAs")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"base_sha={base_sha}\n")
+              output.write(f"event_path={event_path}\n")
+          PY
+
       - name: Check out trusted base revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ steps.target.outputs.base_sha || github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Verify pi is available
@@ -42,8 +110,8 @@ jobs:
           LLM_REVIEW_API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
           LLM_REVIEW_BASE_URL: ${{ vars.LLM_REVIEW_BASE_URL }}
           LLM_REVIEW_MODEL: ${{ vars.LLM_REVIEW_MODEL }}
-          LLM_REVIEW_ID: self-hosted-pi-pr-review
+          LLM_REVIEW_ID: self-hosted-pi-pr-review${{ github.event_name == 'workflow_dispatch' && '-canary' || '' }}
         run: >-
           python3 .github/scripts/pi_pr_review.py
-          --event-path "$GITHUB_EVENT_PATH"
+          --event-path "${{ steps.target.outputs.event_path }}"
           --prompt-path .github/scripts/pi_review_prompt.md


### PR DESCRIPTION
## 1. Why the change?

The Pi workflow needs a safe, repeatable manual provider canary against an actual open pull request. The manual path must preserve the trusted-base review contract, avoid concurrency and duplicate-review collisions with automatic runs, and stay on the containerized code-review runner pool.

## 2. Summary of the change

- Add a required numeric `workflow_dispatch` input for the pull request number.
- Resolve the review target before checkout: reuse the native event for automatic runs, or fetch and validate an open pull request for manual runs.
- Require the target to use this repository as its base and require full 40-character base and head SHAs before synthesizing the reviewer event under `runner.temp`.
- Run pre-checkout target resolution with isolated Python mode so stale self-hosted workspace modules cannot load while `GH_TOKEN` is available.
- Check out the resolved trusted base revision with persisted credentials disabled.
- Keep automatic and manual runs in separate concurrency groups; the numeric input canonicalizes the manual PR key.
- Give each manual run and re-run a unique canary review ID using the workflow run ID and attempt, while preserving the stable production review ID for automatic runs.
- Require the `self-hosted`, `Linux`, `X64`, `container`, and `code-review` runner labels.
- Add workflow contract coverage for target validation, isolated execution, trusted-base checkout, runner selection, concurrency, and repeatable canary IDs.

## 3. Other details

This is an independent, same-base replacement for the closed draft #46 and is based directly on `main` at `db9b09e`.

Verification on head `36d4e79`:

- 144 GitHub-script tests
- Ruff with the repository configuration
- `git diff --check`
- GitHub Ruff check
- Self-hosted Pi review with complete coverage and no actionable findings
- All six review threads resolved

Generic self-hosted Linux/X64 labels can select bare runners; the `container` and `code-review` labels constrain Pi execution to the existing review-runner pool.

A real provider-backed manual canary can run only after this workflow is present on the default branch. The current `pull_request_target` check executes trusted default-branch workflow code, so its success does not prove the new dispatch, target-resolution, or runner-selection path.
