### PR TITLE
Simplify interactive Opik setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,26 @@ cd agent-fleet
 ### 3. Configure and set up
 
 Run the commands below, replacing the example values with your model gateway
-credentials. Setup asks whether to enable Opik tracing and defaults to no; it
-persists the choice in `config.local.env`:
+credentials. Setup then asks for an optional `OPIK_URL`: enter the endpoint to
+use Opik, or press Enter to continue without it. The resulting configuration
+is persisted in `config.local.env`:
 
 ```bash
 export BASE_URL=https://your-model-gateway.example.com  # Do not include /v1
 export API_KEY=your-api-key
 export MODEL=your-model-id
 
-# Optional automation override; omit it to answer the setup prompt.
-export TRACE_TO_OPIK=false
-# To enable tracing instead, set TRACE_TO_OPIK=true and OPIK_URL.
+# Optional: pre-fill this or enter it when setup prompts.
+# export OPIK_URL=https://your-opik-host/api
 
 ./scripts/setup.sh
 ```
 
 Setup stores your credentials in the git-ignored `config.local.env` and puts
 every managed tool on `PATH`, so the runner scripts work in this and future
-shells with no manual environment changes.
+shells with no manual environment changes. For automation or a temporary
+override, `TRACE_TO_OPIK=false` disables Opik even when a saved URL exists;
+`TRACE_TO_OPIK=true` requires `OPIK_URL`.
 
 ### 4. Run one benchmark
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ export MODEL=your-model-id
 
 Setup stores your credentials in the git-ignored `config.local.env` and puts
 every managed tool on `PATH`, so the runner scripts work in this and future
-shells with no manual environment changes. For automation or a temporary
-override, `TRACE_TO_OPIK=false` disables Opik even when a saved URL exists;
-`TRACE_TO_OPIK=true` requires `OPIK_URL`.
+shells with no manual environment changes.
 
 ### 4. Run one benchmark
 

--- a/config.env
+++ b/config.env
@@ -24,14 +24,9 @@
 # API_KEY=sk-your-key
 # MODEL=your-model-id
 
-# ── Opik tracing ─────────────────────────────────────────────────────
-# setup.sh asks only for this optional endpoint, then records an explicit
-# internal TRACE_TO_OPIK state in config.local.env.
+# ── Opik (optional) ──────────────────────────────────────────────────
+# setup.sh asks for this endpoint and persists whether Opik should be used.
 # OPIK_URL=https://opik.example.com/api
-# Advanced fleet-wide override: false disables every supported benchmark path
-# while retaining any saved endpoint and overrides stale OPIK_PLUGIN=enabled
-# settings. true requires OPIK_URL.
-# TRACE_TO_OPIK=true
 # OPIK_PROJECT_NAME=
 
 # ── Package mirrors ───────────────────────────────────────────────────────────

--- a/config.env
+++ b/config.env
@@ -25,12 +25,13 @@
 # MODEL=your-model-id
 
 # ── Opik tracing ─────────────────────────────────────────────────────
-# Fleet-wide switch. Set false to run every supported benchmark path without
-# Opik; this overrides stale subsystem-specific OPIK_PLUGIN=enabled settings.
-# setup.sh records an explicit choice in config.local.env. Uncomment only when
-# configuring the repository without setup.
-# TRACE_TO_OPIK=true
+# setup.sh asks only for this optional endpoint, then records an explicit
+# internal TRACE_TO_OPIK state in config.local.env.
 # OPIK_URL=https://opik.example.com/api
+# Advanced fleet-wide override: false disables every supported benchmark path
+# while retaining any saved endpoint and overrides stale OPIK_PLUGIN=enabled
+# settings. true requires OPIK_URL.
+# TRACE_TO_OPIK=true
 # OPIK_PROJECT_NAME=
 
 # ── Package mirrors ───────────────────────────────────────────────────────────

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -485,9 +485,10 @@ interfaces:
   derives `TRACE_TO_OPIK=true`, while an empty optional URL derives
   `TRACE_TO_OPIK=false`.
 - `TRACE_TO_OPIK` remains the advanced fleet-wide switch for Harbor, workers,
-  rollouts, DinD, ClawBio, and PinchBench. An explicit value takes precedence
-  over URL-based setup inference; setup accepts common boolean spellings and
-  normalizes them, while runtime consumers treat only `false` or `0` as off.
+  rollouts, DinD, ClawBio, and PinchBench. A caller-supplied switch takes
+  precedence over a caller-supplied URL, which in turn takes precedence over
+  saved setup state. Setup accepts common boolean spellings and normalizes
+  them, while runtime consumers treat only `false` or `0` as off.
 - With `TRACE_TO_OPIK=false` there are no traces and no dashboard, Opik
   settings are not exposed to task containers, and the Claude realtime hook
   stays off even if `TB_CC_OPIK_ENABLE_HOOK=1` is set. `TRACE_TO_OPIK=false`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,13 +18,14 @@ For the end-to-end quick start, see the [root README](../README.md#quick-start).
 
 ```bash
 ./scripts/setup.sh
-# Interactive prompts for BASE_URL / API_KEY / MODEL and optional Opik tracing
+# Interactive prompts for BASE_URL / API_KEY / MODEL and an optional OPIK_URL
 ```
 
 Run setup from a complete cloned checkout. `setup.sh` sources neighboring
 repository scripts and is not a standalone download-and-run installer.
-Press Enter at the Opik prompt to keep tracing disabled. If tracing is enabled,
-setup also requires an `OPIK_URL`.
+Enter an `OPIK_URL` to use Opik, or press Enter at that prompt to continue
+without it. Setup derives and persists the internal fleet-wide tracing switch
+from that choice.
 
 Or pre-fill via env vars (suitable for automation):
 
@@ -32,9 +33,13 @@ Or pre-fill via env vars (suitable for automation):
 BASE_URL=https://your-model-gateway.example.com \
 API_KEY=your-token \
 MODEL=your-model-id \
-TRACE_TO_OPIK=false \
+OPIK_URL=https://your-opik-host/api \
 ./scripts/setup.sh
 ```
+
+For an advanced or temporary override, set `TRACE_TO_OPIK=false` to disable
+Opik while retaining a saved endpoint, or set `TRACE_TO_OPIK=true` together
+with `OPIK_URL` to force it on.
 
 **System prerequisites**: Install Docker with Compose v2, Python >=3.9,
 `git`, `curl`, `jq`, `openssl`, Linux `util-linux`, and `procps`. Commands must
@@ -49,7 +54,7 @@ dependency and is prepared separately by the runner.
 
 1. Check system dependencies and provision managed Zellij + uv
 2. Reuse existing local config, gather missing model endpoint values, and
-   persist an explicit Opik tracing choice (default: disabled)
+   gather an optional Opik endpoint while persisting the derived tracing state
 3. Install Node.js via nvm (if missing or < 22.19)
 4. Install Pi (pinned to 0.81.1)
 5. Merge the `sii-gateway` Pi provider and default model
@@ -474,16 +479,23 @@ interfaces:
 - `--detach` is redundant for multi-run input: Harbor runs always detach there
   (an informational notice is printed), while OpenClaw runners stay in the
   foreground and ignore `--detach` with a warning in every mode.
-- Opik tracing is on by default, and the benchmark runtime then requires
-  `OPIK_URL`. `TRACE_TO_OPIK` is the single tracing switch for every runner
-  (Harbor, worker, rollout, DinD, ClawBio, PinchBench), and only the literal
-  values `false` or `0` disable it — any other spelling keeps tracing on.
+- If `TRACE_TO_OPIK` is absent, benchmark runners retain their historical
+  tracing-on default and require `OPIK_URL`. Interactive setup avoids that
+  ambiguity by always persisting an explicit state: a supplied `OPIK_URL`
+  derives `TRACE_TO_OPIK=true`, while an empty optional URL derives
+  `TRACE_TO_OPIK=false`.
+- `TRACE_TO_OPIK` remains the advanced fleet-wide switch for Harbor, workers,
+  rollouts, DinD, ClawBio, and PinchBench. An explicit value takes precedence
+  over URL-based setup inference; setup accepts common boolean spellings and
+  normalizes them, while runtime consumers treat only `false` or `0` as off.
 - With `TRACE_TO_OPIK=false` there are no traces and no dashboard, Opik
   settings are not exposed to task containers, and the Claude realtime hook
   stays off even if `TB_CC_OPIK_ENABLE_HOOK=1` is set. `TRACE_TO_OPIK=false`
   is authoritative in ClawBio: it forces `OPIK_PLUGIN=disabled` even over an
   explicit `OPIK_PLUGIN=enabled`; with tracing on, an explicit `OPIK_PLUGIN`
-  wins and `OPIK_PLUGIN=enabled` requires `OPIK_URL`.
+  wins and `OPIK_PLUGIN=enabled` requires `OPIK_URL`. Setup retains an existing
+  endpoint and credentials when tracing is disabled so they can be re-enabled
+  without re-entry.
 - PinchBench refuses a `TRACE_TO_OPIK=false` run while the OpenClaw gateway
   configs still enable the Opik tracer plugin; regenerate the fleet with
   `TRACE_TO_OPIK=false ./Agents/Openclaw/scripts/setup.sh <n>` first.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -107,6 +107,21 @@ normalize_trace_to_opik() {
 }
 
 configure_opik() {
+  if (( SETUP_CALLER_HAS_OPIK_URL )); then
+    OPIK_URL="$(trim_setup_config_value "${OPIK_URL:-}")"
+  fi
+
+  if (( SETUP_CALLER_HAS_TRACE_TO_OPIK )) &&
+     [[ -n "${TRACE_TO_OPIK:-}" ]]; then
+    # Keep the caller's explicit switch as the highest-priority input.
+    :
+  elif (( SETUP_CALLER_HAS_OPIK_URL )) &&
+       [[ -n "${OPIK_URL:-}" ]]; then
+    # A URL supplied for this setup run enables Opik even if an earlier
+    # no-Opik run persisted TRACE_TO_OPIK=false in config.local.env.
+    TRACE_TO_OPIK=true
+  fi
+
   if [[ -n "${TRACE_TO_OPIK:-}" ]]; then
     if ! normalize_trace_to_opik "$TRACE_TO_OPIK"; then
       err "TRACE_TO_OPIK must be true or false (also accepts yes/no and 1/0)."
@@ -150,6 +165,14 @@ configure_opik() {
 
 # Credentials come from the caller environment first, then the existing
 # checkout config. Prompt only for values that are still missing.
+SETUP_CALLER_HAS_TRACE_TO_OPIK=0
+SETUP_CALLER_HAS_OPIK_URL=0
+if declare -p TRACE_TO_OPIK >/dev/null 2>&1; then
+  SETUP_CALLER_HAS_TRACE_TO_OPIK=1
+fi
+if declare -p OPIK_URL >/dev/null 2>&1; then
+  SETUP_CALLER_HAS_OPIK_URL=1
+fi
 load_existing_setup_config
 info "Gathering model endpoint config..."
 [[ -z "${BASE_URL:-}" ]]   && read -rp "BASE_URL (model gateway, WITHOUT /v1): " BASE_URL

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -106,50 +106,45 @@ normalize_trace_to_opik() {
   esac
 }
 
-prompt_trace_to_opik() {
-  local reply
+configure_opik() {
   if [[ -n "${TRACE_TO_OPIK:-}" ]]; then
     if ! normalize_trace_to_opik "$TRACE_TO_OPIK"; then
       err "TRACE_TO_OPIK must be true or false (also accepts yes/no and 1/0)."
       return 1
     fi
+  elif [[ -n "${OPIK_URL:-}" ]]; then
+    # Preserve the historical/default traced behavior for existing configs
+    # that predate the explicit fleet-wide switch.
+    TRACE_TO_OPIK=true
   else
-    while true; do
-      reply=""
-      if ! read -rp "Enable Opik tracing? [y/N]: " reply; then
-        echo
-      fi
-      case "${reply,,}" in
-        ""|n|no)
-          TRACE_TO_OPIK=false
-          break
-          ;;
-        y|yes)
-          TRACE_TO_OPIK=true
-          break
-          ;;
-        *)
-          warn "Please answer yes or no."
-          ;;
-      esac
-    done
+    if ! read -rp "OPIK_URL (optional; press Enter to disable Opik): " OPIK_URL; then
+      echo
+      OPIK_URL=""
+    fi
+    OPIK_URL="$(trim_setup_config_value "${OPIK_URL:-}")"
+    if [[ -n "$OPIK_URL" ]]; then
+      TRACE_TO_OPIK=true
+    else
+      TRACE_TO_OPIK=false
+    fi
   fi
 
   if [[ "$TRACE_TO_OPIK" == "true" ]]; then
     if [[ -z "${OPIK_URL:-}" ]]; then
-      if ! read -rp "OPIK_URL (remote Opik API endpoint, usually ending in /api): " OPIK_URL; then
+      if ! read -rp "OPIK_URL (required because TRACE_TO_OPIK=true; usually ending in /api): " OPIK_URL; then
         echo
         OPIK_URL=""
       fi
     fi
+    OPIK_URL="$(trim_setup_config_value "${OPIK_URL:-}")"
     if [[ -z "${OPIK_URL:-}" ]]; then
-      err "Opik tracing was enabled but OPIK_URL is empty."
+      err "Opik is enabled but OPIK_URL is empty."
       return 1
     fi
     OPIK_WORKSPACE="${OPIK_WORKSPACE:-default}"
-    ok "Opik tracing enabled"
+    ok "Opik enabled"
   else
-    ok "Opik tracing disabled"
+    ok "Opik disabled"
   fi
 }
 
@@ -165,7 +160,7 @@ if [[ -z "${AUTH_TOKEN:-}" ]]; then
   echo
 fi
 [[ -z "${MODEL:-}" ]]      && read -rp "MODEL (model id): " MODEL
-prompt_trace_to_opik
+configure_opik
 
 for v in BASE_URL AUTH_TOKEN MODEL; do
   if [[ -z "${!v:-}" ]]; then

--- a/scripts/tests/test_setup.py
+++ b/scripts/tests/test_setup.py
@@ -334,7 +334,7 @@ exit 0
         self.assertIn("cannot access the Docker daemon", denied.stderr)
         self.assertNotIn("Environment setup complete", denied.stdout)
 
-    def test_setup_reuses_existing_config_and_defaults_opik_tracing_off(self):
+    def test_setup_reuses_existing_config_and_defaults_opik_off(self):
         original = (
             "# existing values\n"
             "KEEP_SETTING=yes\n"
@@ -356,7 +356,7 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Opik tracing disabled", result.stdout)
+        self.assertIn("Opik disabled", result.stdout)
         config = config_path.read_text(encoding="utf-8")
         self.assertIn("KEEP_SETTING=yes", config)
         self.assertIn("BASE_URL=https://existing.example.invalid", config)
@@ -378,7 +378,7 @@ exit 0
         self.assertEqual(backup.read_text(encoding="utf-8"), original)
         self.assertEqual(backup.stat().st_mode & 0o777, 0o600)
 
-    def test_setup_prompts_for_opik_url_when_tracing_is_enabled(self):
+    def test_setup_enables_opik_when_optional_url_is_entered(self):
         (self.repo / "config.local.env").write_text(
             "BASE_URL=https://existing.example.invalid\n"
             "API_KEY=fake-existing-secret\n"
@@ -390,18 +390,71 @@ exit 0
             [str(SETUP)],
             cwd=self.repo,
             env=self.setup_env(),
-            input="yes\nhttps://opik.example.invalid/api\n",
+            input="https://opik.example.invalid/api\n",
             text=True,
             capture_output=True,
             check=False,
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("Opik tracing enabled", result.stdout)
+        self.assertIn("Opik enabled", result.stdout)
         config = (self.repo / "config.local.env").read_text(encoding="utf-8")
         self.assertIn("TRACE_TO_OPIK=true", config)
         self.assertIn("OPIK_URL=https://opik.example.invalid/api", config)
         self.assertIn("OPIK_WORKSPACE=default", config)
+
+    def test_setup_enables_opik_for_legacy_config_with_url_only(self):
+        (self.repo / "config.local.env").write_text(
+            "BASE_URL=https://existing.example.invalid\n"
+            "API_KEY=fake-existing-secret\n"
+            "MODEL=existing-model\n"
+            "OPIK_URL=https://opik.example.invalid/api\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=self.setup_env(),
+            input="",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Opik enabled", result.stdout)
+        config = (self.repo / "config.local.env").read_text(encoding="utf-8")
+        self.assertIn("TRACE_TO_OPIK=true", config)
+        self.assertIn("OPIK_URL=https://opik.example.invalid/api", config)
+
+    def test_setup_explicit_trace_off_preserves_existing_opik_config(self):
+        (self.repo / "config.local.env").write_text(
+            "BASE_URL=https://existing.example.invalid\n"
+            "API_KEY=fake-existing-secret\n"
+            "MODEL=existing-model\n"
+            "TRACE_TO_OPIK=false\n"
+            "OPIK_URL=https://opik.example.invalid/api\n"
+            "OPIK_API_KEY=fake-opik-secret\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=self.setup_env(),
+            input="",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Opik disabled", result.stdout)
+        config = (self.repo / "config.local.env").read_text(encoding="utf-8")
+        self.assertIn("TRACE_TO_OPIK=false", config)
+        self.assertIn("OPIK_URL=https://opik.example.invalid/api", config)
+        self.assertIn("OPIK_API_KEY=fake-opik-secret", config)
 
     def test_setup_rejects_enabled_tracing_without_opik_url(self):
         (self.repo / "config.local.env").write_text(
@@ -425,7 +478,7 @@ exit 0
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
-            "Opik tracing was enabled but OPIK_URL is empty",
+            "Opik is enabled but OPIK_URL is empty",
             result.stderr,
         )
 

--- a/scripts/tests/test_setup.py
+++ b/scripts/tests/test_setup.py
@@ -456,6 +456,64 @@ exit 0
         self.assertIn("OPIK_URL=https://opik.example.invalid/api", config)
         self.assertIn("OPIK_API_KEY=fake-opik-secret", config)
 
+    def test_setup_caller_url_enables_opik_over_saved_trace_off(self):
+        (self.repo / "config.local.env").write_text(
+            "BASE_URL=https://existing.example.invalid\n"
+            "API_KEY=fake-existing-secret\n"
+            "MODEL=existing-model\n"
+            "TRACE_TO_OPIK=false\n",
+            encoding="utf-8",
+        )
+        env = self.setup_env()
+        env["OPIK_URL"] = "https://opik.example.invalid/api"
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=env,
+            input="",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Opik enabled", result.stdout)
+        config = (self.repo / "config.local.env").read_text(encoding="utf-8")
+        self.assertIn("TRACE_TO_OPIK=true", config)
+        self.assertIn("OPIK_URL=https://opik.example.invalid/api", config)
+
+    def test_setup_caller_trace_off_wins_over_caller_url(self):
+        (self.repo / "config.local.env").write_text(
+            "BASE_URL=https://existing.example.invalid\n"
+            "API_KEY=fake-existing-secret\n"
+            "MODEL=existing-model\n",
+            encoding="utf-8",
+        )
+        env = self.setup_env()
+        env.update(
+            {
+                "TRACE_TO_OPIK": "false",
+                "OPIK_URL": "https://opik.example.invalid/api",
+            }
+        )
+
+        result = subprocess.run(
+            [str(SETUP)],
+            cwd=self.repo,
+            env=env,
+            input="",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Opik disabled", result.stdout)
+        config = (self.repo / "config.local.env").read_text(encoding="utf-8")
+        self.assertIn("TRACE_TO_OPIK=false", config)
+        self.assertIn("OPIK_URL=https://opik.example.invalid/api", config)
+
     def test_setup_rejects_enabled_tracing_without_opik_url(self):
         (self.repo / "config.local.env").write_text(
             "BASE_URL=https://existing.example.invalid\n"


### PR DESCRIPTION
## 1. Why the change?

Interactive setup currently exposes `TRACE_TO_OPIK` as a separate yes/no decision before asking for `OPIK_URL`. These values are operationally related, so the extra tracing question adds user-facing complexity without adding a useful first-run choice.

The internal switch still needs to remain authoritative because it controls Harbor, OpenClaw, PinchBench, and ClawBio behavior and must support temporarily disabling Opik while retaining a saved endpoint.

## 2. Summary of the change

- Replace the tracing yes/no prompt with one optional `OPIK_URL` prompt.
- Derive and persist `TRACE_TO_OPIK=true` when a URL is supplied and `false` when it is left empty.
- Preserve explicit `TRACE_TO_OPIK` overrides, legacy URL-only configurations, and saved Opik settings while tracing is disabled.
- Update setup documentation and the public configuration template to distinguish the simple interactive flow from the advanced fleet-wide override.
- Add regression coverage for URL entry, URL omission, legacy configuration, and explicit trace-off preservation.

## 3. Other details

Validation:

- `python3 -m unittest discover -s scripts/tests` — 118 tests passed
- `bash scripts/tests/test_dind_cgroup_v2.sh`
- `bash scripts/tests/test_dind_run.sh`
- `bash scripts/tests/test_prerequisites.sh`
- `bash -n scripts/setup.sh`
- `git diff --check`
- Real TTY smoke tests in an isolated temporary HOME/repository:
  - empty URL persisted `TRACE_TO_OPIK=false`
  - entered URL persisted `TRACE_TO_OPIK=true`, the URL, and the default workspace
  - explicit `TRACE_TO_OPIK=false` retained the saved URL
  - each run completed the real Docker daemon permission check
