### PR TITLE
Clean up Harbor analyzer when launcher exits

### DIFF
--- a/Agents/utils/common/Harbor/start.sh
+++ b/Agents/utils/common/Harbor/start.sh
@@ -508,13 +508,15 @@ if [[ $# -gt 0 ]]; then
       harbor_rollback_analyzer_startup
       exit 1
     fi
+    trap 'harbor_finish_analyzer_lifecycle' EXIT
   fi
   command_pid=""
   command_signal=""
   trap 'command_signal=TERM; [[ -z "$command_pid" ]] || kill -TERM "$command_pid" 2>/dev/null || true' TERM
   trap 'command_signal=INT; [[ -z "$command_pid" ]] || kill -INT "$command_pid" 2>/dev/null || true' INT
+  trap 'command_signal=HUP; [[ -z "$command_pid" ]] || kill -HUP "$command_pid" 2>/dev/null || true' HUP
   (
-    trap - TERM INT
+    trap - TERM INT HUP
     exec "$@"
   ) <&0 &
   command_pid="$!"
@@ -529,12 +531,14 @@ if [[ $# -gt 0 ]]; then
     command_rc="$?"
   fi
   set -e
-  trap - TERM INT
+  trap - TERM INT HUP
   if [[ -n "$command_signal" ]]; then
+    trap - EXIT
     harbor_rollback_analyzer_startup
     kill "-$command_signal" "$$"
   fi
   harbor_finish_analyzer_lifecycle
+  trap - EXIT
   exit "$command_rc"
 fi
 
@@ -613,12 +617,17 @@ if ! harbor_start_analyzer_if_enabled; then
   harbor_rollback_analyzer_startup
   exit 1
 fi
+trap 'harbor_finish_analyzer_lifecycle' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 harbor_print_run_receipt
 zellij_status=0
 env -u ZELLIJ_SESSION_NAME zellij \
   --session "$ZELLIJ_SESSION_NAME" \
   --new-session-with-layout "$LAYOUT_FILE" || zellij_status="$?"
 harbor_finish_analyzer_lifecycle
+trap - EXIT HUP INT TERM
 final_status=0
 harbor_report_foreground_result "$zellij_status" || final_status="$?"
 exit "$final_status"

--- a/Agents/utils/common/Harbor/start.sh
+++ b/Agents/utils/common/Harbor/start.sh
@@ -618,14 +618,15 @@ if ! harbor_start_analyzer_if_enabled; then
   exit 1
 fi
 trap 'harbor_finish_analyzer_lifecycle' EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
+trap 'zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true; exit 129' HUP
+trap 'zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true; exit 130' INT
+trap 'zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true; exit 143' TERM
 harbor_print_run_receipt
 zellij_status=0
 env -u ZELLIJ_SESSION_NAME zellij \
   --session "$ZELLIJ_SESSION_NAME" \
-  --new-session-with-layout "$LAYOUT_FILE" || zellij_status="$?"
+  --new-session-with-layout "$LAYOUT_FILE" <&0 &
+wait "$!" || zellij_status="$?"
 harbor_finish_analyzer_lifecycle
 trap - EXIT HUP INT TERM
 final_status=0


### PR DESCRIPTION
## Summary

- arm an `EXIT` fallback after successful analyzer startup in foreground and direct-command runs
- handle `HUP` in the existing direct-command signal path
- route foreground `HUP`, `INT`, and `TERM` through lifecycle cleanup
- leave detached analyzer supervision unchanged

## Root cause

The analyzer runs in its own detached session, while foreground and direct-command runs previously stopped it only when `start.sh` reached normal post-run cleanup. Launcher termination could therefore leave the analyzer polling after the run ended.

## Validation

- `bash -n Agents/utils/common/Harbor/start.sh`
- `git diff --check`
- `bash Agents/utils/common/Harbor/tests/test_start_user_feedback.sh`
- `bash Agents/utils/common/Harbor/tests/test_host_defaults.sh`
- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` (55 tests)
- focused Bash check that trapped `HUP` reaches the `EXIT` cleanup

Fixes https://github.com/sii-system/agent-fleet/issues/54
