### PR TITLE
Refresh stale DinD home volumes

### DIFF
--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -402,9 +402,10 @@ case "$DIND_BOOTSTRAP" in
     # Extract the version number instead of matching the whole output line:
     # setup.sh does the same, and an exact-line match would re-run setup on
     # every invocation if `pi --version` ever prints more than the bare version.
-    if ! docker_exec sh -c 'command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$3" ] && test -f "$1" && test -d "$2"' \
+    if ! docker_exec sh -c 'command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$4" ] && test -f "$1" && test -d "$2" && test -f "$3"' \
       sh "$DIND_HOME_DIR/.pi/agent/models.json" \
       "$DIND_HOME_DIR/.pi/agent/skills/harbor-benchmark-runner" \
+      "$DIND_HOME_DIR/.config/agent-fleet/paths.env" \
       "${PI_VERSION:-0.81.1}"; then
       run_setup=1
     fi

--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -402,11 +402,11 @@ case "$DIND_BOOTSTRAP" in
     # Extract the version number instead of matching the whole output line:
     # setup.sh does the same, and an exact-line match would re-run setup on
     # every invocation if `pi --version` ever prints more than the bare version.
-    if ! docker_exec sh -c 'command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$4" ] && test -f "$1" && test -d "$2" && test -f "$3"' \
+    if ! docker_exec sh -c 'paths_file="${AGENT_FLEET_PATHS_FILE:-${XDG_CONFIG_HOME:-$4/.config}/agent-fleet/paths.env}"; command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$3" ] && test -f "$1" && test -d "$2" && test -f "$paths_file"' \
       sh "$DIND_HOME_DIR/.pi/agent/models.json" \
       "$DIND_HOME_DIR/.pi/agent/skills/harbor-benchmark-runner" \
-      "$DIND_HOME_DIR/.config/agent-fleet/paths.env" \
-      "${PI_VERSION:-0.81.1}"; then
+      "${PI_VERSION:-0.81.1}" \
+      "$DIND_HOME_DIR"; then
       run_setup=1
     fi
     ;;

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -84,10 +84,19 @@ fi
 if [[ "${1:-}" == "exec" && "$*" == *"docker info"* ]]; then
   exit 0
 fi
-if [[ "${1:-}" == "exec" && "$*" == *"command -v pi"* &&
-      "${MOCK_PATHS_ENV_MISSING:-0}" == "1" &&
-      "$*" == *"/.config/agent-fleet/paths.env"* ]]; then
-  exit 1
+if [[ "${1:-}" == "exec" && "$*" == *"command -v pi"* ]]; then
+  case "${MOCK_CONTAINER_PATHS_SOURCE:-}" in
+    AGENT_FLEET_PATHS_FILE)
+      [[ "$*" == *'${AGENT_FLEET_PATHS_FILE:-'* ]] || exit 1
+      ;;
+    XDG_CONFIG_HOME)
+      [[ "$*" == *'${XDG_CONFIG_HOME:-$4/.config}'* ]] || exit 1
+      ;;
+  esac
+  if [[ "${MOCK_PATHS_ENV_MISSING:-0}" == "1" &&
+        "$*" == *"agent-fleet/paths.env"* ]]; then
+    exit 1
+  fi
 fi
 exit 0
 MOCK
@@ -194,11 +203,10 @@ DIND_BOOTSTRAP=missing \
 PI_VERSION=0.81.1 \
 "$PROJECT_DIR/scripts/dind-run.sh" --taskset terminalbench21 --agent claude-code --workers 1 > "$LOG"
 
-grep -qF -- '<sh> <-c> <command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$4" ] && test -f "$1" && test -d "$2" && test -f "$3">' "$LOG"
+grep -qF -- '<sh> <-c> <paths_file="${AGENT_FLEET_PATHS_FILE:-${XDG_CONFIG_HOME:-$4/.config}/agent-fleet/paths.env}"; command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$3" ] && test -f "$1" && test -d "$2" && test -f "$paths_file">' "$LOG"
 grep -q -- '</home/agent/.pi/agent/models.json>' "$LOG"
 grep -q -- '</home/agent/.pi/agent/skills/harbor-benchmark-runner>' "$LOG"
-grep -q -- '</home/agent/.config/agent-fleet/paths.env>' "$LOG"
-grep -q -- '<0.81.1>' "$LOG"
+grep -q -- '<0.81.1> </home/agent>' "$LOG"
 grep -q -- '<PI_VERSION=0.81.1>' "$LOG"
 if grep -q -- 'command -v claude' "$LOG"; then
   echo "dind-run.sh still checks the controller for Claude Code" >&2
@@ -219,9 +227,25 @@ PI_VERSION=0.81.1 \
   --taskset terminalbench21 --agent claude-code --workers 1 \
   > "$MISSING_PATHS_LOG"
 
-grep -q -- '</home/agent/.config/agent-fleet/paths.env>' "$MISSING_PATHS_LOG"
+grep -q -- 'AGENT_FLEET_PATHS_FILE' "$MISSING_PATHS_LOG"
 grep -q -- '<./scripts/setup.sh>' "$MISSING_PATHS_LOG"
 grep -q -- '<./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>' "$MISSING_PATHS_LOG"
+
+for paths_source in AGENT_FLEET_PATHS_FILE XDG_CONFIG_HOME; do
+  CONFIGURED_PATHS_LOG="$TMP_DIR/configured-paths-${paths_source}.log"
+  PATH="$TMP_DIR/bin:$PATH" \
+  MOCK_CONTAINER_PATHS_SOURCE="$paths_source" \
+  DIND_BOOTSTRAP=missing \
+  PI_VERSION=0.81.1 \
+  "$PROJECT_DIR/scripts/dind-run.sh" \
+    --taskset terminalbench21 --agent claude-code --workers 1 \
+    > "$CONFIGURED_PATHS_LOG"
+
+  if grep -q -- '<./scripts/setup.sh>' "$CONFIGURED_PATHS_LOG"; then
+    echo "dind-run.sh ignored the container's configured paths-file source: $paths_source" >&2
+    exit 1
+  fi
+done
 
 FALLBACK_LOG="$TMP_DIR/fallback.log"
 PATH="$TMP_DIR/bin:$PATH" \

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -84,6 +84,11 @@ fi
 if [[ "${1:-}" == "exec" && "$*" == *"docker info"* ]]; then
   exit 0
 fi
+if [[ "${1:-}" == "exec" && "$*" == *"command -v pi"* &&
+      "${MOCK_PATHS_ENV_MISSING:-0}" == "1" &&
+      "$*" == *"/.config/agent-fleet/paths.env"* ]]; then
+  exit 1
+fi
 exit 0
 MOCK
 chmod +x "$TMP_DIR/bin/docker"
@@ -189,9 +194,10 @@ DIND_BOOTSTRAP=missing \
 PI_VERSION=0.81.1 \
 "$PROJECT_DIR/scripts/dind-run.sh" --taskset terminalbench21 --agent claude-code --workers 1 > "$LOG"
 
-grep -qF -- '<sh> <-c> <command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$3" ] && test -f "$1" && test -d "$2">' "$LOG"
+grep -qF -- '<sh> <-c> <command -v pi >/dev/null 2>&1 && [ "$(pi --version 2>/dev/null | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)" = "$4" ] && test -f "$1" && test -d "$2" && test -f "$3">' "$LOG"
 grep -q -- '</home/agent/.pi/agent/models.json>' "$LOG"
 grep -q -- '</home/agent/.pi/agent/skills/harbor-benchmark-runner>' "$LOG"
+grep -q -- '</home/agent/.config/agent-fleet/paths.env>' "$LOG"
 grep -q -- '<0.81.1>' "$LOG"
 grep -q -- '<PI_VERSION=0.81.1>' "$LOG"
 if grep -q -- 'command -v claude' "$LOG"; then
@@ -203,6 +209,19 @@ if grep -q -- '<./scripts/setup.sh>' "$LOG"; then
   exit 1
 fi
 grep -q -- '<./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>' "$LOG"
+
+MISSING_PATHS_LOG="$TMP_DIR/missing-paths.log"
+PATH="$TMP_DIR/bin:$PATH" \
+MOCK_PATHS_ENV_MISSING=1 \
+DIND_BOOTSTRAP=missing \
+PI_VERSION=0.81.1 \
+"$PROJECT_DIR/scripts/dind-run.sh" \
+  --taskset terminalbench21 --agent claude-code --workers 1 \
+  > "$MISSING_PATHS_LOG"
+
+grep -q -- '</home/agent/.config/agent-fleet/paths.env>' "$MISSING_PATHS_LOG"
+grep -q -- '<./scripts/setup.sh>' "$MISSING_PATHS_LOG"
+grep -q -- '<./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>' "$MISSING_PATHS_LOG"
 
 FALLBACK_LOG="$TMP_DIR/fallback.log"
 PATH="$TMP_DIR/bin:$PATH" \


### PR DESCRIPTION
## 1. Why the change?

`DIND_BOOTSTRAP=missing` can treat a stale persistent home volume as fully
initialized when Pi, its model configuration, and the Harbor skill exist but
the managed prerequisite path contract does not. Because setup is skipped,
`$DIND_HOME_DIR/.config/agent-fleet/paths.env` is never created and later runs
can depend on coincidental system tool paths.

## 2. Summary of the change

- Require `paths.env` in the DinD `missing` bootstrap probe.
- Re-run setup when the existing home volume lacks that file.
- Preserve the existing fast path when every required artifact is present.
- Add positive and negative shell regression coverage for both decisions.

## 3. Other details

Validation:

- `env -i PATH="$PATH" HOME="$HOME" USER="${USER:-}" bash scripts/tests/test_dind_run.sh`
- `python3 -m unittest scripts/tests/test_setup.py`
- `bash -n scripts/dind-run.sh scripts/tests/test_dind_run.sh`
- `git diff --check`
