### PR TITLE
Keep Harbor analyzer alive after handover errors

### DIFF
--- a/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
+++ b/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
@@ -363,8 +363,12 @@ def main() -> int:
         for handover, source_path, follow_key in pending:
             try:
                 exit_code = _run_one(handover, source_path, config)
-            except ValueError as exc:
-                print(f"Analyzer rejected {source_path}: {exc}", file=sys.stderr)
+            except Exception as exc:  # noqa: BLE001 - isolate one handover from the follow daemon
+                print(
+                    f"Analyzer failed while processing {source_path}: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
                 _record_follow_failure(
                     failed,
                     handover_id=follow_key,

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -16,6 +16,7 @@ SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
+from Agents.utils.common.Harbor.scripts import analyzer_subagent
 from Agents.utils.common.Harbor.scripts.analyzer_subagent import (
     FOLLOW_MAX_FAILURE_ATTEMPTS,
     _default_model,
@@ -397,6 +398,53 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
             state_path.write_text("[]", encoding="utf-8")
 
             self.assertEqual(_load_follow_state(state_path), (set(), {}))
+
+    def test_follow_continues_after_unexpected_handover_exception(self) -> None:
+        class StopFollow(Exception):
+            pass
+
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            state_path = root_path / "analyzer" / ".analyzer_state.json"
+            config = AnalyzerConfig(
+                run_dir=root_path / "run",
+                queue_dir=None,
+                output_dir=state_path.parent,
+            )
+            args = SimpleNamespace(
+                follow=True,
+                handover=root_path / "latest.json",
+                handoff_dir=root_path / "handoffs",
+                ready_file=None,
+                poll_interval=1.0,
+            )
+            pending = [
+                ({"handover_id": "first"}, root_path / "first.json", "first"),
+                ({"handover_id": "second"}, root_path / "second.json", "second"),
+            ]
+
+            with (
+                mock.patch.object(analyzer_subagent, "parse_args", return_value=args),
+                mock.patch.object(analyzer_subagent, "_config", return_value=config),
+                mock.patch.object(
+                    analyzer_subagent,
+                    "_pending_handovers",
+                    side_effect=[pending, StopFollow()],
+                ),
+                mock.patch.object(
+                    analyzer_subagent,
+                    "_run_one",
+                    side_effect=[OSError(28, "No space left on device"), 0],
+                ) as run_one,
+                self.assertRaises(StopFollow),
+            ):
+                analyzer_subagent.main()
+
+            self.assertEqual(run_one.call_count, 2)
+            processed, failed = _load_follow_state(state_path)
+            self.assertEqual(processed, {"second"})
+            self.assertEqual(failed["first"]["attempt_count"], 1)
+            self.assertEqual(failed["first"]["last_exit_code"], 2)
 
     def test_pending_handovers_skip_non_object_json(self) -> None:
         with tempfile.TemporaryDirectory() as root:


### PR DESCRIPTION
## Summary

- isolate unexpected exceptions to the handover currently being processed by analyzer follow mode
- reuse the existing handover failure, backoff, and follow-state path for those exceptions
- continue processing later handovers instead of terminating the analyzer daemon

## Root cause

The follow loop caught only `ValueError`. Other per-handover exceptions, including errors propagated by a task future, escaped the loop and terminated the long-running analyzer process.

## Validation

- `python3 -m unittest Agents.utils.common.Harbor.tests.test_harbor_analyzer_runtime` (21 tests)
- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` (56 tests)
- `python3 -m py_compile Agents/utils/common/Harbor/scripts/analyzer_subagent.py Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py`
- `git diff --check`

Addresses the analyzer-daemon exception isolation item in:

- https://github.com/sii-system/agent-fleet/issues/56
- https://github.com/sii-system/tasks/issues/150#issuecomment-5112305951
