### PR TITLE
Treat degraded analyzer handovers as complete

### DIFF
--- a/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
+++ b/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
@@ -377,7 +377,7 @@ def main() -> int:
                 )
                 _save_follow_state(state_path, processed=processed, failed=failed)
                 continue
-            if exit_code == 0:
+            if exit_code in {0, 3}:
                 processed.add(follow_key)
                 failed.pop(follow_key, None)
                 _save_follow_state(state_path, processed=processed, failed=failed)

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -399,7 +399,7 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
 
             self.assertEqual(_load_follow_state(state_path), (set(), {}))
 
-    def test_follow_continues_after_unexpected_handover_exception(self) -> None:
+    def test_follow_continues_after_exception_and_completes_degraded_handover(self) -> None:
         class StopFollow(Exception):
             pass
 
@@ -434,7 +434,7 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
                 mock.patch.object(
                     analyzer_subagent,
                     "_run_one",
-                    side_effect=[OSError(28, "No space left on device"), 0],
+                    side_effect=[OSError(28, "No space left on device"), 3],
                 ) as run_one,
                 self.assertRaises(StopFollow),
             ):


### PR DESCRIPTION
## Summary

- treat analyzer exit code `3` as a completed handover with task-level failures
- persist the handover in follow state instead of retrying its full task list
- retain the existing per-task fallback reports and internal Pi retry behavior

## Root cause

`run_handover` returns `3` only after publishing the handover artifacts with fallback reports for failed task analyses. Follow mode previously treated every nonzero code as retryable, so it reran successful tasks and created duplicate publications.

## Validation

- `python3 -m unittest Agents.utils.common.Harbor.tests.test_harbor_analyzer_runtime` (21 tests)
- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` (56 tests)
- `python3 -m py_compile Agents/utils/common/Harbor/scripts/analyzer_subagent.py Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py`
- `git diff --check`

Addresses the whole-handover retry item in:

- https://github.com/sii-system/agent-fleet/issues/56
- https://github.com/sii-system/tasks/issues/150#issuecomment-5112305951
