### PR TITLE
Fix Pi review event path resolution

### DIFF
--- a/.github/scripts/tests/test_pi_review_canary_workflow.py
+++ b/.github/scripts/tests/test_pi_review_canary_workflow.py
@@ -1,4 +1,9 @@
+import json
+import os
 import re
+import subprocess
+import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -10,6 +15,13 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        step_start = cls.workflow.index("      - name: Resolve review target")
+        run_marker = "        run: |\n"
+        script_start = cls.workflow.index(run_marker, step_start) + len(run_marker)
+        script_end = cls.workflow.index("\n      - name:", script_start)
+        cls.resolver_script = textwrap.dedent(
+            cls.workflow[script_start:script_end]
+        )
 
     def test_accepts_a_required_pull_request_number(self) -> None:
         self.assertIn("workflow_dispatch:", self.workflow)
@@ -38,6 +50,49 @@ class PiReviewCanaryWorkflowTest(unittest.TestCase):
 
     def test_resolves_target_with_isolated_python(self) -> None:
         self.assertIn("python3 -I - <<'PY'", self.workflow)
+
+    def test_automatic_target_uses_the_runner_event_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            event_path = root / "event.json"
+            output_path = root / "output"
+            base_sha = "a" * 40
+            head_sha = "b" * 40
+            event_path.write_text(
+                json.dumps(
+                    {
+                        "pull_request": {
+                            "base": {"sha": base_sha},
+                            "head": {"sha": head_sha},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "EVENT_NAME": "pull_request_target",
+                    "EVENT_PATH": "",
+                    "GITHUB_EVENT_PATH": str(event_path),
+                    "GITHUB_OUTPUT": str(output_path),
+                }
+            )
+
+            completed = subprocess.run(
+                ["bash", "-c", self.resolver_script],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"),
+                f"base_sha={base_sha}\nevent_path={event_path}\n",
+            )
 
     def test_checks_out_the_resolved_trusted_base(self) -> None:
         self.assertIn("ref: ${{ steps.target.outputs.base_sha", self.workflow)

--- a/.github/workflows/self-hosted-llm-pr-review.yml
+++ b/.github/workflows/self-hosted-llm-pr-review.yml
@@ -29,7 +29,6 @@ jobs:
         id: target
         env:
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_PATH: ${{ github.event_path }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
@@ -44,7 +43,7 @@ jobs:
           from urllib.request import Request, urlopen
 
           if os.environ["EVENT_NAME"] == "pull_request_target":
-              event_path = Path(os.environ["EVENT_PATH"])
+              event_path = Path(os.environ["GITHUB_EVENT_PATH"])
               event = json.loads(event_path.read_text(encoding="utf-8"))
           else:
               number = int(os.environ["INPUT_PR_NUMBER"])


### PR DESCRIPTION
## 1. Why the change?

Automatic self-hosted Pi reviews fail in the `Resolve review target` step after the manual-canary workflow change. The copied `${{ github.event_path }}` value is empty at runtime, so `Path("")` resolves to the working directory and raises `IsADirectoryError` before checkout.

This reproduced on three current `pull_request_target` runs, including [30437495007](https://github.com/sii-system/agent-fleet/actions/runs/30437495007) and [30437544622](https://github.com/sii-system/agent-fleet/actions/runs/30437544622).

## 2. Summary of the change

- Read the runner-provided `GITHUB_EVENT_PATH` directly for automatic reviews instead of copying it through a workflow expression.
- Keep manual `workflow_dispatch` target resolution, revision validation, trusted-base checkout, and review behavior unchanged.
- Add an executable regression test that extracts and runs the real inline resolver with an empty copied event path and a valid runner event path, then verifies the emitted base SHA and event path.

## 3. Other details

Related design record: [sii-system/tasks#149](https://github.com/sii-system/tasks/issues/149).

Verification:

- Red phase reproduced the production `IsADirectoryError` in the new test.
- 178 GitHub-script tests passed.
- 4 top-level tests passed.
- `scripts/tests/test_dind_run.sh` passed.
- Ruff passed with `.github/ruff.toml`.
- Python compileall passed.
- Workflow YAML parsing passed.
- actionlint 1.7.12 passed with only the existing custom self-hosted runner-label warnings ignored.
- `git diff --check` passed.

Expected CI state:

- Ruff is green.
- The self-hosted review check executes the current default-branch `pull_request_target` resolver and therefore reproduces the bug this PR fixes. A post-merge automatic run is required to validate the corrected default-branch path.
- PR Quick CI is skipped for this draft, fork-backed PR by its current event policy.

The complete `scripts/tests` suite is not portable to this macOS host: 8 of 116 tests hit existing environment assumptions (`/var` versus `/private/var`, and missing Linux `flock`/`setsid`).
