### PR TITLE
Enable cgroup v2 nesting in DinD

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -42,5 +42,6 @@ jobs:
           set -euo pipefail
           python3 -m unittest discover -s tests -v
           python3 -m unittest discover -s scripts/tests -v
+          bash scripts/tests/test_dind_cgroup_v2.sh
           bash scripts/tests/test_dind_run.sh
           python3 -m unittest discover -s .github/scripts/tests -v

--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -98,9 +98,11 @@ DIND_BASE_IMAGE="${DIND_BASE_IMAGE:-m.daocloud.io/docker.io/library/debian:bookw
 DIND_UV_IMAGE="${DIND_UV_IMAGE:-m.daocloud.io/ghcr.io/astral-sh/uv:0.11.28}"
 DIND_RUNNER_REQUIREMENTS_FILE="$REPO_ROOT/Agents/utils/common/Harbor/runner-requirements.txt"
 DIND_DOCKERD_ENTRYPOINT_FILE="$REPO_ROOT/scripts/dind/dockerd-entrypoint.sh"
+DIND_CGROUP_V2_HELPER_FILE="$REPO_ROOT/scripts/dind/prepare-cgroup-v2.sh"
 for image_input in \
   "$DIND_IMAGE_DOCKERFILE" \
   "$DIND_DOCKERD_ENTRYPOINT_FILE" \
+  "$DIND_CGROUP_V2_HELPER_FILE" \
   "$DIND_RUNNER_REQUIREMENTS_FILE"; do
   if [[ ! -f "$image_input" ]]; then
     err "DinD image input not found: $image_input"
@@ -109,7 +111,11 @@ for image_input in \
 done
 DIND_IMAGE_FINGERPRINT="$({
   printf '%s\n' "$DIND_BASE_IMAGE" "$DIND_UV_IMAGE"
-  cat "$DIND_IMAGE_DOCKERFILE" "$DIND_DOCKERD_ENTRYPOINT_FILE" "$DIND_RUNNER_REQUIREMENTS_FILE"
+  cat \
+    "$DIND_IMAGE_DOCKERFILE" \
+    "$DIND_DOCKERD_ENTRYPOINT_FILE" \
+    "$DIND_CGROUP_V2_HELPER_FILE" \
+    "$DIND_RUNNER_REQUIREMENTS_FILE"
 } | sha256sum | cut -c1-12)"
 DIND_DEFAULT_IMAGE="agent-fleet-dind:28-$DIND_IMAGE_FINGERPRINT"
 DIND_IMAGE="${DIND_IMAGE:-$DIND_DEFAULT_IMAGE}"

--- a/scripts/dind/Dockerfile
+++ b/scripts/dind/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
 
 COPY --from=uv /uv /uvx /usr/local/bin/
 COPY scripts/dind/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
+COPY scripts/dind/prepare-cgroup-v2.sh /usr/local/bin/prepare-cgroup-v2.sh
 COPY Agents/utils/common/Harbor/runner-requirements.txt /opt/harbor-runner-requirements.txt
 
 ENV PATH="/opt/harbor-runner/bin:${PATH}" \

--- a/scripts/dind/dockerd-entrypoint.sh
+++ b/scripts/dind/dockerd-entrypoint.sh
@@ -2,6 +2,8 @@
 # Start dockerd for the DinD path, or pass an explicit command through unchanged.
 set -eu
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
   set -- dockerd \
     --host=unix:///var/run/docker.sock \
@@ -9,6 +11,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "${1:-}" = dockerd ]; then
+  "$SCRIPT_DIR/prepare-cgroup-v2.sh"
   find /run /var/run -iname 'docker*.pid' -delete 2>/dev/null || true
 fi
 

--- a/scripts/dind/prepare-cgroup-v2.sh
+++ b/scripts/dind/prepare-cgroup-v2.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Prepare a cgroup v2 hierarchy for containers launched by nested dockerd.
+set -eu
+
+cgroup_root="${1:-/sys/fs/cgroup}"
+
+if [ ! -f "$cgroup_root/cgroup.controllers" ]; then
+  exit 0
+fi
+
+mkdir -p "$cgroup_root/init"
+
+# A non-root cgroup cannot both contain processes and distribute domain
+# controllers to children. Move DinD's own processes into /init first, then
+# enable every delegated controller for the nested Docker hierarchy.
+#
+# Repeat because an outer `docker exec` can add a process while the initial
+# process list is being drained.
+while ! {
+  xargs -r -n 1 < "$cgroup_root/cgroup.procs" \
+    > "$cgroup_root/init/cgroup.procs" || :
+  sed -e 's/ / +/g' -e 's/^/+/' \
+    < "$cgroup_root/cgroup.controllers" \
+    > "$cgroup_root/cgroup.subtree_control"
+}; do
+  :
+done

--- a/scripts/dind/prepare-cgroup-v2.sh
+++ b/scripts/dind/prepare-cgroup-v2.sh
@@ -1,12 +1,23 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Prepare a cgroup v2 hierarchy for containers launched by nested dockerd.
-set -eu
+set -euo pipefail
 
 cgroup_root="${1:-/sys/fs/cgroup}"
+max_attempts=100
+retry_delay=0.01
 
-if [ ! -f "$cgroup_root/cgroup.controllers" ]; then
+if [[ ! -f "$cgroup_root/cgroup.controllers" ]]; then
   exit 0
 fi
+
+controllers=()
+read -r -a controllers < "$cgroup_root/cgroup.controllers" || true
+if (( ${#controllers[@]} == 0 )); then
+  exit 0
+fi
+
+controller_directives=("${controllers[@]/#/+}")
+controller_line="${controller_directives[*]}"
 
 mkdir -p "$cgroup_root/init"
 
@@ -15,13 +26,24 @@ mkdir -p "$cgroup_root/init"
 # enable every delegated controller for the nested Docker hierarchy.
 #
 # Repeat because an outer `docker exec` can add a process while the initial
-# process list is being drained.
-while ! {
+# process list is being drained. Bound the retries so a persistent cgroup
+# write failure cannot block dockerd startup forever.
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   xargs -r -n 1 < "$cgroup_root/cgroup.procs" \
     > "$cgroup_root/init/cgroup.procs" || :
-  sed -e 's/ / +/g' -e 's/^/+/' \
-    < "$cgroup_root/cgroup.controllers" \
-    > "$cgroup_root/cgroup.subtree_control"
-}; do
-  :
+
+  if {
+    printf '%s\n' "$controller_line" \
+      > "$cgroup_root/cgroup.subtree_control"
+  } 2>/dev/null; then
+    exit 0
+  fi
+
+  if (( attempt < max_attempts )); then
+    sleep "$retry_delay"
+  fi
 done
+
+printf 'failed to enable cgroup v2 controllers after %d attempts: %s\n' \
+  "$max_attempts" "$controller_line" >&2
+exit 1

--- a/scripts/tests/test_dind_cgroup_v2.sh
+++ b/scripts/tests/test_dind_cgroup_v2.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CGROUP_V2_ROOT="$TMP_DIR/cgroup-v2"
+mkdir -p "$CGROUP_V2_ROOT"
+printf '%s\n' 'cpu io memory pids' > "$CGROUP_V2_ROOT/cgroup.controllers"
+printf '%s\n' 101 202 > "$CGROUP_V2_ROOT/cgroup.procs"
+: > "$CGROUP_V2_ROOT/cgroup.subtree_control"
+
+"$REPO_ROOT/scripts/dind/prepare-cgroup-v2.sh" "$CGROUP_V2_ROOT"
+
+test -d "$CGROUP_V2_ROOT/init"
+printf '%s\n' 101 202 > "$TMP_DIR/expected-procs"
+cmp "$TMP_DIR/expected-procs" "$CGROUP_V2_ROOT/init/cgroup.procs"
+grep -Fxq -- '+cpu +io +memory +pids' "$CGROUP_V2_ROOT/cgroup.subtree_control"
+
+CGROUP_V1_ROOT="$TMP_DIR/cgroup-v1"
+mkdir -p "$CGROUP_V1_ROOT"
+"$REPO_ROOT/scripts/dind/prepare-cgroup-v2.sh" "$CGROUP_V1_ROOT"
+test ! -e "$CGROUP_V1_ROOT/init"

--- a/scripts/tests/test_dind_cgroup_v2.sh
+++ b/scripts/tests/test_dind_cgroup_v2.sh
@@ -18,6 +18,33 @@ printf '%s\n' 101 202 > "$TMP_DIR/expected-procs"
 cmp "$TMP_DIR/expected-procs" "$CGROUP_V2_ROOT/init/cgroup.procs"
 grep -Fxq -- '+cpu +io +memory +pids' "$CGROUP_V2_ROOT/cgroup.subtree_control"
 
+EMPTY_CONTROLLERS_ROOT="$TMP_DIR/empty-controllers"
+mkdir -p "$EMPTY_CONTROLLERS_ROOT"
+printf '\n' > "$EMPTY_CONTROLLERS_ROOT/cgroup.controllers"
+printf '%s\n' 303 > "$EMPTY_CONTROLLERS_ROOT/cgroup.procs"
+printf '%s\n' 'unchanged' > "$EMPTY_CONTROLLERS_ROOT/cgroup.subtree_control"
+
+"$REPO_ROOT/scripts/dind/prepare-cgroup-v2.sh" "$EMPTY_CONTROLLERS_ROOT"
+
+test ! -e "$EMPTY_CONTROLLERS_ROOT/init"
+grep -Fxq 'unchanged' "$EMPTY_CONTROLLERS_ROOT/cgroup.subtree_control"
+
+WRITE_FAILURE_ROOT="$TMP_DIR/write-failure"
+mkdir -p "$WRITE_FAILURE_ROOT"
+printf '%s\n' 'cpu' > "$WRITE_FAILURE_ROOT/cgroup.controllers"
+printf '%s\n' 404 > "$WRITE_FAILURE_ROOT/cgroup.procs"
+mkdir "$WRITE_FAILURE_ROOT/cgroup.subtree_control"
+
+if "$REPO_ROOT/scripts/dind/prepare-cgroup-v2.sh" "$WRITE_FAILURE_ROOT" \
+  > "$TMP_DIR/write-failure.stdout" \
+  2> "$TMP_DIR/write-failure.stderr"; then
+  echo "expected a persistent cgroup write failure" >&2
+  exit 1
+fi
+grep -Fxq \
+  'failed to enable cgroup v2 controllers after 100 attempts: +cpu' \
+  "$TMP_DIR/write-failure.stderr"
+
 CGROUP_V1_ROOT="$TMP_DIR/cgroup-v1"
 mkdir -p "$CGROUP_V1_ROOT"
 "$REPO_ROOT/scripts/dind/prepare-cgroup-v2.sh" "$CGROUP_V1_ROOT"

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -30,6 +30,7 @@ if old not in text:
 path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
 cp "$REPO_ROOT/scripts/dind/dockerd-entrypoint.sh" "$PROJECT_DIR/scripts/dind/dockerd-entrypoint.sh"
+cp "$REPO_ROOT/scripts/dind/prepare-cgroup-v2.sh" "$PROJECT_DIR/scripts/dind/prepare-cgroup-v2.sh"
 cp "$REPO_ROOT/scripts/run_fleet.sh" "$PROJECT_DIR/scripts/run_fleet.sh"
 cp "$REPO_ROOT/scripts/prerequisites.sh" "$PROJECT_DIR/scripts/prerequisites.sh"
 cp "$REPO_ROOT/scripts/fleet_spec_io.sh" "$PROJECT_DIR/scripts/fleet_spec_io.sh"


### PR DESCRIPTION
## 1. Why the change?

On cgroup v2 hosts, the custom privileged DinD runner could start its own
daemon but failed when Harbor launched a nested task container:

```text
cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in an invalid state
```

The DinD entrypoint left its own processes in the delegated root cgroup while
nested dockerd attempted to distribute domain controllers to child cgroups.
As a result, every Docker-backed benchmark task failed during environment
setup before the agent could run.

## 2. Summary of the change

- Move DinD's root cgroup processes into an `/init` child before dockerd starts.
- Enable all delegated cgroup v2 controllers for nested containers, retrying
  around `docker exec` process races.
- Keep cgroup v1 behavior unchanged.
- Include the new helper in the DinD image and image fingerprint so existing
  runners rebuild onto the fixed image.
- Add focused cgroup v1/v2 tests and run them in PR CI.

## 3. Other details

Validation:

- `python3 -m unittest discover -s scripts/tests -v` — 116 tests passed.
- `bash scripts/tests/test_dind_cgroup_v2.sh`
- `bash scripts/tests/test_dind_run.sh`
- Shell syntax checks and `git diff --check`
- Built the updated DinD image on a cgroup v2 host and started a real nested
  `busybox` container successfully. The DinD root cgroup had zero processes,
  its own processes were under `/init`, and all delegated controllers were
  enabled.

The real validation used no API credentials or other secrets.
