### PR TITLE
Fix Harbor benchmark PID identity mismatch

### DIFF
--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -65,7 +65,11 @@ if harbor_is_native_registry_main; then
   : > "$HARBOR_JOB_DIR_FILE"
   rm -f "$HARBOR_BENCHMARK_EXIT_FILE"
   # BASHPID needs bash >= 4; at this top-level scope $$ is the same pid.
-  printf '%s\t%s\n' "${BASHPID:-$$}" "$(awk '{print $22}' "/proc/${BASHPID:-$$}/stat")" > "$HARBOR_BENCHMARK_PID_FILE"
+  harbor_benchmark_pid="${BASHPID:-$$}"
+  printf '%s\t%s\n' \
+    "$harbor_benchmark_pid" \
+    "$(awk '{print $22}' "/proc/$harbor_benchmark_pid/stat")" \
+    > "$HARBOR_BENCHMARK_PID_FILE"
   record_harbor_benchmark_exit() {
     local rc="$?"
     # The exit file is the completion contract with the registry monitor;

--- a/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
@@ -75,6 +75,16 @@ inherited = {name: os.environ[name] for name in connection_fields if name in os.
 Path(f"{capture}.opik-environment").write_text(json.dumps(inherited, sort_keys=True))
 
 if os.environ.get("HARBOR_CAPTURE_RESULT") == "1":
+    pid_file = Path(os.environ["HARBOR_BENCHMARK_PID_FILE"])
+    if pid_file.is_file():
+        recorded_pid, recorded_start_time = pid_file.read_text().split()
+        actual_start_time = Path(f"/proc/{recorded_pid}/stat").read_text().split()[21]
+        if recorded_start_time != actual_start_time:
+            raise SystemExit(
+                "benchmark PID identity mismatch: "
+                f"pid={recorded_pid} recorded={recorded_start_time} actual={actual_start_time}"
+            )
+        Path(f"{capture}.pid-identity").write_text("valid")
     output = Path(args[args.index("-o") + 1]) / "fake-run"
     output.mkdir(parents=True, exist_ok=True)
     result = {
@@ -357,6 +367,7 @@ main() {
   run_harboropik \
     "claude-code" "$capture_bin" "$registry_capture" "$tmp/claude-registry" \
     "codepde@1.0" "" "true" "0"
+  assert_file_content "${registry_capture}.pid-identity" "valid"
   assert_registry_summary "$tmp/claude-registry/run/summary.txt"
   assert_registry_summary_requires_result "$tmp/registry-missing-result"
 


### PR DESCRIPTION
## Summary

- capture the outer Harbor wrapper PID before entering command substitution
- write the PID and `/proc/<pid>/stat` start time from the same process
- add native-registry integration coverage for the PID identity contract

## Root cause

`BASHPID` was evaluated again inside `$(...)`, where it referred to the command-substitution child rather than the outer Harbor wrapper. The PID file could therefore contain the wrapper PID paired with the child process start time, causing the monitor to treat a live benchmark as an abnormal exit.

Fixes https://github.com/sii-system/agent-fleet/issues/52

## Testing

- `bash -n Agents/utils/common/Harbor/harboropik.sh Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh`
- `bash Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh`
- `git diff --check`