### PR TITLE
Fix Pi retry timeout budget

### DIFF
--- a/.github/scripts/pi_pr_review.py
+++ b/.github/scripts/pi_pr_review.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
@@ -305,6 +306,7 @@ class PiClient:
         retry_malformed: bool = False,
         response_validator: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
+        deadline = time.monotonic() + self.timeout
         with tempfile.TemporaryDirectory(prefix="pi-pr-review-") as tmp:
             root = Path(tmp)
             runtime_dir = root / "pi-agent"
@@ -333,6 +335,11 @@ class PiClient:
             prior_tool_calls = 0
             attempts = 2 if retry_malformed else 1
             for _ in range(attempts):
+                remaining_timeout = deadline - time.monotonic()
+                if remaining_timeout <= 0:
+                    raise PiReviewError(
+                        f"pi timed out after {self.timeout:g}s"
+                    )
                 try:
                     completed = subprocess.run(
                         command,
@@ -341,7 +348,7 @@ class PiClient:
                         input=model_input,
                         text=True,
                         capture_output=True,
-                        timeout=self.timeout,
+                        timeout=remaining_timeout,
                         check=False,
                     )
                 except subprocess.TimeoutExpired as exc:

--- a/.github/scripts/tests/test_pi_pr_review.py
+++ b/.github/scripts/tests/test_pi_pr_review.py
@@ -423,15 +423,18 @@ class PiClientTest(unittest.TestCase):
         self.assertIn("fatal error", str(ctx.exception))
 
     def test_timeout_raises(self) -> None:
-        client = self._make_client(timeout=0, pi_binary="/usr/bin/sleep")
-        # sleep 999 should exceed timeout=0
-        with mock.patch("subprocess.run") as run_mock:
+        client = self._make_client(timeout=30)
+        with mock.patch(
+            "time.monotonic",
+            side_effect=[100.0, 100.0],
+        ), mock.patch("subprocess.run") as run_mock:
             run_mock.side_effect = subprocess.TimeoutExpired(
-                ["sleep", "999"], 0.001
+                ["pi"], 30
             )
             with self.assertRaises(pi_review.PiReviewError) as ctx:
                 client.review("prompt", "diff")
             self.assertIn("timed out", str(ctx.exception))
+        run_mock.assert_called_once()
 
     def test_pi_not_found_raises(self) -> None:
         client = self._make_client(pi_binary="/nonexistent/pi-binary")
@@ -506,6 +509,27 @@ class PiClientTest(unittest.TestCase):
 
         timeouts = [call.kwargs["timeout"] for call in run_mock.call_args_list]
         self.assertEqual(timeouts, [30, 17.5])
+
+    def test_malformed_retry_stops_when_timeout_budget_is_exhausted(self) -> None:
+        client = self._make_client(timeout=30)
+        malformed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_make_text_response("not JSON"),
+            stderr="",
+        )
+
+        with mock.patch(
+            "time.monotonic",
+            side_effect=[100.0, 100.0, 130.0],
+        ), mock.patch(
+            "subprocess.run",
+            return_value=malformed,
+        ) as run_mock, self.assertRaises(pi_review.PiReviewError) as ctx:
+            client.review("prompt", "diff", retry_malformed=True)
+
+        self.assertIn("timed out after 30s", str(ctx.exception))
+        run_mock.assert_called_once()
 
     def test_retries_one_schema_invalid_model_response(self) -> None:
         client = self._make_client()

--- a/.github/scripts/tests/test_pi_pr_review.py
+++ b/.github/scripts/tests/test_pi_pr_review.py
@@ -480,6 +480,33 @@ class PiClientTest(unittest.TestCase):
         self.assertEqual(result, {"findings": [], "_pi_tool_calls": 3})
         self.assertEqual(run_mock.call_count, 2)
 
+    def test_malformed_retry_uses_remaining_timeout_budget(self) -> None:
+        client = self._make_client(timeout=30)
+        malformed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_make_text_response("not JSON"),
+            stderr="",
+        )
+        valid = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_make_findings_response([]),
+            stderr="",
+        )
+
+        with mock.patch(
+            "time.monotonic",
+            side_effect=[100.0, 100.0, 112.5],
+        ), mock.patch(
+            "subprocess.run",
+            side_effect=[malformed, valid],
+        ) as run_mock:
+            client.review("prompt", "diff", retry_malformed=True)
+
+        timeouts = [call.kwargs["timeout"] for call in run_mock.call_args_list]
+        self.assertEqual(timeouts, [30, 17.5])
+
     def test_retries_one_schema_invalid_model_response(self) -> None:
         client = self._make_client()
         invalid = subprocess.CompletedProcess(


### PR DESCRIPTION
## 1. Why the change?

Malformed Pi output can trigger a second subprocess attempt with a fresh 900-second timeout. Two attempts can therefore exceed the 20-minute workflow ceiling.

## 2. Summary of the change

- Establish one monotonic deadline for each Pi review invocation.
- Give every retry only the remaining portion of the configured timeout.
- Keep the existing 900-second total budget so long successful reviews are not cut off.
- Add a regression test proving a retry receives the reduced remaining timeout.

## 3. Other details

Verification:

- `python3 -m unittest discover -s .github/scripts/tests -v` — 180 passed
- `uvx --from ruff==0.16.0 ruff check --config .github/ruff.toml` — passed
- `git diff --check upstream/main...HEAD` — passed

The broader quick-check suite was also attempted locally. Its macOS-specific failures from missing `flock`/`setsid`, `/var` path canonicalization, and the DinD signal test reproduce on unchanged `upstream/main`.

Because the reviewer uses `pull_request_target`, a pre-merge run executes the base-branch implementation; provider-backed validation of this deadline change requires a post-merge canary.