### PR TITLE
Keep DinD credentials out of process argv

### DIFF
--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -389,8 +389,58 @@ if [[ -n "$registry_mirrors" && -z "${TB_SKIP_DOCKERHUB_PREFLIGHT:-}" ]]; then
   run_env+=("TB_SKIP_DOCKERHUB_PREFLIGHT=1")
 fi
 
+DIND_EXEC_ENV_FILE=""
+
+cleanup_dind_exec_env_file() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if [[ -n "$DIND_EXEC_ENV_FILE" && -e "$DIND_EXEC_ENV_FILE" ]]; then
+    rm -f -- "$DIND_EXEC_ENV_FILE" ||
+      warn "failed to remove DinD execution env file: $DIND_EXEC_ENV_FILE"
+  fi
+  exit "$status"
+}
+
+create_dind_exec_env_file() {
+  local entry name previous_umask
+  for entry in "${run_env[@]}"; do
+    name="${entry%%=*}"
+    if [[ ! "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      err "invalid DinD execution environment variable name: $name"
+      return 1
+    fi
+    if [[ "$entry" == *$'\n'* || "$entry" == *$'\r'* ]]; then
+      err "DinD execution environment variable cannot contain a newline: $name"
+      return 1
+    fi
+  done
+
+  previous_umask="$(umask)"
+  umask 077
+  if ! DIND_EXEC_ENV_FILE="$(mktemp /tmp/agent-fleet-dind-env.XXXXXX)"; then
+    umask "$previous_umask"
+    err "failed to create DinD execution env file"
+    return 1
+  fi
+  umask "$previous_umask"
+  if ! chmod 0600 "$DIND_EXEC_ENV_FILE"; then
+    err "failed to restrict DinD execution env file permissions"
+    return 1
+  fi
+  if ! printf '%s\n' "${run_env[@]}" > "$DIND_EXEC_ENV_FILE"; then
+    err "failed to write DinD execution env file"
+    return 1
+  fi
+}
+
+trap cleanup_dind_exec_env_file EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+create_dind_exec_env_file
+
 docker_exec_env() {
-  docker_exec env "${run_env[@]}" "$@"
+  docker "${exec_base[@]}" --env-file "$DIND_EXEC_ENV_FILE" "$DIND_NAME" "$@"
 }
 
 run_setup=0

--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -390,14 +390,32 @@ if [[ -n "$registry_mirrors" && -z "${TB_SKIP_DOCKERHUB_PREFLIGHT:-}" ]]; then
 fi
 
 DIND_EXEC_ENV_FILE=""
+DIND_EXEC_CHILD_PID=""
 
-cleanup_dind_exec_env_file() {
-  local status=$?
-  trap - EXIT HUP INT TERM
+remove_dind_exec_env_file() {
   if [[ -n "$DIND_EXEC_ENV_FILE" && -e "$DIND_EXEC_ENV_FILE" ]]; then
     rm -f -- "$DIND_EXEC_ENV_FILE" ||
       warn "failed to remove DinD execution env file: $DIND_EXEC_ENV_FILE"
   fi
+  DIND_EXEC_ENV_FILE=""
+}
+
+cleanup_dind_exec_env_file() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  remove_dind_exec_env_file
+  exit "$status"
+}
+
+handle_dind_exec_signal() {
+  local signal="$1" status="$2" child_pid="$DIND_EXEC_CHILD_PID"
+  trap - HUP INT TERM
+  remove_dind_exec_env_file
+  if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    kill "-$signal" "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+  fi
+  DIND_EXEC_CHILD_PID=""
   exit "$status"
 }
 
@@ -434,13 +452,18 @@ create_dind_exec_env_file() {
 }
 
 trap cleanup_dind_exec_env_file EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
+trap 'handle_dind_exec_signal HUP 129' HUP
+trap 'handle_dind_exec_signal INT 130' INT
+trap 'handle_dind_exec_signal TERM 143' TERM
 create_dind_exec_env_file
 
 docker_exec_env() {
-  docker "${exec_base[@]}" --env-file "$DIND_EXEC_ENV_FILE" "$DIND_NAME" "$@"
+  local status=0
+  docker "${exec_base[@]}" --env-file "$DIND_EXEC_ENV_FILE" "$DIND_NAME" "$@" <&0 &
+  DIND_EXEC_CHILD_PID=$!
+  wait "$DIND_EXEC_CHILD_PID" || status=$?
+  DIND_EXEC_CHILD_PID=""
+  return "$status"
 }
 
 run_setup=0

--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -391,6 +391,7 @@ fi
 
 DIND_EXEC_ENV_FILE=""
 DIND_EXEC_CHILD_PID=""
+DIND_EXEC_PID_FILE=""
 
 remove_dind_exec_env_file() {
   if [[ -n "$DIND_EXEC_ENV_FILE" && -e "$DIND_EXEC_ENV_FILE" ]]; then
@@ -400,9 +401,46 @@ remove_dind_exec_env_file() {
   DIND_EXEC_ENV_FILE=""
 }
 
+remove_dind_exec_pid_file() {
+  local pid_file="$DIND_EXEC_PID_FILE"
+  DIND_EXEC_PID_FILE=""
+  [[ -n "$pid_file" ]] || return 0
+
+  docker exec --user "$DIND_USER" "$DIND_NAME" \
+    rm -f -- "$pid_file" >/dev/null 2>&1 || true
+}
+
+signal_dind_exec_process() {
+  local signal="$1" pid_file="$DIND_EXEC_PID_FILE"
+  [[ -n "$pid_file" ]] || return 0
+
+  docker exec --user "$DIND_USER" "$DIND_NAME" sh -c '
+    # agent-fleet-dind-exec-signal
+    pid_file=$1
+    signal=$2
+    attempt=0
+    pid=
+    while [ "$attempt" -lt 20 ]; do
+      if IFS= read -r pid < "$pid_file"; then
+        break
+      fi
+      attempt=$((attempt + 1))
+      sleep 0.05
+    done
+    rm -f -- "$pid_file"
+    case "$pid" in
+      ""|*[!0-9]*)
+        exit 1
+        ;;
+    esac
+    kill "-$signal" "$pid"
+  ' sh "$pid_file" "$signal" >/dev/null 2>&1
+}
+
 cleanup_dind_exec_env_file() {
   local status=$?
   trap - EXIT HUP INT TERM
+  remove_dind_exec_pid_file
   remove_dind_exec_env_file
   exit "$status"
 }
@@ -411,6 +449,10 @@ handle_dind_exec_signal() {
   local signal="$1" status="$2" child_pid="$DIND_EXEC_CHILD_PID"
   trap - HUP INT TERM
   remove_dind_exec_env_file
+  if ! signal_dind_exec_process "$signal"; then
+    warn "failed to forward $signal to the DinD execution process"
+  fi
+  DIND_EXEC_PID_FILE=""
   if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
     kill "-$signal" "$child_pid" 2>/dev/null || true
     wait "$child_pid" 2>/dev/null || true
@@ -459,10 +501,21 @@ create_dind_exec_env_file
 
 docker_exec_env() {
   local status=0
-  docker "${exec_base[@]}" --env-file "$DIND_EXEC_ENV_FILE" "$DIND_NAME" "$@" <&0 &
+  local exec_wrapper='pid_file=$1; shift; printf "%s\n" "$$" > "$pid_file" || exit 125; exec "$@"'
+  DIND_EXEC_PID_FILE="$DIND_HOME_DIR/.agent-fleet-dind-exec.${DIND_EXEC_ENV_FILE##*.}.pid"
+  (
+    # Non-interactive Bash starts direct asynchronous commands with SIGINT
+    # ignored. Restore the default before exec so Ctrl-C can stop Docker.
+    trap - INT
+    exec docker "${exec_base[@]}" \
+      --env-file "$DIND_EXEC_ENV_FILE" "$DIND_NAME" \
+      sh -c "$exec_wrapper" agent-fleet-dind-exec \
+      "$DIND_EXEC_PID_FILE" "$@" <&0
+  ) &
   DIND_EXEC_CHILD_PID=$!
   wait "$DIND_EXEC_CHILD_PID" || status=$?
   DIND_EXEC_CHILD_PID=""
+  remove_dind_exec_pid_file
   return "$status"
 }
 

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -69,7 +69,8 @@ EOF
 LOG="$TMP_DIR/docker.log"
 DOCKER_ACTION_LOG="$TMP_DIR/docker-actions.log"
 DOCKER_ENV_CAPTURE_LOG="$TMP_DIR/docker-env-capture.log"
-export DOCKER_ACTION_LOG DOCKER_ENV_CAPTURE_LOG
+DOCKER_SIGNAL_LOG="$TMP_DIR/docker-signal.log"
+export DOCKER_ACTION_LOG DOCKER_ENV_CAPTURE_LOG DOCKER_SIGNAL_LOG
 cat > "$TMP_DIR/bin/docker" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -142,7 +143,18 @@ if [[ "${1:-}" == "exec" && "${MOCK_FAIL_RUN_FLEET:-0}" == "1" &&
 fi
 if [[ "${1:-}" == "exec" && "${MOCK_SIGNAL_RUN_FLEET:-0}" == "1" &&
       "$*" == *"./scripts/run_fleet.sh"* ]]; then
+  record_signal_state() {
+    local state="present"
+    [[ ! -e "$env_file" ]] && state="removed"
+    printf 'TERM env_file=%s\n' "$state" > "$DOCKER_SIGNAL_LOG"
+    exit 0
+  }
+  trap record_signal_state TERM
   kill -TERM "$PPID"
+  sleep 1
+  state="present"
+  [[ ! -e "$env_file" ]] && state="removed"
+  printf 'natural env_file=%s\n' "$state" > "$DOCKER_SIGNAL_LOG"
   exit 0
 fi
 exit 0
@@ -274,6 +286,7 @@ for secret in sk-local opik-local; do
 done
 
 : > "$DOCKER_ENV_CAPTURE_LOG"
+: > "$DOCKER_SIGNAL_LOG"
 SIGNAL_LOG="$TMP_DIR/signal.log"
 signal_status=0
 PATH="$TMP_DIR/bin:$PATH" \
@@ -286,6 +299,10 @@ TRACE_TO_OPIK=false \
   signal_status=$?
 if [[ "$signal_status" != "143" ]]; then
   echo "dind-run.sh did not preserve the TERM exit status: $signal_status" >&2
+  exit 1
+fi
+if ! grep -Fxq -- 'TERM env_file=removed' "$DOCKER_SIGNAL_LOG"; then
+  echo "dind-run.sh did not remove the env file before terminating Docker" >&2
   exit 1
 fi
 assert_env_files_removed "signaled DinD run"

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -70,7 +70,16 @@ LOG="$TMP_DIR/docker.log"
 DOCKER_ACTION_LOG="$TMP_DIR/docker-actions.log"
 DOCKER_ENV_CAPTURE_LOG="$TMP_DIR/docker-env-capture.log"
 DOCKER_SIGNAL_LOG="$TMP_DIR/docker-signal.log"
-export DOCKER_ACTION_LOG DOCKER_ENV_CAPTURE_LOG DOCKER_SIGNAL_LOG
+DOCKER_SIGNAL_HELPER_LOG="$TMP_DIR/docker-signal-helper.log"
+DOCKER_SIGNAL_TARGET_PID_FILE="$TMP_DIR/docker-signal-target.pid"
+DOCKER_ACTIVE_ENV_FILE_PATH_FILE="$TMP_DIR/docker-active-env-file-path"
+export \
+  DOCKER_ACTION_LOG \
+  DOCKER_ENV_CAPTURE_LOG \
+  DOCKER_SIGNAL_LOG \
+  DOCKER_SIGNAL_HELPER_LOG \
+  DOCKER_SIGNAL_TARGET_PID_FILE \
+  DOCKER_ACTIVE_ENV_FILE_PATH_FILE
 cat > "$TMP_DIR/bin/docker" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -111,7 +120,21 @@ if [[ "${1:-}" == "exec" ]]; then
       done < "$env_file"
       printf 'END\n'
     } >> "$DOCKER_ENV_CAPTURE_LOG"
+    printf '%s\n' "$env_file" > "$DOCKER_ACTIVE_ENV_FILE_PATH_FILE"
   fi
+fi
+
+if [[ "${1:-}" == "exec" &&
+      "$*" == *"agent-fleet-dind-exec-signal"* ]]; then
+  signal="${!#}"
+  active_env_file="$(cat "$DOCKER_ACTIVE_ENV_FILE_PATH_FILE")"
+  state="present"
+  [[ ! -e "$active_env_file" ]] && state="removed"
+  printf '%s env_file=%s\n' \
+    "$signal" "$state" > "$DOCKER_SIGNAL_HELPER_LOG"
+  target_pid="$(cat "$DOCKER_SIGNAL_TARGET_PID_FILE")"
+  kill "-$signal" "$target_pid"
+  exit 0
 fi
 
 if [[ "${1:-}" == "ps" ]]; then
@@ -141,20 +164,31 @@ if [[ "${1:-}" == "exec" && "${MOCK_FAIL_RUN_FLEET:-0}" == "1" &&
       "$*" == *"./scripts/run_fleet.sh"* ]]; then
   exit 42
 fi
-if [[ "${1:-}" == "exec" && "${MOCK_SIGNAL_RUN_FLEET:-0}" == "1" &&
+if [[ "${1:-}" == "exec" && -n "${MOCK_SIGNAL_RUN_FLEET:-}" &&
       "$*" == *"./scripts/run_fleet.sh"* ]]; then
+  signal="$MOCK_SIGNAL_RUN_FLEET"
+  case "$signal" in
+    INT|TERM)
+      ;;
+    *)
+      echo "unsupported mock signal: $signal" >&2
+      exit 1
+      ;;
+  esac
+  printf '%s\n' "$$" > "$DOCKER_SIGNAL_TARGET_PID_FILE"
   record_signal_state() {
     local state="present"
     [[ ! -e "$env_file" ]] && state="removed"
-    printf 'TERM env_file=%s\n' "$state" > "$DOCKER_SIGNAL_LOG"
+    printf '%s env_file=%s\n' "$signal" "$state" > "$DOCKER_SIGNAL_LOG"
     exit 0
   }
-  trap record_signal_state TERM
-  kill -TERM "$PPID"
+  trap record_signal_state "$signal"
+  kill "-$signal" "$PPID"
   sleep 1
   state="present"
   [[ ! -e "$env_file" ]] && state="removed"
-  printf 'natural env_file=%s\n' "$state" > "$DOCKER_SIGNAL_LOG"
+  printf 'natural-after-%s env_file=%s\n' \
+    "$signal" "$state" > "$DOCKER_SIGNAL_LOG"
   exit 0
 fi
 exit 0
@@ -216,8 +250,8 @@ for secret in sk-local opik-local; do
     exit 1
   fi
 done
-grep -Eq -- '^docker <exec> <--user> <agent> <--env-file> </tmp/agent-fleet-dind-env\.[^>]+> <agent-fleet-dind> <./scripts/setup.sh>$' "$LOG"
-grep -Eq -- '^docker <exec> <--user> <agent> <--env-file> </tmp/agent-fleet-dind-env\.[^>]+> <agent-fleet-dind> <./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>$' "$LOG"
+grep -Eq -- '^docker <exec> <--user> <agent> <--env-file> </tmp/agent-fleet-dind-env\.[^>]+> <agent-fleet-dind> <sh> <-c> <pid_file=\$1;.*> <agent-fleet-dind-exec> </home/agent/\.agent-fleet-dind-exec\.[^>]+\.pid> <./scripts/setup.sh>$' "$LOG"
+grep -Eq -- '^docker <exec> <--user> <agent> <--env-file> </tmp/agent-fleet-dind-env\.[^>]+> <agent-fleet-dind> <sh> <-c> <pid_file=\$1;.*> <agent-fleet-dind-exec> </home/agent/\.agent-fleet-dind-exec\.[^>]+\.pid> <./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>$' "$LOG"
 if grep -Eq -- '^docker <exec> <--user> <agent> .* <env> .*<./scripts/(setup|run_fleet).sh>' "$LOG"; then
   echo "dind-run.sh still passes execution variables through an in-container env argv" >&2
   exit 1
@@ -285,27 +319,40 @@ for secret in sk-local opik-local; do
   fi
 done
 
-: > "$DOCKER_ENV_CAPTURE_LOG"
-: > "$DOCKER_SIGNAL_LOG"
-SIGNAL_LOG="$TMP_DIR/signal.log"
-signal_status=0
-PATH="$TMP_DIR/bin:$PATH" \
-MOCK_SIGNAL_RUN_FLEET=1 \
-DIND_BOOTSTRAP=always \
-TRACE_TO_OPIK=false \
-"$PROJECT_DIR/scripts/dind-run.sh" \
-  --taskset terminalbench21 --agent claude-code --workers 1 \
-  > "$SIGNAL_LOG" 2>&1 ||
-  signal_status=$?
-if [[ "$signal_status" != "143" ]]; then
-  echo "dind-run.sh did not preserve the TERM exit status: $signal_status" >&2
-  exit 1
-fi
-if ! grep -Fxq -- 'TERM env_file=removed' "$DOCKER_SIGNAL_LOG"; then
-  echo "dind-run.sh did not remove the env file before terminating Docker" >&2
-  exit 1
-fi
-assert_env_files_removed "signaled DinD run"
+run_signal_test() {
+  local signal="$1" expected_status="$2"
+  local signal_log="$TMP_DIR/signal-${signal}.log"
+  local signal_status=0
+
+  : > "$DOCKER_ENV_CAPTURE_LOG"
+  : > "$DOCKER_SIGNAL_LOG"
+  : > "$DOCKER_SIGNAL_HELPER_LOG"
+  PATH="$TMP_DIR/bin:$PATH" \
+  MOCK_SIGNAL_RUN_FLEET="$signal" \
+  DIND_BOOTSTRAP=always \
+  TRACE_TO_OPIK=false \
+  "$PROJECT_DIR/scripts/dind-run.sh" \
+    --taskset terminalbench21 --agent claude-code --workers 1 \
+    > "$signal_log" 2>&1 ||
+    signal_status=$?
+  if [[ "$signal_status" != "$expected_status" ]]; then
+    echo "dind-run.sh did not preserve the $signal exit status: $signal_status" >&2
+    exit 1
+  fi
+  if ! grep -Fxq -- "$signal env_file=removed" "$DOCKER_SIGNAL_LOG"; then
+    echo "dind-run.sh did not remove the env file before forwarding $signal" >&2
+    exit 1
+  fi
+  if ! grep -Fxq -- \
+    "$signal env_file=removed" "$DOCKER_SIGNAL_HELPER_LOG"; then
+    echo "dind-run.sh did not signal the container process after env cleanup" >&2
+    exit 1
+  fi
+  assert_env_files_removed "$signal-signaled DinD run"
+}
+
+run_signal_test TERM 143
+run_signal_test INT 130
 
 mkdir -p "$TMP_DIR/existing-bin"
 cat > "$TMP_DIR/existing-bin/docker" <<'MOCK'

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -59,21 +59,59 @@ cat > "$PROJECT_DIR/config.local.env" <<'EOF'
 BASE_URL=https://local.example.com
 API_KEY=sk-local
 MODEL=local-model
+OPIK_API_KEY=opik-local
+PIP_INDEX_URL=https://packages.example.com/simple
+NPM_CONFIG_REGISTRY=https://npm.example.com
 DIND_REGISTRY_MIRRORS="https://docker.m.daocloud.io, https://mirror.ccs.tencentyun.com"
 DIND_DEFAULT_ADDRESS_POOLS="base=10.200.0.0/13,size=21;base=172.16.0.0/12,size=20"
 EOF
 
 LOG="$TMP_DIR/docker.log"
 DOCKER_ACTION_LOG="$TMP_DIR/docker-actions.log"
-export DOCKER_ACTION_LOG
+DOCKER_ENV_CAPTURE_LOG="$TMP_DIR/docker-env-capture.log"
+export DOCKER_ACTION_LOG DOCKER_ENV_CAPTURE_LOG
 cat > "$TMP_DIR/bin/docker" <<'MOCK'
 #!/usr/bin/env bash
+set -euo pipefail
+
 printf '%s\n' "$*" >> "$DOCKER_ACTION_LOG"
 printf 'docker'
 for arg in "$@"; do
   printf ' <%s>' "$arg"
 done
 printf '\n'
+
+if [[ "${1:-}" == "exec" ]]; then
+  env_file=""
+  previous=""
+  for arg in "$@"; do
+    if [[ "$previous" == "--env-file" ]]; then
+      env_file="$arg"
+      break
+    fi
+    previous="$arg"
+  done
+  if [[ -n "$env_file" ]]; then
+    if [[ ! -f "$env_file" ]]; then
+      echo "docker exec env file does not exist: $env_file" >&2
+      exit 1
+    fi
+    if mode="$(stat -c '%a' "$env_file" 2>/dev/null)"; then
+      :
+    else
+      mode="$(stat -f '%Lp' "$env_file")"
+    fi
+    {
+      printf 'BEGIN %s\n' "$*"
+      printf 'ENV_FILE %s\n' "$env_file"
+      printf 'MODE %s\n' "$mode"
+      while IFS= read -r entry || [[ -n "$entry" ]]; do
+        printf 'ENV %s\n' "$entry"
+      done < "$env_file"
+      printf 'END\n'
+    } >> "$DOCKER_ENV_CAPTURE_LOG"
+  fi
+fi
 
 if [[ "${1:-}" == "ps" ]]; then
   exit 0
@@ -98,10 +136,36 @@ if [[ "${1:-}" == "exec" && "$*" == *"command -v pi"* ]]; then
     exit 1
   fi
 fi
+if [[ "${1:-}" == "exec" && "${MOCK_FAIL_RUN_FLEET:-0}" == "1" &&
+      "$*" == *"./scripts/run_fleet.sh"* ]]; then
+  exit 42
+fi
+if [[ "${1:-}" == "exec" && "${MOCK_SIGNAL_RUN_FLEET:-0}" == "1" &&
+      "$*" == *"./scripts/run_fleet.sh"* ]]; then
+  kill -TERM "$PPID"
+  exit 0
+fi
 exit 0
 MOCK
 chmod +x "$TMP_DIR/bin/docker"
 
+assert_env_files_removed() {
+  local context="$1" env_file leaked=0
+  while IFS= read -r env_file; do
+    if [[ "$env_file" == "$PROJECT_DIR" || "$env_file" == "$PROJECT_DIR/"* ]]; then
+      echo "$context used an env file inside the repository: $env_file" >&2
+      leaked=1
+    fi
+    if [[ -e "$env_file" ]]; then
+      echo "$context left its env file behind: $env_file" >&2
+      rm -f -- "$env_file"
+      leaked=1
+    fi
+  done < <(sed -n 's/^ENV_FILE //p' "$DOCKER_ENV_CAPTURE_LOG")
+  [[ "$leaked" == "0" ]]
+}
+
+: > "$DOCKER_ENV_CAPTURE_LOG"
 PATH="$TMP_DIR/bin:$PATH" \
 DIND_BOOTSTRAP=always \
 DIND_USER_UID=1234 \
@@ -134,16 +198,48 @@ grep -q -- '<--build-arg> <UV_IMAGE=m.daocloud.io/ghcr.io/astral-sh/uv:0.11.28>'
 grep -q -- "<-f> <$PROJECT_DIR/scripts/dind/Dockerfile> <-t> <$RUNNER_IMAGE> <$PROJECT_DIR>" "$LOG"
 grep -q -- "<--label> <agent-fleet.runner-image=$RUNNER_IMAGE>" "$LOG"
 grep -q -- "^docker <run> .* <-w> <$PROJECT_DIR> <$RUNNER_IMAGE> " "$LOG"
-grep -q -- '<env> <REPO_DIR='"$PROJECT_DIR"'> <BASE_URL=https://local.example.com> <API_KEY=sk-local> <MODEL=local-model>' "$LOG"
-# The documented no-Opik escape must survive the DinD env handoff.
-grep -q -- '<TRACE_TO_OPIK=false>' "$LOG"
+for secret in sk-local opik-local; do
+  if grep -Fq -- "$secret" "$LOG" || grep -Fq -- "$secret" "$DOCKER_ACTION_LOG"; then
+    echo "dind-run.sh exposed a fake credential in Docker argv: $secret" >&2
+    exit 1
+  fi
+done
+grep -Eq -- '^docker <exec> <--user> <agent> <--env-file> </tmp/agent-fleet-dind-env\.[^>]+> <agent-fleet-dind> <./scripts/setup.sh>$' "$LOG"
+grep -Eq -- '^docker <exec> <--user> <agent> <--env-file> </tmp/agent-fleet-dind-env\.[^>]+> <agent-fleet-dind> <./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>$' "$LOG"
+if grep -Eq -- '^docker <exec> <--user> <agent> .* <env> .*<./scripts/(setup|run_fleet).sh>' "$LOG"; then
+  echo "dind-run.sh still passes execution variables through an in-container env argv" >&2
+  exit 1
+fi
+env_capture_count="$(grep -c '^BEGIN ' "$DOCKER_ENV_CAPTURE_LOG" || true)"
+secure_mode_count="$(grep -c '^MODE 600$' "$DOCKER_ENV_CAPTURE_LOG" || true)"
+if [[ "$env_capture_count" != "2" || "$secure_mode_count" != "2" ]]; then
+  echo "setup and benchmark must each receive the same mode-0600 env file" >&2
+  exit 1
+fi
+for expected_env in \
+  "REPO_DIR=$PROJECT_DIR" \
+  "BASE_URL=https://local.example.com" \
+  "API_KEY=sk-local" \
+  "MODEL=local-model" \
+  "HOME=/home/agent" \
+  "HTTP_PROXY=http://proxy.invalid:8080" \
+  "HTTPS_PROXY=http://proxy.invalid:8443" \
+  "TRACE_TO_OPIK=false" \
+  "OPIK_API_KEY=opik-local" \
+  "PIP_INDEX_URL=https://packages.example.com/simple" \
+  "NPM_CONFIG_REGISTRY=https://npm.example.com"; do
+  if [[ "$(grep -Fxc -- "ENV $expected_env" "$DOCKER_ENV_CAPTURE_LOG" || true)" != "2" ]]; then
+    echo "setup and benchmark did not both receive: ${expected_env%%=*}" >&2
+    exit 1
+  fi
+done
+assert_env_files_removed "successful DinD run"
 if grep -q -- '<sh> <-lc>.*apk add' "$LOG"; then
   echo "dind-run.sh installed dependencies inside the running DinD container" >&2
   exit 1
 fi
 grep -q -- '<./scripts/setup.sh>' "$LOG"
-grep -q -- '^docker <exec> <--user> <agent> <agent-fleet-dind> <env> .* <./scripts/setup.sh>$' "$LOG"
-if grep -q -- '^docker <exec> <agent-fleet-dind> <env> .* <./scripts/setup.sh>$' "$LOG"; then
+if grep -q -- '^docker <exec> <agent-fleet-dind> .* <./scripts/setup.sh>$' "$LOG"; then
   echo "dind-run.sh ran setup as container root" >&2
   exit 1
 fi
@@ -156,6 +252,43 @@ if [[ "$home_chown_count" != "1" ]]; then
   exit 1
 fi
 grep -q -- '<./scripts/run_fleet.sh> <--taskset> <terminalbench21> <--agent> <claude-code> <--workers> <1>' "$LOG"
+
+: > "$DOCKER_ENV_CAPTURE_LOG"
+FAILURE_LOG="$TMP_DIR/failure.log"
+if PATH="$TMP_DIR/bin:$PATH" \
+  MOCK_FAIL_RUN_FLEET=1 \
+  DIND_BOOTSTRAP=always \
+  TRACE_TO_OPIK=false \
+  "$PROJECT_DIR/scripts/dind-run.sh" \
+    --taskset terminalbench21 --agent claude-code --workers 1 \
+    > "$FAILURE_LOG" 2>&1; then
+  echo "dind-run.sh ignored a benchmark docker exec failure" >&2
+  exit 1
+fi
+assert_env_files_removed "failed DinD run"
+for secret in sk-local opik-local; do
+  if grep -Fq -- "$secret" "$FAILURE_LOG" || grep -Fq -- "$secret" "$DOCKER_ACTION_LOG"; then
+    echo "failed DinD run exposed a fake credential in Docker argv: $secret" >&2
+    exit 1
+  fi
+done
+
+: > "$DOCKER_ENV_CAPTURE_LOG"
+SIGNAL_LOG="$TMP_DIR/signal.log"
+signal_status=0
+PATH="$TMP_DIR/bin:$PATH" \
+MOCK_SIGNAL_RUN_FLEET=1 \
+DIND_BOOTSTRAP=always \
+TRACE_TO_OPIK=false \
+"$PROJECT_DIR/scripts/dind-run.sh" \
+  --taskset terminalbench21 --agent claude-code --workers 1 \
+  > "$SIGNAL_LOG" 2>&1 ||
+  signal_status=$?
+if [[ "$signal_status" != "143" ]]; then
+  echo "dind-run.sh did not preserve the TERM exit status: $signal_status" >&2
+  exit 1
+fi
+assert_env_files_removed "signaled DinD run"
 
 mkdir -p "$TMP_DIR/existing-bin"
 cat > "$TMP_DIR/existing-bin/docker" <<'MOCK'
@@ -207,7 +340,7 @@ grep -qF -- '<sh> <-c> <paths_file="${AGENT_FLEET_PATHS_FILE:-${XDG_CONFIG_HOME:
 grep -q -- '</home/agent/.pi/agent/models.json>' "$LOG"
 grep -q -- '</home/agent/.pi/agent/skills/harbor-benchmark-runner>' "$LOG"
 grep -q -- '<0.81.1> </home/agent>' "$LOG"
-grep -q -- '<PI_VERSION=0.81.1>' "$LOG"
+grep -q -- '^ENV PI_VERSION=0.81.1$' "$DOCKER_ENV_CAPTURE_LOG"
 if grep -q -- 'command -v claude' "$LOG"; then
   echo "dind-run.sh still checks the controller for Claude Code" >&2
   exit 1


### PR DESCRIPTION
## 1. Why the change?

DinD setup and benchmark commands currently receive their environment through
an in-container `env KEY=value ...` command. Credential values such as
`API_KEY` and `OPIK_API_KEY` therefore appear in both the host Docker CLI argv
and the container process argv while those commands start.

## 2. Summary of the change

- Write the DinD execution environment to a random host-side file under
  `/tmp`, created with `umask 077` and explicitly restricted to mode `0600`.
- Pass that file through `docker exec --env-file` so credential values are
  environment data rather than command arguments.
- Remove the temporary file after success, command failure, and
  `HUP`/`INT`/`TERM`.
- Reject carriage returns and newlines that Docker env-file syntax cannot
  represent safely.
- Preserve proxy, tracing, package-source, registry, and preflight environment
  forwarding for both setup and benchmark execution.

## 3. Other details

Validation:

- `env -i PATH="$PATH" HOME="$HOME" USER="${USER:-}" bash scripts/tests/test_dind_run.sh`
- `python3 -m unittest scripts/tests/test_setup.py`
- `bash -n scripts/dind-run.sh scripts/tests/test_dind_run.sh scripts/setup.sh`
- `git diff --check`
- A fresh real DinD bootstrap and benchmark dry-run using unique temporary
  Docker resources and fake credentials.

The real-run Docker argv contained only the mode-`0600` temporary file path;
both fake credentials reached setup and benchmark through the environment,
and the file was absent after completion. All validation containers, volumes,
and temporary checkouts were removed.
