### PR TITLE
Run DinD setup as the host-aligned user

### DIFF
--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -355,7 +355,7 @@ if [[ "$DIND_USER" != "root" ]]; then
   if [[ "$current_uid" != "$DIND_USER_UID" || "$current_gid" != "$DIND_USER_GID" ]]; then
     docker exec "$DIND_NAME" usermod -o -u "$DIND_USER_UID" -g "$DIND_USER_GID" "$DIND_USER"
   fi
-  docker exec "$DIND_NAME" chown -R "$DIND_USER:$DIND_USER" "$DIND_HOME_DIR"
+  docker exec "$DIND_NAME" chown -R "$DIND_USER_UID:$DIND_USER_GID" "$DIND_HOME_DIR"
 fi
 
 declare -a exec_base=(exec --user "$DIND_USER")

--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -355,7 +355,7 @@ if [[ "$DIND_USER" != "root" ]]; then
   if [[ "$current_uid" != "$DIND_USER_UID" || "$current_gid" != "$DIND_USER_GID" ]]; then
     docker exec "$DIND_NAME" usermod -o -u "$DIND_USER_UID" -g "$DIND_USER_GID" "$DIND_USER"
   fi
-  docker exec "$DIND_NAME" chown -R "$DIND_USER" "$DIND_HOME_DIR"
+  docker exec "$DIND_NAME" chown -R "$DIND_USER:$DIND_USER" "$DIND_HOME_DIR"
 fi
 
 declare -a exec_base=(exec --user "$DIND_USER")
@@ -393,10 +393,6 @@ docker_exec_env() {
   docker_exec env "${run_env[@]}" "$@"
 }
 
-docker_exec_root_env() {
-  docker exec "$DIND_NAME" env "${run_env[@]}" "$@"
-}
-
 run_setup=0
 case "$DIND_BOOTSTRAP" in
   always)
@@ -420,10 +416,7 @@ esac
 
 if [[ "$run_setup" == "1" ]]; then
   info "running scripts/setup.sh inside DinD"
-  docker_exec_root_env ./scripts/setup.sh
-  if [[ "$DIND_USER" != "root" ]]; then
-    docker exec "$DIND_NAME" chown -R "$DIND_USER" "$DIND_HOME_DIR"
-  fi
+  docker_exec_env ./scripts/setup.sh
 fi
 
 info "running scripts/run_fleet.sh ${fleet_args[*]} inside DinD"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -430,12 +430,48 @@ if [[ -n "${CLAUDE_TGZ_SOURCE:-}" && -n "${CLAUDE_WHEEL_DIR_SOURCE:-}" ]]; then
 fi
 
 # ---- 7. Clone repo ----
-if git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+repo_destination_has_entries() (
+  local entries=()
+  shopt -s dotglob nullglob
+  entries=("$1"/*)
+  (( ${#entries[@]} > 0 ))
+)
+
+git_probe_output=""
+if git_probe_output="$(git -C "$REPO_DIR" rev-parse --git-dir 2>&1)"; then
   ok "Repo already exists: $REPO_DIR (skip clone)"
 else
-  info "Cloning repo to $REPO_DIR..."
-  git clone --recurse-submodules "$REPO_URL" "$REPO_DIR"
-  ok "Repo cloned"
+  git_probe_status=$?
+  if [[ -e "$REPO_DIR/.git" || -L "$REPO_DIR/.git" ]]; then
+    err "Cannot inspect existing repository at $REPO_DIR; refusing to clone over it."
+  elif [[ -e "$REPO_DIR" || -L "$REPO_DIR" ]]; then
+    if [[ ! -d "$REPO_DIR" ]]; then
+      err "Repository destination exists and is not a directory: $REPO_DIR"
+    elif [[ ! -r "$REPO_DIR" || ! -x "$REPO_DIR" ]]; then
+      err "Cannot inspect repository destination: $REPO_DIR"
+    elif repo_destination_has_entries "$REPO_DIR"; then
+      err "Git repository probe failed and destination is not empty: $REPO_DIR"
+    else
+      info "Cloning repo to $REPO_DIR..."
+      git clone --recurse-submodules "$REPO_URL" "$REPO_DIR"
+      ok "Repo cloned"
+      git_probe_status=0
+    fi
+  else
+    info "Cloning repo to $REPO_DIR..."
+    git clone --recurse-submodules "$REPO_URL" "$REPO_DIR"
+    ok "Repo cloned"
+    git_probe_status=0
+  fi
+
+  if [[ "$git_probe_status" != "0" ]]; then
+    if [[ -n "$git_probe_output" ]]; then
+      printf '%s\n' "$git_probe_output" >&2
+    else
+      err "git rev-parse failed with status $git_probe_status"
+    fi
+    exit "$git_probe_status"
+  fi
 fi
 info "Syncing submodules..."
 if ! git -C "$REPO_DIR" submodule sync --recursive ||

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -90,6 +90,8 @@ chmod +x "$TMP_DIR/bin/docker"
 
 PATH="$TMP_DIR/bin:$PATH" \
 DIND_BOOTSTRAP=always \
+DIND_USER_UID=1234 \
+DIND_USER_GID=5678 \
 HTTP_PROXY=http://proxy.invalid:8080 \
 HTTPS_PROXY=http://proxy.invalid:8443 \
 NO_PROXY=existing.example \
@@ -132,7 +134,7 @@ if grep -q -- '^docker <exec> <agent-fleet-dind> <env> .* <./scripts/setup.sh>$'
   exit 1
 fi
 home_chown_count="$(
-  grep -c -- '^docker <exec> <agent-fleet-dind> <chown> <-R> <agent:agent> </home/agent>$' "$LOG" ||
+  grep -c -- '^docker <exec> <agent-fleet-dind> <chown> <-R> <1234:5678> </home/agent>$' "$LOG" ||
     true
 )"
 if [[ "$home_chown_count" != "1" ]]; then

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -11,6 +11,10 @@ mkdir -p \
   "$PROJECT_DIR/Agents/utils/common/Harbor" \
   "$TMP_DIR/bin"
 cp "$REPO_ROOT/scripts/dind-run.sh" "$PROJECT_DIR/scripts/dind-run.sh"
+if grep -q -- 'docker_exec_root_env' "$PROJECT_DIR/scripts/dind-run.sh"; then
+  echo "dind-run.sh still defines or uses the root setup helper" >&2
+  exit 1
+fi
 # First-occurrence rewrite via python: GNU sed's -i and 0,/re/ addressing
 # are unavailable in the BSD sed shipped on macOS.
 python3 - "$PROJECT_DIR/scripts/dind-run.sh" <<'PY'
@@ -122,6 +126,19 @@ if grep -q -- '<sh> <-lc>.*apk add' "$LOG"; then
   exit 1
 fi
 grep -q -- '<./scripts/setup.sh>' "$LOG"
+grep -q -- '^docker <exec> <--user> <agent> <agent-fleet-dind> <env> .* <./scripts/setup.sh>$' "$LOG"
+if grep -q -- '^docker <exec> <agent-fleet-dind> <env> .* <./scripts/setup.sh>$' "$LOG"; then
+  echo "dind-run.sh ran setup as container root" >&2
+  exit 1
+fi
+home_chown_count="$(
+  grep -c -- '^docker <exec> <agent-fleet-dind> <chown> <-R> <agent:agent> </home/agent>$' "$LOG" ||
+    true
+)"
+if [[ "$home_chown_count" != "1" ]]; then
+  echo "dind-run.sh should prepare the home volume once before non-root setup" >&2
+  exit 1
+fi
 grep -q -- '<./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>' "$LOG"
 
 mkdir -p "$TMP_DIR/existing-bin"
@@ -192,7 +209,7 @@ DIND_TEST_ASSUME_HOST=0 \
 "$PROJECT_DIR/scripts/dind-run.sh" --taskset terminalbench21 --agent claude-code --workers 1 --dry-run > "$FALLBACK_LOG" 2>&1
 
 grep -q -- '\[WARN\] dind-run.sh cannot start DinD inside a container; running scripts/run_fleet.sh directly' "$FALLBACK_LOG"
-grep -q -- 'Command: env DATASET_NAME=terminalbench21 AGENT=claude-code TB_AGENT=claude-code TOTAL_WORKERS=1 TB_N_CONCURRENT=1 bash' "$FALLBACK_LOG"
+grep -q -- 'Command: env DATASET_NAME=terminalbench21 AGENT=claude-code TB_AGENT=claude-code TOTAL_WORKERS=1 TB_N_CONCURRENT=1 FLEET_TASKS= bash' "$FALLBACK_LOG"
 if grep -q '^docker' "$FALLBACK_LOG"; then
   echo "dind-run.sh invoked Docker after detecting a container" >&2
   exit 1

--- a/scripts/tests/test_setup.py
+++ b/scripts/tests/test_setup.py
@@ -80,6 +80,24 @@ echo '9.9.9'
             "git",
             """#!/usr/bin/env bash
 printf '%s\n' "$*" >>"$SETUP_TEST_STATE/git.log"
+if [[ "${1:-}" == "-C" && "${3:-}" == "rev-parse" && "${4:-}" == "--git-dir" ]]; then
+  if [[ -n "${SETUP_TEST_GIT_REV_PARSE_ERROR:-}" ]]; then
+    printf '%s\n' "$SETUP_TEST_GIT_REV_PARSE_ERROR" >&2
+    exit "${SETUP_TEST_GIT_REV_PARSE_STATUS:-128}"
+  fi
+  printf '.git\n'
+fi
+if [[ "${1:-}" == "clone" ]]; then
+  destination="${@: -1}"
+  mkdir -p "$destination/.git"
+  for skill in \
+    harbor-benchmark-runner \
+    openclaw-fleet-operations \
+    openclaw-benchmark-runners; do
+    mkdir -p "$destination/skills/$skill"
+    printf '# fixture\n' >"$destination/skills/$skill/SKILL.md"
+  done
+fi
 """,
         )
         for command in ("curl", "jq"):
@@ -243,6 +261,7 @@ exit 0
         self.assertFalse((self.state / "shadow-pi.log").exists())
         self.assertNotIn("anthropic-ai", npm_log)
         git_log = (self.state / "git.log").read_text(encoding="utf-8")
+        self.assertNotIn("clone", git_log)
         self.assertIn("submodule sync --recursive", git_log)
         self.assertIn("submodule update --init --recursive", git_log)
 
@@ -414,6 +433,103 @@ exit 0
         gitignore = SETUP.parents[1] / ".gitignore"
         patterns = gitignore.read_text(encoding="utf-8").splitlines()
         self.assertIn("*.local.env.bak.agent-fleet", patterns)
+
+    def test_setup_reports_git_failure_for_existing_checkout_without_cloning(self):
+        env = self.setup_env()
+        env.update(
+            {
+                "BASE_URL": "https://gateway.example.invalid",
+                "API_KEY": "fake-setup-secret",
+                "MODEL": "test-model",
+                "TRACE_TO_OPIK": "false",
+                "SETUP_TEST_GIT_REV_PARSE_ERROR": (
+                    "fatal: detected dubious ownership in repository"
+                ),
+            }
+        )
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot inspect existing repository", result.stderr.lower())
+        self.assertIn("fatal: detected dubious ownership", result.stderr)
+        git_log = (self.state / "git.log").read_text(encoding="utf-8")
+        self.assertNotIn("clone", git_log)
+        self.assertNotIn("submodule", git_log)
+
+    def test_setup_refuses_nonempty_non_repository_without_cloning(self):
+        (self.repo / ".git").rmdir()
+        env = self.setup_env()
+        env.update(
+            {
+                "BASE_URL": "https://gateway.example.invalid",
+                "API_KEY": "fake-setup-secret",
+                "MODEL": "test-model",
+                "TRACE_TO_OPIK": "false",
+                "SETUP_TEST_GIT_REV_PARSE_ERROR": (
+                    "fatal: not a git repository (or any parent directories): .git"
+                ),
+            }
+        )
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("destination is not empty", result.stderr.lower())
+        self.assertIn("fatal: not a git repository", result.stderr)
+        git_log = (self.state / "git.log").read_text(encoding="utf-8")
+        self.assertNotIn("clone", git_log)
+        self.assertNotIn("submodule", git_log)
+
+    def test_setup_clones_into_empty_destination_after_expected_probe_failure(self):
+        empty_repo = self.root / "empty-repo"
+        empty_repo.mkdir()
+        env = self.setup_env()
+        env.update(
+            {
+                "REPO_DIR": str(empty_repo),
+                "BASE_URL": "https://gateway.example.invalid",
+                "API_KEY": "fake-setup-secret",
+                "MODEL": "test-model",
+                "TRACE_TO_OPIK": "false",
+                "SETUP_TEST_GIT_REV_PARSE_ERROR": (
+                    "fatal: not a git repository (or any parent directories): .git"
+                ),
+            }
+        )
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        git_log = (self.state / "git.log").read_text(encoding="utf-8")
+        self.assertIn(
+            f"clone --recurse-submodules "
+            f"https://github.com/sii-system/agent-fleet.git {empty_repo}",
+            git_log,
+        )
+        self.assertIn("submodule sync --recursive", git_log)
+        self.assertTrue((empty_repo / "config.local.env").is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. Why the change?

DinD aligns its benchmark user with the host UID/GID and bind-mounts the
checkout, but setup was the one launcher step still executed as container
root. Git then rejected the host-owned checkout as dubious, while `setup.sh`
treated every failed repository probe as a missing repository and attempted
to clone over the populated mount. Root setup could also leave artifacts that
the benchmark, Monitor, and Analyzer user could not update.

Fixes #57.

## 2. Summary of the change

- Prepare the DinD home volume once as `DIND_USER:DIND_USER`, then run setup
  through the same `--user "$DIND_USER"` path as `run_fleet.sh`.
- Remove the root setup helper and the post-setup recursive ownership repair.
- Make repository detection fail closed when `.git` exists, the destination is
  inaccessible, or the destination is non-empty; retain the original Git
  diagnostic instead of falling through to `git clone`.
- Preserve cloning for missing or empty destinations and keep recursive
  submodule sync/update behavior.
- Add regression coverage for non-root setup, ownership preparation, existing
  checkout reuse, dubious-ownership failure, non-repository populated
  destinations, and the valid empty-destination clone path.

## 3. Other details

Validation:

- `bash scripts/tests/test_dind_run.sh`
- `python3 -m unittest scripts/tests/test_setup.py` (8 tests)
- Bash syntax checks and `git diff --check`
- Fresh DinD container and volumes with fake credentials, completing setup,
  recursive submodule initialization, Docker permission validation, and
  `run_fleet.sh --dry-run`
- Verified setup outputs in the home volume and checkout were owned by the
  host-aligned `DIND_USER` UID/GID and remained writable

The validation checkout is a linked worktree, so the successful fresh
bootstrap mounted an isolated `/tmp` copy of its Git metadata; the original
worktree was not modified. Test containers, volumes, fake configuration, and
temporary metadata were removed afterward.

A full benchmark using real credentials was intentionally not run because the
separate DinD credential-argv hardening is outside this PR. The stale-home
bootstrap probe and credential transport defects are also intentionally left
for follow-up changes. No real secret was used or recorded.
