### PR TITLE
Retain whole-run analyzer publication manifest

### DIFF
--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 from . import PROMPT_VERSION, SCHEMA_VERSION, TAXONOMY_VERSION
 from .contract import validate_handover
-from .io import stable_hash, utc_now, write_json_atomic, write_text_atomic
+from .io import load_json, stable_hash, utc_now, write_json_atomic, write_text_atomic
 from .pi import dispatch_to_child
 from .prompt import (
     build_dispatch_retry_prompt,
@@ -529,21 +529,51 @@ def _write_outputs(
     write_text_atomic(fix_index_path, fix_index_jsonl)
     if raw_final_snapshot_path:
         write_json_atomic(raw_final_snapshot_path, final_json)
+    generated_at = utc_now()
+    artifacts = {
+        "benchmark_report_path": str(report_path),
+        "env_infra_tasks_path": str(env_infra_path),
+        "fix_line_index_path": str(fix_index_path),
+        "raw_final_json_path": str(raw_final_snapshot_path) if raw_final_snapshot_path else None,
+    }
     latest_artifacts = {
         "schema_version": SCHEMA_VERSION,
         "kind": "harbor_analyzer_latest_artifacts",
         "handover_id": handover_id,
         "publication_id": publication_id,
         "run_id": benchmark_report.get("run_id"),
-        "generated_at": utc_now(),
-        "artifacts": {
-            "benchmark_report_path": str(report_path),
-            "env_infra_tasks_path": str(env_infra_path),
-            "fix_line_index_path": str(fix_index_path),
-            "raw_final_json_path": str(raw_final_snapshot_path) if raw_final_snapshot_path else None,
-        },
+        "generated_at": generated_at,
+        "artifacts": artifacts,
     }
     with _publish_lock(config.output_dir):
+        publications: list[dict[str, Any]] = []
+        if latest_artifacts_path.is_file():
+            previous = load_json(latest_artifacts_path)
+            if previous.get("run_id") == latest_artifacts["run_id"]:
+                previous_publications = previous.get("publications")
+                if isinstance(previous_publications, list):
+                    publications = list(previous_publications)
+                elif previous.get("handover_id") and previous.get("publication_id"):
+                    publications = [
+                        {
+                            "handover_id": previous["handover_id"],
+                            "publication_id": previous["publication_id"],
+                            "generated_at": previous.get("generated_at"),
+                            "artifacts": previous.get("artifacts"),
+                        }
+                    ]
+        publications = [
+            item for item in publications if item.get("handover_id") != handover_id
+        ]
+        publications.append(
+            {
+                "handover_id": handover_id,
+                "publication_id": publication_id,
+                "generated_at": generated_at,
+                "artifacts": artifacts,
+            }
+        )
+        latest_artifacts["publications"] = publications
         write_json_atomic(latest_artifacts_path, latest_artifacts)
     return benchmark_report
 

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -756,6 +756,66 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
                 manifest["artifacts"]["raw_final_json_path"],
                 str(output_dir / "analyzer-final-json" / HANDOVER_ID / f"{publication_id}.json"),
             )
+            self.assertEqual(
+                manifest["publications"],
+                [
+                    {
+                        "handover_id": HANDOVER_ID,
+                        "publication_id": publication_id,
+                        "generated_at": manifest["generated_at"],
+                        "artifacts": manifest["artifacts"],
+                    }
+                ],
+            )
+
+    def test_latest_manifest_retains_each_handover_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            output_dir = Path(root) / "analyzer"
+            config = AnalyzerConfig(
+                run_dir=Path(root) / "run",
+                queue_dir=Path(root) / "run" / "queue",
+                output_dir=output_dir,
+            )
+            second_handover_id = "sha256-" + ("c" * 64)
+            second_final = final_json()
+            second_final["handover_id"] = second_handover_id
+            second_final["benchmark_report"]["handover_id"] = second_handover_id
+            second_final["env_infra_tasks"]["handover_id"] = second_handover_id
+
+            first = _write_outputs(
+                config=config,
+                handover_id=HANDOVER_ID,
+                final_json=final_json(),
+                provenance=None,
+                prompt_path=None,
+                raw_final_json_path=output_dir / "analyzer-final-json" / f"{HANDOVER_ID}.json",
+            )
+            second = _write_outputs(
+                config=config,
+                handover_id=second_handover_id,
+                final_json=second_final,
+                provenance=None,
+                prompt_path=None,
+                raw_final_json_path=output_dir
+                / "analyzer-final-json"
+                / f"{second_handover_id}.json",
+            )
+
+            manifest = json.loads(
+                (output_dir / "analyzer-artifacts-latest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["handover_id"], second_handover_id)
+            self.assertEqual(
+                [item["handover_id"] for item in manifest["publications"]],
+                [HANDOVER_ID, second_handover_id],
+            )
+            self.assertEqual(
+                [item["publication_id"] for item in manifest["publications"]],
+                [
+                    first["analyzer_metadata"]["publication_id"],
+                    second["analyzer_metadata"]["publication_id"],
+                ],
+            )
 
     def test_latest_manifest_uses_one_immutable_publication_for_same_handover_writers(self) -> None:
         with tempfile.TemporaryDirectory() as root:
@@ -776,6 +836,8 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
             )
             publication_id = manifest["publication_id"]
             artifacts = manifest["artifacts"]
+            self.assertEqual(len(manifest["publications"]), 1)
+            self.assertEqual(manifest["publications"][0]["publication_id"], publication_id)
 
             for path in artifacts.values():
                 self.assertIsNotNone(path)


### PR DESCRIPTION
## Summary

- retain every handover's immutable artifact publication in `analyzer-artifacts-latest.json`
- replace an older entry when the same handover is published again
- update the whole-run publication list under the existing publish lock
- preserve the top-level latest-publication fields for compatibility

## Root cause

Each handover previously replaced the complete latest manifest. Multi-handover runs therefore exposed only the final handover's artifact paths even though earlier immutable publications remained on disk.

The manifest now includes a `publications` list for the current run. Benchmark reports, env/infra task files, and fix-line indexes remain immutable per-handover artifacts and are not rewritten into a second aggregate format.

## Validation

- `python3 -m unittest Agents.utils.common.Harbor.tests.test_harbor_analyzer_runtime` (22 tests)
- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` (57 tests)
- `python3 -m py_compile Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py`
- `git diff --check`

Addresses the incomplete whole-run latest manifest item in:

- https://github.com/sii-system/agent-fleet/issues/56
- https://github.com/sii-system/tasks/issues/150#issuecomment-5112305951
