### PR TITLE
Fix RL rollout CodeQL findings

### DIFF
--- a/Agents/utils/rl/ensure_rl_job_zellij.sh
+++ b/Agents/utils/rl/ensure_rl_job_zellij.sh
@@ -23,7 +23,8 @@ ensure_zellij_web_sharing_config() {
   fi
 }
 
-submission_slug="$(safe_name "$ray_submission_id")"
+submission_storage_id="${RL_ZELLIJ_SUBMISSION_STORAGE_ID:-$ray_submission_id}"
+submission_slug="$(safe_name "$submission_storage_id")"
 agent_slug="$(safe_name "${RL_AGENT:-claude-code}")"
 dataset_slug="$(safe_name "$dataset_name")"
 session_name="harbor-rollout-${agent_slug}-${dataset_slug}-${submission_slug}"

--- a/Agents/utils/rl/ensure_rl_job_zellij.sh
+++ b/Agents/utils/rl/ensure_rl_job_zellij.sh
@@ -5,9 +5,9 @@ RL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HARBOR_SCRIPT_DIR="${HARBOR_SCRIPT_DIR:-$(cd "$RL_SCRIPT_DIR/../common/Harbor" && pwd)}"
 . "$HARBOR_SCRIPT_DIR/env.sh"
 
-ray_submission_id="${1:?ray submission id required}"
+ray_submission_id="${1:-${RL_ZELLIJ_SUBMISSION_ID:?ray submission id required}}"
 dataset_name="${2:-${RL_DATASET_NAME:-seta}}"
-job_queue_dir="${3:-${RL_JOB_QUEUE_ROOT}/$(printf '%s' "$ray_submission_id" | tr -c 'A-Za-z0-9._-' '-')}"
+job_queue_dir="${3:-${RL_ZELLIJ_JOB_QUEUE_DIR:-${RL_JOB_QUEUE_ROOT}/$(printf '%s' "$ray_submission_id" | tr -c 'A-Za-z0-9._-' '-')}}"
 
 safe_name() {
   printf '%s' "$1" | tr '/[:space:]' '---' | tr -cd 'A-Za-z0-9._-'

--- a/Agents/utils/rl/rollout_remote_harbor.py
+++ b/Agents/utils/rl/rollout_remote_harbor.py
@@ -16,6 +16,7 @@ import signal
 import subprocess
 import threading
 import time
+from hashlib import sha256
 from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -34,6 +35,9 @@ DEFAULT_API_KEY_MODE = os.environ.get("RL_API_KEY_MODE", "static").strip().lower
 DEFAULT_OPIK_PROJECT_NAME = os.environ.get("OPIK_PROJECT_NAME", "")
 DEFAULT_DISABLED_TASK_IDS = os.environ.get("RL_DISABLED_TASK_IDS", "")
 DEFAULT_TIMEOUT = float(os.environ.get("RL_REQUEST_TIMEOUT", "3600"))
+REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+COMMAND_ARG_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,255}\Z")
+SENSITIVE_KEY_RE = re.compile(r"(^|[_-])(api[-_]?key|token|secret|password)([_-]|\Z)", re.IGNORECASE)
 TRACE_LOG = Path(os.environ.get("RL_TRACE_LOG", "/workspace/runs/rl-rollout-requests.jsonl"))
 QUEUE_DIR = Path(os.environ.get("RL_QUEUE_DIR", "/workspace/runs/rl-rollout-queue"))
 PENDING_DIR = QUEUE_DIR / "pending"
@@ -83,6 +87,60 @@ def _safe_slug(value: str, *, fallback: str = "default") -> str:
     return slug or fallback
 
 
+def _is_relative_path(value: Path) -> bool:
+    return not value.is_absolute() and ".." not in value.parts
+
+
+def _require_contained_path(path: Path, root: Path, *, label: str) -> Path:
+    resolved_path = path.resolve()
+    resolved_root = root.resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(f"{label} {resolved_path} is outside trusted root {resolved_root}") from exc
+    return resolved_path
+
+
+def _storage_id(value: str, *, prefix: str) -> str:
+    digest = sha256(value.encode("utf-8")).hexdigest()[:32]
+    return f"{prefix}-{digest}"
+
+
+def _validated_request_id(value: Any) -> str:
+    if value is None or str(value).strip() == "":
+        return uuid4().hex[:12]
+    request_id = str(value).strip()
+    if not REQUEST_ID_RE.fullmatch(request_id):
+        raise ValueError("request_id may contain only letters, digits, dot, underscore, and hyphen, up to 128 characters")
+    return request_id
+
+
+def _validated_command_arg_id(value: Any, *, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} is required")
+    if not COMMAND_ARG_ID_RE.fullmatch(text):
+        raise ValueError(f"{label} may contain only letters, digits, dot, underscore, and hyphen")
+    return text
+
+
+def _contains_sensitive_key(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if isinstance(key, str) and SENSITIVE_KEY_RE.search(key):
+                return True
+            if _contains_sensitive_key(nested):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_sensitive_key(item) for item in value)
+    return False
+
+
+def _reject_request_secrets(request: dict[str, Any]) -> None:
+    if _contains_sensitive_key(request):
+        raise ValueError("per-request secrets are not accepted; configure RL_API_KEY on the rollout server instead")
+
+
 def _short_suffix(value: str, width: int = 6) -> str:
     value = str(value or "").strip()
     return value[-width:] if value else ""
@@ -92,7 +150,7 @@ def _extract_ray_submission_id(request: dict[str, Any]) -> str:
     ray_submission_id = _first_nonempty(request.get("ray_submission_id"))
     if not ray_submission_id:
         raise ValueError("top-level ray_submission_id is required in rollout mode")
-    return ray_submission_id
+    return _validated_command_arg_id(ray_submission_id, label="ray_submission_id")
 
 
 def _extract_opik_project_name(request: dict[str, Any], ray_submission_id: str) -> str:
@@ -128,14 +186,14 @@ def _display_name(task_name: str, polar_task_id: str, session_id: str) -> str:
 
 def _queue_for_submission(ray_submission_id: str) -> Path:
     if not ray_submission_id:
-        return QUEUE_DIR
-    return JOB_QUEUE_ROOT / _safe_slug(ray_submission_id)
+        return _require_contained_path(QUEUE_DIR, QUEUE_DIR, label="queue dir")
+    return _require_contained_path(JOB_QUEUE_ROOT / _storage_id(ray_submission_id, prefix="submission"), JOB_QUEUE_ROOT, label="queue dir")
 
 
 def _submission_session_name(ray_submission_id: str, dataset_name: str) -> str:
     agent_slug = _safe_slug(os.environ.get("RL_AGENT", "claude-code"))
     dataset_slug = _safe_slug(dataset_name)
-    submission_slug = _safe_slug(ray_submission_id)
+    submission_slug = _storage_id(ray_submission_id, prefix="submission")
     return f"harbor-rollout-{agent_slug}-{dataset_slug}-{submission_slug}"
 
 
@@ -214,7 +272,7 @@ def _ensure_submission_zellij(
         raise ValueError("ray_submission_id is required in rollout mode so a worker zellij session can be started")
     if not ENABLE_DYNAMIC_JOB_ZELLIJ:
         raise RuntimeError("RL_DYNAMIC_JOB_ZELLIJ=0 is unsupported without a prestarted worker pool")
-    submission_slug = _safe_slug(ray_submission_id)
+    submission_slug = _storage_id(ray_submission_id, prefix="submission")
     expected_session = _submission_session_name(ray_submission_id, dataset_name)
     ready_session = _cached_job_session(submission_slug)
     if ready_session:
@@ -242,7 +300,7 @@ def _ensure_submission_zellij(
             "OPIK_PROJECT_NAME": opik_project_name,
         })
         returncode, stdout, stderr = _run_helper(
-            [str(script), ray_submission_id, dataset_name, str(queue_dir)],
+            [str(script)],
             cwd=str(SCRIPT_DIR),
             env=env,
             timeout=float(os.environ.get("RL_JOB_ZELLIJ_START_TIMEOUT", "45")),
@@ -278,7 +336,7 @@ def _dataset_roots() -> dict[str, Path]:
             roots[name.strip()] = Path(path.strip())
         else:
             roots[Path(item).name] = Path(item)
-    return roots
+    return {name: root.resolve() for name, root in roots.items()}
 
 
 def _task_sort_key(path: Path) -> tuple[int, int | str]:
@@ -286,14 +344,57 @@ def _task_sort_key(path: Path) -> tuple[int, int | str]:
 
 
 def _dataset_root(dataset_name: str | None = None, dataset_root: str | None = None) -> Path:
+    if dataset_root:
+        raise ValueError("dataset_root cannot be supplied by request; configure RL_DATASET_ROOTS on the rollout server")
     roots = _dataset_roots()
-    root = Path(dataset_root) if dataset_root else roots.get(dataset_name or DEFAULT_DATASET_NAME)
+    selected_dataset = dataset_name or DEFAULT_DATASET_NAME
+    _validated_command_arg_id(selected_dataset, label="dataset_name")
+    root = roots.get(selected_dataset)
     if root is None:
         raise ValueError(f"unknown dataset_name={dataset_name!r}; known={sorted(roots)}")
-    root = root.resolve()
     if not root.is_dir():
         raise FileNotFoundError(f"dataset root does not exist: {root}")
     return root
+
+
+def _allowed_request_value(request: dict[str, Any], *paths: str) -> Any:
+    for path in paths:
+        value: Any = request
+        for part in path.split("."):
+            if not isinstance(value, dict):
+                value = None
+                break
+            value = value.get(part)
+        if value not in (None, ""):
+            return value
+    return ""
+
+
+def _worker_options(request: dict[str, Any]) -> dict[str, Any]:
+    option_paths = {
+        "force_build": ("force_build", "trial_config.environment.force_build"),
+        "max_new_tokens": ("max_new_tokens", "trial_config.agent.kwargs.max_new_tokens"),
+        "model_info": ("model_info", "trial_config.agent.kwargs.model_info"),
+        "claude_code_max_output_tokens": (
+            "claude_code_max_output_tokens",
+            "trial_config.agent.kwargs.claude_code_max_output_tokens",
+        ),
+        "max_turns": ("max_turns", "trial_config.agent.kwargs.max_turns"),
+        "temperature": ("temperature", "trial_config.agent.kwargs.temperature", "trial_config.agent.kwargs.llm_kwargs.temperature"),
+        "top_p": ("top_p", "trial_config.agent.kwargs.llm_kwargs.top_p", "trial_config.agent.kwargs.top_p"),
+        "top_k": ("top_k", "trial_config.agent.kwargs.llm_kwargs.top_k", "trial_config.agent.kwargs.top_k"),
+        "min_p": ("min_p", "trial_config.agent.kwargs.llm_kwargs.min_p", "trial_config.agent.kwargs.min_p"),
+        "llm_timeout": ("llm_timeout", "trial_config.agent.kwargs.llm_kwargs.timeout"),
+        "llm_max_retries": ("llm_max_retries", "trial_config.agent.kwargs.llm_kwargs.max_retries"),
+        "agent_timeout_multiplier": ("agent_timeout_multiplier", "trial_config.agent.agent_timeout_multiplier"),
+        "collect_rollout_details": ("collect_rollout_details", "trial_config.agent.kwargs.collect_rollout_details"),
+        "enable_summarize": ("enable_summarize", "trial_config.agent.kwargs.enable_summarize"),
+    }
+    return {
+        key: value
+        for key, paths in option_paths.items()
+        if (value := _allowed_request_value(request, *paths)) != ""
+    }
 
 
 def list_dataset_tasks(
@@ -316,23 +417,23 @@ def resolve_task_path(request: dict[str, Any]) -> Path:
     raw_task = request.get("task_path") or request.get("task_id")
     if not raw_task:
         raise ValueError("task_id or task_path is required")
-    task_path = Path(raw_task)
-    if not task_path.is_absolute():
-        task_path = dataset_root / task_path
-    task_path = task_path.resolve()
-    try:
-        task_path.relative_to(dataset_root)
-    except ValueError as exc:
-        raise ValueError(f"task path {task_path} is outside dataset root {dataset_root}") from exc
-    if not task_path.is_dir():
-        raise FileNotFoundError(f"task path does not exist: {task_path}")
-    if task_path.name in _disabled_task_ids():
-        raise ValueError(f"task id {task_path.name} is disabled for dataset {request.get('dataset_name') or DEFAULT_DATASET_NAME}")
-    return task_path
+    task_id = str(raw_task).strip()
+    task_path = Path(task_id)
+    if not task_id or not _is_relative_path(task_path) or len(task_path.parts) != 1:
+        raise ValueError("task_id or task_path must be a relative path inside the configured dataset root")
+    for candidate in dataset_root.iterdir():
+        if candidate.name == task_id and candidate.is_dir():
+            task_path = _require_contained_path(candidate, dataset_root, label="task path")
+            if task_path.name in _disabled_task_ids():
+                raise ValueError(f"task id {task_path.name} is disabled for dataset {request.get('dataset_name') or DEFAULT_DATASET_NAME}")
+            return task_path
+    raise FileNotFoundError(f"task path does not exist: {dataset_root / task_id}")
 
 
 def _enqueue_request(request: dict[str, Any]) -> tuple[str, Path]:
-    request_id = request.get("request_id") or uuid4().hex[:12]
+    _reject_request_secrets(request)
+    request_id = _validated_request_id(request.get("request_id"))
+    request_file_id = _storage_id(request_id, prefix="request")
     session_id = request.get("session_id") or uuid4().hex
     task_path = resolve_task_path(request)
     dataset_root = _dataset_root(request.get("dataset_name"), request.get("dataset_root"))
@@ -354,8 +455,8 @@ def _enqueue_request(request: dict[str, Any]) -> tuple[str, Path]:
         opik_project_name,
     )
     payload = {
-        **request,
         "request_id": request_id,
+        "request_file_id": request_file_id,
         "session_id": session_id,
         "ray_submission_id": ray_submission_id,
         "polar_task_id": polar_task_id,
@@ -367,17 +468,16 @@ def _enqueue_request(request: dict[str, Any]) -> tuple[str, Path]:
         "model_name": model_name,
         "opik_project_name": opik_project_name,
         "api_base": request.get("api_base") or os.environ.get("RL_API_BASE", ""),
-        "api_key": request.get("api_key") or DEFAULT_API_KEY,
-        "api_key_mode": DEFAULT_API_KEY_MODE,
         "queue_dir": str(queue_dir),
         "zellij_session": zellij_session,
         "created_at": _now(),
     }
+    payload.update(_worker_options(request))
     pending_dir.mkdir(parents=True, exist_ok=True)
     results_dir.mkdir(parents=True, exist_ok=True)
     active_dir.mkdir(parents=True, exist_ok=True)
-    tmp_path = pending_dir / f"{request_id}.json.tmp"
-    final_path = pending_dir / f"{request_id}.json"
+    tmp_path = pending_dir / f"{request_file_id}.json.tmp"
+    final_path = pending_dir / f"{request_file_id}.json"
     tmp_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True), encoding="utf-8")
     tmp_path.replace(final_path)
     _append_trace({
@@ -395,7 +495,7 @@ def _enqueue_request(request: dict[str, Any]) -> tuple[str, Path]:
         "queue_dir": str(queue_dir),
         "zellij_session": zellij_session,
     })
-    return request_id, results_dir / f"{request_id}.json"
+    return request_id, results_dir / f"{request_file_id}.json"
 
 
 def _wait_result(result_path: Path, timeout: float) -> dict[str, Any]:
@@ -482,9 +582,10 @@ class Handler(BaseHTTPRequestHandler):
             suffix = "/tasks"
             if parsed.path.startswith(prefix) and parsed.path.endswith(suffix):
                 dataset_name = parsed.path[len(prefix):-len(suffix)].strip("/")
-                dataset_root = (query.get("dataset_root") or [None])[0]
+                if query.get("dataset_root"):
+                    raise ValueError("dataset_root query parameter is not accepted")
                 include_disabled = (query.get("include_disabled") or ["false"])[0].lower() in {"1", "true", "yes"}
-                tasks = list_dataset_tasks(dataset_name, dataset_root, include_disabled=include_disabled)
+                tasks = list_dataset_tasks(dataset_name, include_disabled=include_disabled)
                 self._send_json(HTTPStatus.OK, {"dataset_name": dataset_name, "task_count": len(tasks), "task_ids": tasks, "disabled_task_ids": sorted(_disabled_task_ids())})
                 return
             self._send_json(HTTPStatus.NOT_FOUND, {"detail": "not found"})

--- a/Agents/utils/rl/rollout_remote_harbor.py
+++ b/Agents/utils/rl/rollout_remote_harbor.py
@@ -37,7 +37,6 @@ DEFAULT_DISABLED_TASK_IDS = os.environ.get("RL_DISABLED_TASK_IDS", "")
 DEFAULT_TIMEOUT = float(os.environ.get("RL_REQUEST_TIMEOUT", "3600"))
 REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 COMMAND_ARG_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,255}\Z")
-SENSITIVE_KEY_RE = re.compile(r"(^|[_-])(api[-_]?key|token|secret|password)([_-]|\Z)", re.IGNORECASE)
 TRACE_LOG = Path(os.environ.get("RL_TRACE_LOG", "/workspace/runs/rl-rollout-requests.jsonl"))
 QUEUE_DIR = Path(os.environ.get("RL_QUEUE_DIR", "/workspace/runs/rl-rollout-queue"))
 PENDING_DIR = QUEUE_DIR / "pending"
@@ -124,22 +123,6 @@ def _validated_command_arg_id(value: Any, *, label: str) -> str:
     return text
 
 
-def _contains_sensitive_key(value: Any) -> bool:
-    if isinstance(value, dict):
-        for key, nested in value.items():
-            if isinstance(key, str) and SENSITIVE_KEY_RE.search(key):
-                return True
-            if _contains_sensitive_key(nested):
-                return True
-    elif isinstance(value, list):
-        return any(_contains_sensitive_key(item) for item in value)
-    return False
-
-
-def _reject_request_secrets(request: dict[str, Any]) -> None:
-    if _contains_sensitive_key(request):
-        raise ValueError("per-request secrets are not accepted; configure RL_API_KEY on the rollout server instead")
-
 
 def _short_suffix(value: str, width: int = 6) -> str:
     value = str(value or "").strip()
@@ -177,6 +160,21 @@ def _extract_polar_task_id(request: dict[str, Any], session_id: str) -> str:
         request.get("session_id"),
         session_id,
     )
+
+
+def _extract_api_base(request: dict[str, Any]) -> str:
+    api_base = _allowed_request_value(request, "api_base", "trial_config.agent.kwargs.api_base")
+    if api_base == "":
+        api_base = os.environ.get("RL_API_BASE", "")
+    if api_base == "":
+        return ""
+    api_base = str(api_base).strip()
+    parsed = urlparse(api_base)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("api_base must be an http or https URL with a host")
+    if any(ord(char) < 32 for char in api_base):
+        raise ValueError("api_base cannot contain control characters")
+    return api_base
 
 
 def _display_name(task_name: str, polar_task_id: str, session_id: str) -> str:
@@ -294,6 +292,7 @@ def _ensure_submission_zellij(
         env = os.environ.copy()
         env.update({
             "RL_ZELLIJ_SUBMISSION_ID": ray_submission_id,
+            "RL_ZELLIJ_SUBMISSION_STORAGE_ID": submission_slug,
             "RL_ZELLIJ_JOB_QUEUE_DIR": str(queue_dir),
             "RL_JOB_RUNTIME_ROOT": str(JOB_RUNTIME_ROOT),
             "RL_MODEL_NAME": model_name,
@@ -344,14 +343,19 @@ def _task_sort_key(path: Path) -> tuple[int, int | str]:
 
 
 def _dataset_root(dataset_name: str | None = None, dataset_root: str | None = None) -> Path:
-    if dataset_root:
-        raise ValueError("dataset_root cannot be supplied by request; configure RL_DATASET_ROOTS on the rollout server")
     roots = _dataset_roots()
     selected_dataset = dataset_name or DEFAULT_DATASET_NAME
     _validated_command_arg_id(selected_dataset, label="dataset_name")
     root = roots.get(selected_dataset)
     if root is None:
         raise ValueError(f"unknown dataset_name={dataset_name!r}; known={sorted(roots)}")
+    if dataset_root:
+        requested_root = os.path.normpath(str(dataset_root).strip())
+        matched_root = next((configured_root for configured_root in roots.values() if requested_root == str(configured_root)), None)
+        if matched_root is None:
+            raise ValueError("dataset_root must match a configured dataset root")
+        if matched_root != root:
+            raise ValueError("dataset_root does not match dataset_name")
     if not root.is_dir():
         raise FileNotFoundError(f"dataset root does not exist: {root}")
     return root
@@ -431,7 +435,6 @@ def resolve_task_path(request: dict[str, Any]) -> Path:
 
 
 def _enqueue_request(request: dict[str, Any]) -> tuple[str, Path]:
-    _reject_request_secrets(request)
     request_id = _validated_request_id(request.get("request_id"))
     request_file_id = _storage_id(request_id, prefix="request")
     session_id = request.get("session_id") or uuid4().hex
@@ -467,7 +470,7 @@ def _enqueue_request(request: dict[str, Any]) -> tuple[str, Path]:
         "dataset_root": str(dataset_root),
         "model_name": model_name,
         "opik_project_name": opik_project_name,
-        "api_base": request.get("api_base") or os.environ.get("RL_API_BASE", ""),
+        "api_base": _extract_api_base(request),
         "queue_dir": str(queue_dir),
         "zellij_session": zellij_session,
         "created_at": _now(),
@@ -582,10 +585,9 @@ class Handler(BaseHTTPRequestHandler):
             suffix = "/tasks"
             if parsed.path.startswith(prefix) and parsed.path.endswith(suffix):
                 dataset_name = parsed.path[len(prefix):-len(suffix)].strip("/")
-                if query.get("dataset_root"):
-                    raise ValueError("dataset_root query parameter is not accepted")
+                dataset_root = (query.get("dataset_root") or [None])[0]
                 include_disabled = (query.get("include_disabled") or ["false"])[0].lower() in {"1", "true", "yes"}
-                tasks = list_dataset_tasks(dataset_name, include_disabled=include_disabled)
+                tasks = list_dataset_tasks(dataset_name, dataset_root, include_disabled=include_disabled)
                 self._send_json(HTTPStatus.OK, {"dataset_name": dataset_name, "task_count": len(tasks), "task_ids": tasks, "disabled_task_ids": sorted(_disabled_task_ids())})
                 return
             self._send_json(HTTPStatus.NOT_FOUND, {"detail": "not found"})

--- a/Agents/utils/rl/rollout_remote_harbor.py
+++ b/Agents/utils/rl/rollout_remote_harbor.py
@@ -16,8 +16,8 @@ import signal
 import subprocess
 import threading
 import time
-from hashlib import sha256
 from datetime import datetime, timezone
+from hashlib import sha256
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path

--- a/Agents/utils/rl/run_rl_rollout_worker.sh
+++ b/Agents/utils/rl/run_rl_rollout_worker.sh
@@ -258,12 +258,13 @@ while true; do
   fi
 
   request_id="$(json_get "$request_file" request_id)"
+  request_file_id="$(json_get "$request_file" request_file_id)"
+  request_file_id="${request_file_id:-$request_id}"
   task_name="$(json_get "$request_file" task_id)"
   dataset_root="$(json_get "$request_file" dataset_root)"
   model_name="$(json_get "$request_file" model_name)"
   api_base="$(json_get_first "$request_file" api_base trial_config.agent.kwargs.api_base)"
-  api_key="$(json_get_first "$request_file" api_key trial_config.agent.kwargs.api_key trial_config.agent.kwargs.llm_kwargs.api_key)"
-  api_key="${api_key:-${RL_API_KEY:-}}"
+  api_key="${RL_API_KEY:-${API_KEY:-}}"
   session_id="$(json_get "$request_file" session_id)"
   ray_submission_id="$(json_get "$request_file" ray_submission_id)"
   opik_project_name="$(json_get "$request_file" opik_project_name)"
@@ -291,7 +292,7 @@ while true; do
   task_safe="$(safe_name "$display_name")"
   task_jobs_root="$JOBS_ROOT/rl-worker-${WORKER_ID}/${request_id}-${task_safe}"
   task_console_log="$task_jobs_root/console.log"
-  result_out="$RESULTS_DIR/${request_id}.json"
+  result_out="$RESULTS_DIR/${request_file_id}.json"
 
   mkdir -p "$task_jobs_root"
   printf '%s\t%s\t%s\t%s\t%s\n' "$request_id" "$task_name" "$display_name" "$ray_submission_id" "$polar_task_id" > "$CURRENT_FILE"
@@ -374,18 +375,23 @@ PY
       export API_KEY="$api_key"
       export TB_ANTHROPIC_AUTH_TOKEN="$api_key"
     fi
-    python3 - "$api_key" "$session_id" \
-      "${temperature:-${RL_TEMPERATURE:-}}" \
-      "${top_p:-${RL_TOP_P:-}}" \
-      "${top_k:-${RL_TOP_K:-}}" \
-      "${min_p:-${RL_MIN_P:-}}" \
-      "${llm_timeout:-${RL_LLM_TIMEOUT:-}}" \
-      "${llm_max_retries:-${RL_LLM_MAX_RETRIES:-}}" <<'PY' > "$task_jobs_root/llm_kwargs.json"
+    export TB_LLM_KWARGS="$(
+      python3 - "$session_id" \
+        "${temperature:-${RL_TEMPERATURE:-}}" \
+        "${top_p:-${RL_TOP_P:-}}" \
+        "${top_k:-${RL_TOP_K:-}}" \
+        "${min_p:-${RL_MIN_P:-}}" \
+        "${llm_timeout:-${RL_LLM_TIMEOUT:-}}" \
+        "${llm_max_retries:-${RL_LLM_MAX_RETRIES:-}}" <<'PY'
 import json
+import os
 import sys
 
-api_key, session_id, temperature, top_p, top_k, min_p, timeout, max_retries = sys.argv[1:9]
-payload = {"api_key": api_key}
+session_id, temperature, top_p, top_k, min_p, timeout, max_retries = sys.argv[1:8]
+payload = {}
+api_key = os.environ.get("API_KEY", "")
+if api_key:
+    payload["api_key"] = api_key
 
 def add_number(name, value, cast=float):
     value = str(value).strip()
@@ -409,7 +415,7 @@ if session_id:
     }
 print(json.dumps(payload, separators=(",", ":")))
 PY
-    export TB_LLM_KWARGS="$(cat "$task_jobs_root/llm_kwargs.json")"
+    )"
     export TB_TASK_ID="$task_name"
     export TB_INCLUDE_TASKS="$task_name"
     export INCLUDE_TASKS="$task_name"

--- a/Agents/utils/rl/tests/test_rollout_request_context.py
+++ b/Agents/utils/rl/tests/test_rollout_request_context.py
@@ -232,6 +232,99 @@ class RolloutRequestContextTest(unittest.TestCase):
             "ray_1.2-3",
         )
 
+    def test_submission_zellij_helper_receives_hashed_storage_identifier(self) -> None:
+        root_path = Path(self.stack.enter_context(tempfile.TemporaryDirectory()))
+        queue_dir = root_path / "queue" / MODULE._storage_id("ray-submission-test", prefix="submission")
+        runtime_root = root_path / "runtime"
+        storage_id = MODULE._storage_id("ray-submission-test", prefix="submission")
+        expected_session = MODULE._submission_session_name("ray-submission-test", "seta")
+        helper = mock.Mock(return_value=(0, f"{expected_session}\n", ""))
+
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_RUNTIME_ROOT", runtime_root))
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_LOCKS", {}))
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_READY", {}))
+        self.stack.enter_context(mock.patch.object(MODULE, "_zellij_session_exists", mock.Mock(return_value=False)))
+        self.stack.enter_context(mock.patch.object(MODULE, "_run_helper", helper))
+
+        session = MODULE._ensure_submission_zellij(
+            "ray-submission-test",
+            "seta",
+            queue_dir,
+            "model-from-request",
+            "ray-submission-test",
+        )
+
+        self.assertEqual(session, expected_session)
+        env = helper.call_args.kwargs["env"]
+        self.assertEqual(env["RL_ZELLIJ_SUBMISSION_ID"], "ray-submission-test")
+        self.assertEqual(env["RL_ZELLIJ_SUBMISSION_STORAGE_ID"], storage_id)
+        self.assertEqual(env["RL_ZELLIJ_JOB_QUEUE_DIR"], str(queue_dir))
+
+    def test_existing_hashed_zellij_session_is_reused_without_helper(self) -> None:
+        storage_id = MODULE._storage_id("ray-submission-test", prefix="submission")
+        expected_session = MODULE._submission_session_name("ray-submission-test", "seta")
+
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_LOCKS", {}))
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_READY", {storage_id: expected_session}))
+        self.stack.enter_context(mock.patch.object(MODULE, "_zellij_session_exists", mock.Mock(return_value=True)))
+        helper = self.stack.enter_context(mock.patch.object(MODULE, "_run_helper"))
+
+        session = MODULE._ensure_submission_zellij(
+            "ray-submission-test",
+            "seta",
+            Path("/tmp/queue"),
+            "model-from-request",
+            "ray-submission-test",
+        )
+
+        self.assertEqual(session, expected_session)
+        helper.assert_not_called()
+
+    def test_legacy_raw_zellij_session_is_not_reused_for_hashed_queue(self) -> None:
+        legacy_session = "harbor-rollout-claude-code-seta-ray-submission-test"
+        hashed_session = MODULE._submission_session_name("ray-submission-test", "seta")
+        helper = mock.Mock(return_value=(0, f"{hashed_session}\n", ""))
+
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_LOCKS", {}))
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_READY", {"ray-submission-test": legacy_session}))
+        exists = self.stack.enter_context(mock.patch.object(MODULE, "_zellij_session_exists", mock.Mock(return_value=True)))
+        self.stack.enter_context(mock.patch.object(MODULE, "_run_helper", helper))
+
+        session = MODULE._ensure_submission_zellij(
+            "ray-submission-test",
+            "seta",
+            Path("/tmp/queue"),
+            "model-from-request",
+            "ray-submission-test",
+        )
+
+        self.assertEqual(session, hashed_session)
+        self.assertNotIn(mock.call(legacy_session), exists.call_args_list)
+        helper.assert_called_once()
+
+    def test_different_submission_cached_session_is_not_reused(self) -> None:
+        other_storage_id = MODULE._storage_id("other-submission", prefix="submission")
+        other_session = MODULE._submission_session_name("other-submission", "seta")
+        current_session = MODULE._submission_session_name("ray-submission-test", "seta")
+        helper = mock.Mock(return_value=(0, f"{current_session}\n", ""))
+
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_LOCKS", {}))
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_ZELLIJ_READY", {other_storage_id: other_session}))
+        exists = self.stack.enter_context(mock.patch.object(MODULE, "_zellij_session_exists", mock.Mock(return_value=True)))
+        self.stack.enter_context(mock.patch.object(MODULE, "_run_helper", helper))
+
+        session = MODULE._ensure_submission_zellij(
+            "ray-submission-test",
+            "seta",
+            Path("/tmp/queue"),
+            "model-from-request",
+            "ray-submission-test",
+        )
+
+        self.assertEqual(session, current_session)
+        self.assertNotIn(mock.call(other_session), exists.call_args_list)
+        helper.assert_called_once()
+
     def test_rejects_command_arg_injection_in_ray_submission_id(self) -> None:
         with self.assertRaisesRegex(ValueError, "ray_submission_id may contain only"):
             self._enqueue_with_temp_context({"ray_submission_id": "ray; touch /tmp/pwned"})
@@ -270,28 +363,44 @@ class RolloutRequestContextTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "outside trusted root"):
             MODULE.resolve_task_path({"dataset_name": "seta", "task_id": "linked-task"})
 
-    def test_rejects_request_supplied_dataset_root(self) -> None:
-        with self.assertRaisesRegex(ValueError, "dataset_root cannot be supplied"):
-            self._enqueue_with_temp_context({"dataset_root": "/tmp"})
+    def test_accepts_request_dataset_root_only_when_configured(self) -> None:
+        root_path = Path(self.stack.enter_context(tempfile.TemporaryDirectory()))
+        dataset_root = root_path / "dataset"
+        (dataset_root / "task-1").mkdir(parents=True)
 
-    def test_rejects_per_request_secrets_in_nested_payload(self) -> None:
-        with self.assertRaisesRegex(ValueError, "per-request secrets are not accepted"):
-            self._enqueue_with_temp_context({
-                "trial_config": {
-                    "agent": {
-                        "kwargs": {
-                            "llm_kwargs": {
-                                "api_key": "request-secret",
-                            },
+        self.stack.enter_context(mock.patch.object(MODULE, "DEFAULT_DATASET_NAME", "seta"))
+        self.stack.enter_context(mock.patch.object(MODULE, "DEFAULT_DATASET_ROOT", dataset_root))
+        self.stack.enter_context(mock.patch.dict(os.environ, {"RL_DATASET_ROOTS": ""}))
+
+        self.assertEqual(MODULE._dataset_root("seta", str(dataset_root)), dataset_root.resolve())
+        with self.assertRaisesRegex(ValueError, "dataset_root must match a configured dataset root"):
+            MODULE._dataset_root("seta", str(root_path / "other"))
+
+    def test_secret_like_request_fields_are_not_persisted_to_queue(self) -> None:
+        _, _, job_queue_root, _ = self._enqueue_with_temp_context({
+            "trial_config": {
+                "agent": {
+                    "kwargs": {
+                        "api_base": "https://example.test/v1",
+                        "llm_kwargs": {
+                            "api_key": "request-secret",
                         },
                     },
                 },
-            })
+            },
+            "metadata": {"access_token": "request-token"},
+        })
 
-    def test_enqueued_payload_does_not_store_per_request_api_key(self) -> None:
-        _, _, job_queue_root, _ = self._enqueue_with_temp_context({"api_base": "https://example.test/v1"})
+        payload = self._read_default_payload(job_queue_root)
+        serialized = json.dumps(payload, sort_keys=True)
+        self.assertNotIn("api_key", payload)
+        self.assertNotIn("trial_config", payload)
+        self.assertNotIn("metadata", payload)
+        self.assertNotIn("request-secret", serialized)
+        self.assertNotIn("request-token", serialized)
 
-        payload = json.loads(
+    def _read_default_payload(self, job_queue_root: Path) -> dict[str, object]:
+        return json.loads(
             (
                 job_queue_root
                 / MODULE._storage_id("ray-submission-test", prefix="submission")
@@ -299,6 +408,49 @@ class RolloutRequestContextTest(unittest.TestCase):
                 / f"{MODULE._storage_id('request-1', prefix='request')}.json"
             ).read_text(encoding="utf-8")
         )
+
+    def test_enqueued_payload_preserves_nested_api_base(self) -> None:
+        _, _, job_queue_root, _ = self._enqueue_with_temp_context({
+            "trial_config": {
+                "agent": {
+                    "kwargs": {
+                        "api_base": "https://polar.example.test/v1/chat/completions",
+                    },
+                },
+            },
+        })
+
+        payload = self._read_default_payload(job_queue_root)
+        self.assertEqual(payload["api_base"], "https://polar.example.test/v1/chat/completions")
+        self.assertNotIn("trial_config", payload)
+
+    def test_top_level_api_base_takes_precedence_over_nested_value(self) -> None:
+        _, _, job_queue_root, _ = self._enqueue_with_temp_context({
+            "api_base": "https://top.example.test/v1",
+            "trial_config": {
+                "agent": {
+                    "kwargs": {
+                        "api_base": "https://nested.example.test/v1",
+                    },
+                },
+            },
+        })
+
+        payload = self._read_default_payload(job_queue_root)
+        self.assertEqual(payload["api_base"], "https://top.example.test/v1")
+
+    def test_rejects_invalid_api_base_format(self) -> None:
+        for api_base in ("/relative", "ftp://example.test/v1", "https://example.test/evil\nheader"):
+            with (
+                self.subTest(api_base=api_base),
+                self.assertRaisesRegex(ValueError, "api_base"),
+            ):
+                self._enqueue_with_temp_context({"api_base": api_base})
+
+    def test_enqueued_payload_does_not_store_per_request_api_key(self) -> None:
+        _, _, job_queue_root, _ = self._enqueue_with_temp_context({"api_base": "https://example.test/v1"})
+
+        payload = self._read_default_payload(job_queue_root)
         self.assertNotIn("api_key", payload)
         self.assertEqual(payload["api_base"], "https://example.test/v1")
 

--- a/Agents/utils/rl/tests/test_rollout_request_context.py
+++ b/Agents/utils/rl/tests/test_rollout_request_context.py
@@ -8,6 +8,7 @@ import json
 import os
 import tempfile
 import unittest
+from contextlib import ExitStack
 from pathlib import Path
 from unittest import mock
 
@@ -19,6 +20,10 @@ SPEC.loader.exec_module(MODULE)
 
 
 class RolloutRequestContextTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stack = ExitStack()
+        self.addCleanup(self.stack.close)
+
     def _handler(self, body: bytes):
         handler = object.__new__(MODULE.Handler)
         handler.path = "/run_trial"
@@ -26,6 +31,41 @@ class RolloutRequestContextTest(unittest.TestCase):
         handler.rfile = io.BytesIO(body)
         handler._send_json = mock.Mock()
         return handler
+
+    def _enqueue_with_temp_context(
+        self,
+        request: dict[str, object],
+        *,
+        task_name: str = "task-1",
+    ) -> tuple[str, Path, Path, mock.Mock]:
+        root_path = Path(self.stack.enter_context(tempfile.TemporaryDirectory()))
+        dataset_root = root_path / "dataset"
+        task_path = dataset_root / task_name
+        task_path.mkdir(parents=True)
+        (task_path / "task.yaml").write_text("instruction: test\n", encoding="utf-8")
+
+        job_queue_root = root_path / "queue" / "jobs"
+        trace_log = root_path / "trace.jsonl"
+        ensure_zellij = mock.Mock(return_value="test-zellij-session")
+        self.stack.enter_context(mock.patch.object(MODULE, "DEFAULT_DATASET_NAME", "seta"))
+        self.stack.enter_context(mock.patch.object(MODULE, "DEFAULT_DATASET_ROOT", dataset_root))
+        self.stack.enter_context(mock.patch.object(MODULE, "DEFAULT_DISABLED_TASK_IDS", ""))
+        self.stack.enter_context(mock.patch.object(MODULE, "JOB_QUEUE_ROOT", job_queue_root))
+        self.stack.enter_context(mock.patch.object(MODULE, "TRACE_LOG", trace_log))
+        self.stack.enter_context(mock.patch.object(MODULE, "_ensure_submission_zellij", ensure_zellij))
+        self.stack.enter_context(mock.patch.dict(os.environ, {"RL_DATASET_ROOTS": ""}))
+
+        full_request = {
+            "request_id": "request-1",
+            "task_id": task_name,
+            "dataset_name": "seta",
+            "model_name": "model-from-request",
+            "ray_submission_id": "ray-submission-test",
+            "polar_task_id": "polar-task-test",
+        }
+        full_request.update(request)
+        request_id, result_path = MODULE._enqueue_request(full_request)
+        return request_id, result_path, job_queue_root, ensure_zellij
 
     def test_invalid_json_bodies_return_bad_request(self) -> None:
         invalid_bodies = (
@@ -141,14 +181,15 @@ class RolloutRequestContextTest(unittest.TestCase):
                     "polar_task_id": "polar-task-test",
                 })
 
-            queue_dir = job_queue_root / "ray-submission-test"
+            queue_dir = job_queue_root / MODULE._storage_id("ray-submission-test", prefix="submission")
+            request_file_id = MODULE._storage_id("request-1", prefix="request")
             payload = json.loads(
-                (queue_dir / "pending" / "request-1.json").read_text(encoding="utf-8")
+                (queue_dir / "pending" / f"{request_file_id}.json").read_text(encoding="utf-8")
             )
             trace = json.loads(trace_log.read_text(encoding="utf-8"))
 
             self.assertEqual(request_id, "request-1")
-            self.assertEqual(result_path, queue_dir / "results" / "request-1.json")
+            self.assertEqual(result_path, queue_dir / "results" / f"{request_file_id}.json")
             self.assertEqual(payload["model_name"], "model-from-request")
             self.assertEqual(payload["ray_submission_id"], "ray-submission-test")
             self.assertNotIn("ray_job_id", payload)
@@ -164,6 +205,102 @@ class RolloutRequestContextTest(unittest.TestCase):
                 "model-from-request",
                 "ray-submission-test",
             )
+
+    def test_enqueue_accepts_space_in_task_path_but_not_shell_chars_in_command_args(self) -> None:
+        request_id, result_path, job_queue_root, ensure_zellij = self._enqueue_with_temp_context(
+            {
+                "request_id": "req_1.2-3",
+                "task_id": "task with spaces",
+                "ray_submission_id": "ray_1.2-3",
+            },
+            task_name="task with spaces",
+        )
+
+        queue_dir = job_queue_root / MODULE._storage_id("ray_1.2-3", prefix="submission")
+        request_file_id = MODULE._storage_id("req_1.2-3", prefix="request")
+        payload = json.loads((queue_dir / "pending" / f"{request_file_id}.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(request_id, "req_1.2-3")
+        self.assertEqual(result_path, queue_dir / "results" / f"{request_file_id}.json")
+        self.assertEqual(payload["request_file_id"], request_file_id)
+        self.assertEqual(payload["task_id"], "task with spaces")
+        ensure_zellij.assert_called_once_with(
+            "ray_1.2-3",
+            "seta",
+            queue_dir,
+            "model-from-request",
+            "ray_1.2-3",
+        )
+
+    def test_rejects_command_arg_injection_in_ray_submission_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ray_submission_id may contain only"):
+            self._enqueue_with_temp_context({"ray_submission_id": "ray; touch /tmp/pwned"})
+
+    def test_rejects_command_arg_injection_in_dataset_name(self) -> None:
+        with self.assertRaisesRegex(ValueError, "dataset_name may contain only"):
+            self._enqueue_with_temp_context({"dataset_name": "seta; touch /tmp/pwned"})
+
+    def test_rejects_request_id_path_traversal_and_shell_metacharacters(self) -> None:
+        for bad_request_id in ("../escape", "req/escape", "req with spaces", "req;touch"):
+            with (
+                self.subTest(bad_request_id=bad_request_id),
+                self.assertRaisesRegex(ValueError, "request_id may contain only"),
+            ):
+                self._enqueue_with_temp_context({"request_id": bad_request_id})
+
+    def test_rejects_task_path_outside_dataset_root(self) -> None:
+        with self.assertRaisesRegex(ValueError, "relative path inside"):
+            self._enqueue_with_temp_context({"task_path": "../outside"})
+
+        with self.assertRaisesRegex(ValueError, "relative path inside"):
+            self._enqueue_with_temp_context({"task_path": "/tmp/outside"})
+
+    def test_rejects_symlink_escape_from_dataset_root(self) -> None:
+        root_path = Path(self.stack.enter_context(tempfile.TemporaryDirectory()))
+        dataset_root = root_path / "dataset"
+        outside_task = root_path / "outside-task"
+        dataset_root.mkdir()
+        outside_task.mkdir()
+        (dataset_root / "linked-task").symlink_to(outside_task, target_is_directory=True)
+
+        self.stack.enter_context(mock.patch.object(MODULE, "DEFAULT_DATASET_NAME", "seta"))
+        self.stack.enter_context(mock.patch.object(MODULE, "DEFAULT_DATASET_ROOT", dataset_root))
+        self.stack.enter_context(mock.patch.dict(os.environ, {"RL_DATASET_ROOTS": ""}))
+
+        with self.assertRaisesRegex(ValueError, "outside trusted root"):
+            MODULE.resolve_task_path({"dataset_name": "seta", "task_id": "linked-task"})
+
+    def test_rejects_request_supplied_dataset_root(self) -> None:
+        with self.assertRaisesRegex(ValueError, "dataset_root cannot be supplied"):
+            self._enqueue_with_temp_context({"dataset_root": "/tmp"})
+
+    def test_rejects_per_request_secrets_in_nested_payload(self) -> None:
+        with self.assertRaisesRegex(ValueError, "per-request secrets are not accepted"):
+            self._enqueue_with_temp_context({
+                "trial_config": {
+                    "agent": {
+                        "kwargs": {
+                            "llm_kwargs": {
+                                "api_key": "request-secret",
+                            },
+                        },
+                    },
+                },
+            })
+
+    def test_enqueued_payload_does_not_store_per_request_api_key(self) -> None:
+        _, _, job_queue_root, _ = self._enqueue_with_temp_context({"api_base": "https://example.test/v1"})
+
+        payload = json.loads(
+            (
+                job_queue_root
+                / MODULE._storage_id("ray-submission-test", prefix="submission")
+                / "pending"
+                / f"{MODULE._storage_id('request-1', prefix='request')}.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertNotIn("api_key", payload)
+        self.assertEqual(payload["api_base"], "https://example.test/v1")
 
     def test_only_top_level_opik_project_name_overrides_submission(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## 1. Why the Change?

GitHub Code Scanning reported 13 findings in the RL rollout request and worker flow:

- 1 command-line injection finding
- 11 path injection findings
- 1 clear-text storage of sensitive data finding

Request-controlled identifiers, dataset/task paths, queue filenames, and credentials could reach command, filesystem, or persistent queue boundaries without sufficiently strict validation.

This PR addresses the risks corresponding to Code Scanning alerts #1–#13. Alert #14 is unrelated to the RL rollout flow and is intentionally outside the scope of this change.

## 2. Summary of the Change

- Validate request-controlled identifiers before they reach command and session startup paths.
- Use stable hashed storage identifiers for queue and result paths.
- Keep hashed queue paths, zellij sessions, and runtime layouts on the same trusted storage identifier.
- Prevent legacy sessions that still monitor raw-name queues from being incorrectly reused for hashed queues.
- Accept a request-supplied `dataset_root` only when it exactly matches a server-configured trusted dataset root.
- Normalize task paths and prevent traversal, absolute-path, nested-path, and symlink-escape risks.
- Persist only an explicit allowlist of worker options instead of the complete request.
- Prevent API keys and other credentials from being written to queue payloads.
- Preserve and validate `trial_config.agent.kwargs.api_base`, with the top-level `api_base` taking precedence.
- Read worker credentials only from trusted server-side environment configuration.
- Add regression tests for the command, path, credential-storage, nested API base, and legacy-session cases.

## 3. Other details

### Verification

The fix is based on:

`upstream/main@77b4bed77783adb147e71f838d107f3a6b411d9f`

A/B CodeQL verification used the same CodeQL CLI and Python query pack for both revisions:

| Revision | Command injection | Path injection | Clear-text storage | Total |
|---|---:|---:|---:|---:|
| Latest unmodified `upstream/main` | 1 | 11 | 1 | 13 |
| This branch | 0 | 0 | 0 | 0 |

Additional validation:

- 26 related RL unit tests passed.
- Ruff passed.
- RL shell scripts passed syntax checks.
- Relevant Python files passed compilation checks.
- `git diff --check` passed.
- The RL timeout trace-gate test passed.
- No CodeQL suppressions or ignore rules were added.

### Compatibility considerations

- Request-supplied `dataset_root` values are accepted only when they exactly match a server-configured trusted root.
- Per-request credentials are not persisted in queue payloads; worker credentials come from trusted environment configuration.
- Request identifiers and task paths are more strictly validated.
- Queue and session storage identifiers are synchronized to prevent legacy-session queue mismatches.
- Nested `trial_config.agent.kwargs.api_base` remains supported, with the top-level value taking precedence.

The two P1 automated review findings concerning nested `api_base` preservation and legacy-session queue reuse have been addressed with regression coverage.

Alert #14 (`actions/excessive-secrets-exposure`) is unrelated, was fixed separately, and is not modified by this PR.
