### PR TITLE
feat(harbor): add fixer execution policy checks

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -325,6 +325,20 @@ with no env/infra tasks produces an empty fix plan without invoking Pi.
 Starting generation removes any stale `fix-plan-latest.json`; if no task
 summary succeeds, Fixer writes a diagnostic empty plan and exits nonzero.
 
+## Harbor Fixer: Execution Policy
+
+`harbor_fixer/policy.py` independently evaluates a complete Fix Plan before an
+executor consumes it. T1 applies deny-first built-in and optional user rules;
+T2 routes bounded writes inside the workspace or configured writable roots to
+an isolated policy agent; T3 routes Docker, dependency, service, outside-root,
+dynamic, and otherwise unknown-effect commands to the policy agent.
+
+The policy agent reuses the Fixer Pi invocation contract without tools. Invalid
+output, invocation failure, configuration errors, or any denied command fail
+closed. The complete decision is atomically written to
+`execution-policy-decision.json`. The policy layer is admission and audit, not
+an OS sandbox, and does not itself execute commands.
+
 ## More Details
 
 Architecture, script roles, task resolution, and full variable descriptions are in [STRUCT.md](./STRUCT.md).

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -37,9 +37,11 @@ Agents/utils/common/Harbor/
     │   ├── agent_invocation.py # Fixer prompt assembly and Pi adapter
     │   ├── analyzer_inputs.py  # Analyzer artifact to task-input translation
     │   ├── artifact_io.py      # JSON, JSONL, and text artifact I/O
+    │   ├── builtin_policy.py   # Fixed T1 allow and deny rules
     │   ├── plan_generation.py  # Task summary and plan generation flow
     │   ├── planning_context/   # Runtime inventory and workspace evidence
-    │   ├── prompts.py          # Task and plan agent contracts
+    │   ├── policy.py           # Policy routing, validation, and preflight
+    │   ├── prompts.py          # Task, plan, and policy-agent contracts
     │   └── validation.py       # Analyzer, task-summary, and Fix Plan validation
     ├── online_rule_analyzer.py # Optional console-only online analysis
     └── write_harbor_registry_summary.py # Native registry summary writer
@@ -69,6 +71,17 @@ Plan generation is independently usable and produces
 dispatching isolated no-tool Pi agents. Tests are split between
 `test_harbor_fixer_plan.py` and `test_harbor_fixer_runtime_context.py`, with
 shared fixtures in the non-discovered `fixer_test_support.py`.
+
+## Harbor Fixer Execution Policy
+
+`policy.py` consumes a validated Fix Plan without executing it. It coordinates
+user rules, write-target resolution against configured roots, T2/T3 routing,
+strict policy-agent output validation, retry, and fail-closed behavior.
+`builtin_policy.py` owns the fixed T1 allow and deny rules, while `prompts.py`
+owns the T2 and T3 agent contracts. T2 covers bounded writes inside configured
+roots; T3 covers Docker, dependency, service, outside-root, dynamic, and
+otherwise unknown-effect commands. Isolated tests live in
+`test_harbor_fixer_policy.py`.
 
 ## Path Resolution
 

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/builtin_policy.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/builtin_policy.py
@@ -1,0 +1,121 @@
+"""Built-in T1 allow and deny rules for Harbor Fixer execution policy."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+_DENY_EXECUTABLES = {
+    "rm",
+    "rmdir",
+    "shred",
+    "unlink",
+    "wipefs",
+}
+_READ_ONLY_COMMANDS = {
+    "cat",
+    "diff",
+    "du",
+    "echo",
+    "file",
+    "grep",
+    "head",
+    "id",
+    "ls",
+    "printf",
+    "pwd",
+    "rg",
+    "stat",
+    "tail",
+    "test",
+    "true",
+    "uname",
+    "wc",
+    "which",
+}
+_SAFE_GIT_SUBCOMMANDS = {
+    "diff",
+    "log",
+    "rev-parse",
+    "show",
+    "status",
+}
+_SAFE_DOCKER_SUBCOMMANDS = {
+    "images",
+    "info",
+    "inspect",
+    "logs",
+    "ps",
+    "version",
+}
+_FIND_WRITE_ACTIONS = {
+    "-delete",
+    "-exec",
+    "-execdir",
+    "-fprint",
+    "-fprint0",
+    "-fprintf",
+    "-ok",
+    "-okdir",
+}
+
+
+def _has_output_option(tokens: Sequence[str]) -> bool:
+    return any(token == "--output" or token.startswith("--output=") for token in tokens)
+
+
+def builtin_destructive_reason(tokens: Sequence[str]) -> tuple[str, str] | None:
+    """Return the built-in denial reason for one token sequence, if any."""
+
+    for token in tokens:
+        executable = Path(token).name
+        if executable in _DENY_EXECUTABLES or executable.startswith("mkfs"):
+            return "builtin_destructive_command", executable
+    if tokens:
+        executable = Path(tokens[0]).name
+        if executable == "find" and any(
+            token in _FIND_WRITE_ACTIONS for token in tokens[1:]
+        ):
+            return "builtin_destructive_find", "find"
+    return None
+
+
+def builtin_read_only_reason(
+    command_tokens: Sequence[str],
+) -> tuple[str, str] | None:
+    """Return the built-in allow reason for one normalized command."""
+
+    if not command_tokens:
+        return None
+    executable = Path(command_tokens[0]).name
+    if executable in _READ_ONLY_COMMANDS:
+        if executable == "diff" and _has_output_option(command_tokens[1:]):
+            return None
+        return (
+            f"builtin_read_only_{executable}",
+            f"built-in read-only command: {executable}",
+        )
+    if executable == "git" and len(command_tokens) >= 2:
+        if _has_output_option(command_tokens[2:]):
+            return None
+        if command_tokens[1] in _SAFE_GIT_SUBCOMMANDS:
+            return (
+                "builtin_read_only_git",
+                f"built-in read-only git {command_tokens[1]}",
+            )
+        if list(command_tokens[1:3]) == ["branch", "--show-current"]:
+            return "builtin_read_only_git", "built-in read-only git branch query"
+    if (
+        executable == "docker"
+        and len(command_tokens) >= 2
+        and command_tokens[1] in _SAFE_DOCKER_SUBCOMMANDS
+    ):
+        return (
+            "builtin_read_only_docker",
+            f"built-in read-only docker {command_tokens[1]}",
+        )
+    if executable == "find" and not any(
+        token in _FIND_WRITE_ACTIONS for token in command_tokens[1:]
+    ):
+        return "builtin_read_only_find", "built-in read-only find"
+    return None

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy.py
@@ -1,0 +1,622 @@
+"""Deterministic and agent-backed execution policy for Harbor Fixer."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .agent_invocation import AgentInvoker
+from .artifact_io import read_json, write_json_atomic
+from .builtin_policy import builtin_destructive_reason, builtin_read_only_reason
+from .prompts import (
+    T2_POLICY_AGENT_PROMPT,
+    T3_POLICY_AGENT_PROMPT,
+    build_validation_retry_prompt,
+)
+from .validation import (
+    ValidationError,
+    parse_strict_json_object,
+    require_dict,
+    require_enum,
+    require_list,
+    require_string,
+)
+
+POLICY_VERSION = "fixer-policy-v1"
+POLICY_DECISIONS = {"allow", "deny"}
+RISK_LEVELS = {"low", "medium", "high"}
+CONTROL_TOKENS = {";", "&&", "||", "|", "&"}
+REDIRECTION_TOKENS = {
+    ">",
+    ">>",
+    "<",
+    "<<",
+    "<<<",
+    "<>",
+    ">&",
+    "&>",
+    "&>>",
+    "<&",
+}
+OUTPUT_REDIRECTION_TOKENS = {">", ">>", "<>", ">&", "&>", "&>>"}
+SHELL_NAMES = {"bash", "dash", "ksh", "sh", "zsh"}
+WRITE_EACH_OPERAND = {
+    "chmod",
+    "chown",
+    "chgrp",
+    "mkdir",
+    "tee",
+    "touch",
+    "truncate",
+}
+WRITE_LAST_OPERAND = {"cp", "install", "ln", "mv", "sed"}
+
+
+@dataclass(frozen=True)
+class PrefixRule:
+    rule_id: str
+    pattern: tuple[str, ...]
+    match: str
+    decision: str
+
+
+def _lex(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def _segments(tokens: list[str]) -> list[list[str]]:
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in CONTROL_TOKENS:
+            if current:
+                segments.append(current)
+                current = []
+            continue
+        current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _command_tokens(segment: list[str]) -> list[str]:
+    result: list[str] = []
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        if token in REDIRECTION_TOKENS:
+            index += 2
+            continue
+        if (
+            token.isdigit()
+            and index + 1 < len(segment)
+            and segment[index + 1] in REDIRECTION_TOKENS
+        ):
+            index += 3
+            continue
+        result.append(token)
+        index += 1
+    while result:
+        while result and "=" in result[0] and not result[0].startswith("="):
+            name, _value = result[0].split("=", 1)
+            if not name.replace("_", "a").isalnum():
+                break
+            result.pop(0)
+        if not result:
+            break
+        wrapper = Path(result[0]).name
+        if wrapper not in {"command", "env", "nohup", "sudo"}:
+            break
+        result.pop(0)
+        while result and result[0].startswith("-"):
+            option = result.pop(0)
+            if (
+                wrapper == "sudo"
+                and option
+                in {
+                    "-C",
+                    "-g",
+                    "-h",
+                    "-p",
+                    "-r",
+                    "-T",
+                    "-t",
+                    "-u",
+                }
+                and result
+            ):
+                result.pop(0)
+    return result
+
+
+def _nested_shell_commands(command_tokens: list[str]) -> list[str]:
+    if not command_tokens or Path(command_tokens[0]).name not in SHELL_NAMES:
+        return []
+    for index, token in enumerate(command_tokens[1:], start=1):
+        if token == "-c" and index + 1 < len(command_tokens):
+            return [command_tokens[index + 1]]
+        if (
+            token.startswith("-")
+            and "c" in token[1:]
+            and index + 1 < len(command_tokens)
+        ):
+            return [command_tokens[index + 1]]
+    return []
+
+
+def _embedded_shell_commands(command: str) -> list[str]:
+    substitutions = re.findall(r"\$\(([^()]*)\)", command)
+    substitutions.extend(re.findall(r"`([^`]*)`", command))
+    return substitutions
+
+
+def _rule_segments(command: str, *, depth: int = 0) -> list[list[str]]:
+    if depth > 4:
+        return []
+    tokens = _lex(command)
+    segments = [_command_tokens(segment) for segment in _segments(tokens)]
+    segments = [segment for segment in segments if segment]
+    nested_segments: list[list[str]] = []
+    for segment in segments:
+        for nested in _nested_shell_commands(segment):
+            nested_segments.extend(_rule_segments(nested, depth=depth + 1))
+    return [*segments, *nested_segments]
+
+
+def _builtin_deny_reason(command: str) -> tuple[str, str] | None:
+    try:
+        tokens = _lex(command)
+    except ValueError:
+        return None
+    reason = builtin_destructive_reason(tokens)
+    if reason is not None:
+        return reason
+    for segment in _segments(tokens):
+        command_tokens = _command_tokens(segment)
+        if not command_tokens:
+            continue
+        reason = builtin_destructive_reason(command_tokens)
+        if reason is not None:
+            return reason
+        executable = Path(command_tokens[0]).name
+        if executable == "xargs" and command_tokens[1:]:
+            nested_reason = _builtin_deny_reason(" ".join(command_tokens[1:]))
+            if nested_reason is not None:
+                return nested_reason
+        for nested in _nested_shell_commands(command_tokens):
+            nested_reason = _builtin_deny_reason(nested)
+            if nested_reason is not None:
+                return nested_reason
+    for nested in _embedded_shell_commands(command):
+        nested_reason = _builtin_deny_reason(nested)
+        if nested_reason is not None:
+            return nested_reason
+    return None
+
+
+def _validate_rule(item: Any, name: str, decision: str) -> PrefixRule:
+    payload = require_dict(item, name)
+    rule_id = require_string(payload.get("rule_id"), f"{name}.rule_id")
+    pattern = tuple(
+        require_string(value, f"{name}.pattern[{index}]")
+        for index, value in enumerate(
+            require_list(payload.get("pattern"), f"{name}.pattern")
+        )
+    )
+    if not pattern:
+        raise ValidationError(f"{name}.pattern must be non-empty")
+    match = require_enum(
+        payload.get("match", "exact"), f"{name}.match", {"exact", "prefix"}
+    )
+    if decision == "allow" and match == "prefix" and len(pattern) < 2:
+        raise ValidationError(
+            f"{name} prefix allow pattern must contain at least two tokens"
+        )
+    return PrefixRule(rule_id=rule_id, pattern=pattern, match=match, decision=decision)
+
+
+def load_user_rules(path: Path | None) -> tuple[list[PrefixRule], str]:
+    if path is None:
+        return [], ""
+    payload = read_json(path)
+    if (
+        payload.get("schema_version") != 1
+        or payload.get("kind") != "harbor_fixer_policy_rules"
+    ):
+        raise ValidationError(
+            "policy rules must be harbor_fixer_policy_rules schema_version 1"
+        )
+    rules: list[PrefixRule] = []
+    for decision in ("deny", "allow"):
+        for index, item in enumerate(require_list(payload.get(decision, []), decision)):
+            rules.append(_validate_rule(item, f"{decision}[{index}]", decision))
+    return rules, str(path)
+
+
+def _rule_matches(rule: PrefixRule, command_tokens: list[str]) -> bool:
+    if rule.match == "exact":
+        return tuple(command_tokens) == rule.pattern
+    return tuple(command_tokens[: len(rule.pattern)]) == rule.pattern
+
+
+def evaluate_t1(command: str, user_rules: list[PrefixRule]) -> dict[str, Any] | None:
+    deny_reason = _builtin_deny_reason(command)
+    if deny_reason is not None:
+        reason_code, executable = deny_reason
+        return {
+            "tier": "T1",
+            "decision": "deny",
+            "risk_level": "high",
+            "source": "builtin_rule",
+            "rule_id": reason_code,
+            "reason_code": reason_code,
+            "reason": f"built-in policy prohibits destructive command: {executable}",
+        }
+    try:
+        tokens = _lex(command)
+    except ValueError:
+        return None
+    segments = [_command_tokens(segment) for segment in _segments(tokens)]
+    segments = [segment for segment in segments if segment]
+    try:
+        rule_segments = _rule_segments(command)
+    except ValueError:
+        return None
+    for rule in [rule for rule in user_rules if rule.decision == "deny"]:
+        if any(_rule_matches(rule, segment) for segment in rule_segments):
+            return {
+                "tier": "T1",
+                "decision": "deny",
+                "risk_level": "high",
+                "source": "user_rule",
+                "rule_id": rule.rule_id,
+                "reason_code": "user_deny_rule",
+                "reason": f"command matches user deny rule {rule.rule_id}",
+            }
+    if any(token in REDIRECTION_TOKENS for token in tokens):
+        return None
+    if any(marker in command for marker in ("$(", "`", "<(", ">(")):
+        return None
+    matched: list[tuple[str, str, str]] = []
+    for segment in segments:
+        user_allow = next(
+            (
+                rule
+                for rule in user_rules
+                if rule.decision == "allow" and _rule_matches(rule, segment)
+            ),
+            None,
+        )
+        if user_allow is not None:
+            matched.append(
+                ("user_rule", user_allow.rule_id, "command matches user allow rule")
+            )
+            continue
+        builtin = builtin_read_only_reason(segment)
+        if builtin is None:
+            return None
+        matched.append(("builtin_rule", builtin[0], builtin[1]))
+    if not matched:
+        return None
+    sources = {item[0] for item in matched}
+    return {
+        "tier": "T1",
+        "decision": "allow",
+        "risk_level": "low",
+        "source": sources.pop() if len(sources) == 1 else "combined_rules",
+        "rule_id": ",".join(item[1] for item in matched),
+        "reason_code": "t1_allow_rule",
+        "reason": "; ".join(item[2] for item in matched),
+    }
+
+
+def _operand_tokens(segment: list[str]) -> list[str]:
+    command_tokens = _command_tokens(segment)
+    if not command_tokens:
+        return []
+    return [token for token in command_tokens[1:] if not token.startswith("-")]
+
+
+def _write_targets(tokens: list[str]) -> list[str]:
+    targets: list[str] = []
+    for index, token in enumerate(tokens[:-1]):
+        target = tokens[index + 1]
+        if token in OUTPUT_REDIRECTION_TOKENS and not (
+            token in {">&", "<&"} and (target.isdigit() or target == "-")
+        ):
+            targets.append(target)
+    for segment in _segments(tokens):
+        command_tokens = _command_tokens(segment)
+        if not command_tokens:
+            continue
+        executable = Path(command_tokens[0]).name
+        operands = _operand_tokens(segment)
+        if executable in WRITE_EACH_OPERAND:
+            targets.extend(operands)
+        elif executable in WRITE_LAST_OPERAND and operands:
+            targets.append(operands[-1])
+    return list(dict.fromkeys(targets))
+
+
+def _is_dynamic_path(value: str) -> bool:
+    return value.startswith("~") or any(
+        marker in value for marker in ("$", "*", "?", "[", "]", "{", "}")
+    )
+
+
+def analyze_paths(
+    command: str,
+    cwd: Path,
+    writable_roots: list[Path],
+) -> dict[str, Any]:
+    try:
+        tokens = _lex(command)
+    except ValueError as exc:
+        return {
+            "classification": "unknown_or_outside",
+            "write_targets": [],
+            "dynamic": True,
+            "reason": f"shell_parse_error: {exc}",
+        }
+    targets: list[dict[str, Any]] = []
+    dynamic = False
+    for raw in _write_targets(tokens):
+        if _is_dynamic_path(raw):
+            dynamic = True
+            targets.append({"raw": raw, "resolved": "", "inside_writable_roots": False})
+            continue
+        path = Path(raw)
+        resolved = (path if path.is_absolute() else cwd / path).resolve()
+        inside = any(resolved.is_relative_to(root) for root in writable_roots)
+        targets.append(
+            {
+                "raw": raw,
+                "resolved": str(resolved),
+                "inside_writable_roots": inside,
+            }
+        )
+    inside_only = (
+        bool(targets)
+        and not dynamic
+        and all(target["inside_writable_roots"] for target in targets)
+    )
+    return {
+        "classification": "inside_writable_roots"
+        if inside_only
+        else "unknown_or_outside",
+        "write_targets": targets,
+        "dynamic": dynamic,
+        "reason": (
+            "all detected write targets resolve inside writable roots"
+            if inside_only
+            else "no bounded inside-root write set could be established"
+        ),
+    }
+
+
+def _validate_agent_decision(
+    payload: dict[str, Any],
+    *,
+    tier: str,
+    plan_id: str,
+    command_id: str,
+) -> None:
+    expected_fields = {
+        "schema_version",
+        "kind",
+        "tier",
+        "plan_id",
+        "command_id",
+        "decision",
+        "risk_level",
+        "reason_code",
+        "reason",
+    }
+    if set(payload) != expected_fields:
+        raise ValidationError("policy agent decision fields do not match contract")
+    if payload.get("schema_version") != 1:
+        raise ValidationError("policy agent decision schema_version must be 1")
+    if payload.get("kind") != "harbor_fixer_policy_agent_decision":
+        raise ValidationError("policy agent decision kind is invalid")
+    if payload.get("tier") != tier:
+        raise ValidationError("policy agent decision tier does not match input")
+    if payload.get("plan_id") != plan_id or payload.get("command_id") != command_id:
+        raise ValidationError("policy agent decision identity does not match input")
+    require_enum(payload.get("decision"), "decision", POLICY_DECISIONS)
+    require_enum(payload.get("risk_level"), "risk_level", RISK_LEVELS)
+    reason_code = require_string(payload.get("reason_code"), "reason_code")
+    if re.fullmatch(r"[a-z][a-z0-9_]*", reason_code) is None:
+        raise ValidationError("reason_code must be lower snake_case")
+    require_string(payload.get("reason"), "reason")
+
+
+def _agent_decision(
+    invoker: AgentInvoker | None,
+    policy_input: dict[str, Any],
+    *,
+    max_attempts: int = 2,
+) -> dict[str, Any]:
+    tier = policy_input["tier"]
+    plan_id = policy_input["plan_id"]
+    command_id = policy_input["command"]["command_id"]
+    base_prompt = T2_POLICY_AGENT_PROMPT if tier == "T2" else T3_POLICY_AGENT_PROMPT
+    if invoker is None:
+        return {
+            "tier": tier,
+            "decision": "deny",
+            "risk_level": "high",
+            "source": "policy_agent_fallback",
+            "rule_id": "",
+            "reason_code": "policy_agent_unavailable",
+            "reason": "policy agent is required for commands not resolved by T1",
+        }
+    prompt = base_prompt
+    previous_output = ""
+    last_error = "policy agent returned no valid decision"
+    for attempt in range(1, max_attempts + 1):
+        try:
+            raw = invoker.invoke(
+                prompt,
+                policy_input,
+                attempt=attempt,
+                label=f"policy-{tier.lower()}-{plan_id}-{command_id}",
+            )
+            previous_output = raw
+            decision = parse_strict_json_object(raw)
+            _validate_agent_decision(
+                decision,
+                tier=tier,
+                plan_id=plan_id,
+                command_id=command_id,
+            )
+            return {
+                "tier": tier,
+                "decision": decision["decision"],
+                "risk_level": decision["risk_level"],
+                "source": "policy_agent",
+                "rule_id": "",
+                "reason_code": decision["reason_code"],
+                "reason": decision["reason"],
+            }
+        except Exception as exc:  # noqa: BLE001 - policy errors must fail closed
+            last_error = f"{exc.__class__.__name__}: {exc}"
+            prompt = build_validation_retry_prompt(
+                base_prompt=base_prompt,
+                previous_output=previous_output,
+                validation_error=last_error,
+            )
+    return {
+        "tier": tier,
+        "decision": "deny",
+        "risk_level": "high",
+        "source": "policy_agent_fallback",
+        "rule_id": "",
+        "reason_code": "policy_agent_failed_closed",
+        "reason": last_error,
+    }
+
+
+def _configuration_denial(
+    fix_plan: dict[str, Any],
+    error: Exception,
+) -> list[dict[str, Any]]:
+    decisions: list[dict[str, Any]] = []
+    for plan in fix_plan["plans"]:
+        for command in plan["commands"]:
+            decisions.append(
+                {
+                    "plan_id": plan["plan_id"],
+                    "command_id": command["command_id"],
+                    "tier": "T1",
+                    "decision": "deny",
+                    "risk_level": "high",
+                    "source": "policy_configuration",
+                    "rule_id": "",
+                    "reason_code": "policy_configuration_error",
+                    "reason": f"{error.__class__.__name__}: {error}",
+                    "path_analysis": {},
+                }
+            )
+    return decisions
+
+
+def run_policy_preflight(
+    fix_plan: dict[str, Any],
+    workspace_root: Path,
+    output_dir: Path,
+    invoker: AgentInvoker | None,
+    *,
+    user_rules_path: Path | None = None,
+    writable_roots: list[Path] | None = None,
+) -> dict[str, Any]:
+    roots = [workspace_root, *(writable_roots or [])]
+    resolved_roots = list(dict.fromkeys(root.resolve() for root in roots))
+    try:
+        user_rules, rules_source = load_user_rules(user_rules_path)
+    except (OSError, ValidationError, ValueError) as exc:
+        decisions = _configuration_denial(fix_plan, exc)
+        rules_source = str(user_rules_path or "")
+        serialized_user_rules: list[dict[str, Any]] = []
+    else:
+        serialized_user_rules = [
+            {
+                "rule_id": rule.rule_id,
+                "pattern": list(rule.pattern),
+                "match": rule.match,
+                "decision": rule.decision,
+            }
+            for rule in user_rules
+        ]
+        decisions = []
+        for plan in fix_plan["plans"]:
+            for command in plan["commands"]:
+                plan_id = plan["plan_id"]
+                command_id = command["command_id"]
+                cwd_value = Path(command["cwd"])
+                cwd = (
+                    cwd_value if cwd_value.is_absolute() else workspace_root / cwd_value
+                ).resolve()
+                path_analysis = analyze_paths(
+                    command["command"],
+                    cwd,
+                    resolved_roots,
+                )
+                decision = evaluate_t1(command["command"], user_rules)
+                if decision is None:
+                    tier = (
+                        "T2"
+                        if path_analysis["classification"] == "inside_writable_roots"
+                        else "T3"
+                    )
+                    policy_input = {
+                        "schema_version": 1,
+                        "kind": "harbor_fixer_policy_agent_input",
+                        "policy_version": POLICY_VERSION,
+                        "tier": tier,
+                        "plan_id": plan_id,
+                        "command": command,
+                        "plan_context": {
+                            "fix_scope": plan["fix_scope"],
+                            "analyzer_scope_comparison": plan[
+                                "analyzer_scope_comparison"
+                            ],
+                            "task_list": plan["task_list"],
+                            "fix_reason": plan["fix_reason"],
+                        },
+                        "workspace_root": str(workspace_root),
+                        "writable_roots": [str(root) for root in resolved_roots],
+                        "resolved_cwd": str(cwd),
+                        "path_analysis": path_analysis,
+                    }
+                    decision = _agent_decision(invoker, policy_input)
+                decisions.append(
+                    {
+                        "plan_id": plan_id,
+                        "command_id": command_id,
+                        **decision,
+                        "path_analysis": path_analysis,
+                    }
+                )
+    result = {
+        "schema_version": 1,
+        "kind": "harbor_fixer_execution_policy_decision",
+        "policy_version": POLICY_VERSION,
+        "status": (
+            "allowed"
+            if all(decision["decision"] == "allow" for decision in decisions)
+            else "denied"
+        ),
+        "workspace_root": str(workspace_root.resolve()),
+        "writable_roots": [str(root) for root in resolved_roots],
+        "user_rules_path": rules_source,
+        "user_rules": serialized_user_rules,
+        "decisions": decisions,
+    }
+    write_json_atomic(output_dir / "execution-policy-decision.json", result)
+    return result

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/prompts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/prompts.py
@@ -2,6 +2,60 @@
 
 from __future__ import annotations
 
+T2_POLICY_AGENT_PROMPT = """You are the Harbor Fixer T2 execution policy agent.
+
+Evaluate exactly one command that deterministically targets files inside the configured
+writable roots. These files may be environment configuration, daemon configuration, or
+Dockerfiles rather than project source. Return JSON only and use only the supplied input.
+
+Allow the command only when its stated purpose and concrete operation are necessary and
+proportionate to repairing dependency, Docker, benchmark, or host-environment failures.
+Deny broad deletion, credential access, policy modification, persistence unrelated to the
+repair, hidden shell execution, or actions whose actual targets cannot be established.
+The deterministic T1 decision and resolved path facts are authoritative.
+
+Return exactly:
+{
+  "schema_version": 1,
+  "kind": "harbor_fixer_policy_agent_decision",
+  "tier": "T2",
+  "plan_id": "<copy input.plan_id>",
+  "command_id": "<copy input.command.command_id>",
+  "decision": "allow | deny",
+  "risk_level": "low | medium | high",
+  "reason_code": "<stable snake_case code>",
+  "reason": "<concise evidence-based reason>"
+}
+"""
+
+T3_POLICY_AGENT_PROMPT = """You are the Harbor Fixer T3 execution policy agent.
+
+Evaluate exactly one command that was not resolved by T1 and is not a confirmed write
+inside the configured writable roots. T3 commonly includes Docker operations, dependency
+installation, service or daemon operations, network operations, and commands with unknown
+or outside-root effects. Return JSON only and use only the supplied input.
+
+Harbor Fixer legitimately needs broad Docker and environment-repair capabilities. Allow
+such operations when their targets and effects are specific, necessary, and proportionate
+to the supplied fix purpose. Deny generic filesystem deletion, credential access, policy
+modification, unrelated persistence, destructive host-wide cleanup, or obscured/dynamic
+operations whose effects cannot be bounded from the input. Do not treat Docker access by
+itself as a reason to deny; evaluate the concrete Docker operation and arguments.
+
+Return exactly:
+{
+  "schema_version": 1,
+  "kind": "harbor_fixer_policy_agent_decision",
+  "tier": "T3",
+  "plan_id": "<copy input.plan_id>",
+  "command_id": "<copy input.command.command_id>",
+  "decision": "allow | deny",
+  "risk_level": "low | medium | high",
+  "reason_code": "<stable snake_case code>",
+  "reason": "<concise evidence-based reason>"
+}
+"""
+
 TASK_SUBAGENT_PROMPT = """You are a Task Subagent for Harbor Fixer MVP.
 
 Analyze exactly one env/infra task input and return JSON only.

--- a/Agents/utils/common/Harbor/tests/fixer_test_support.py
+++ b/Agents/utils/common/Harbor/tests/fixer_test_support.py
@@ -186,6 +186,28 @@ class SequenceInvoker:
         return self.outputs[index]
 
 
+class PolicyInvoker:
+    def __init__(self, decision: str = "allow") -> None:
+        self.decision = decision
+        self.records: list[tuple[str, dict, int, str]] = []
+
+    def invoke(self, prompt: str, payload: dict, *, attempt: int, label: str) -> str:
+        self.records.append((prompt, payload, attempt, label))
+        return json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "harbor_fixer_policy_agent_decision",
+                "tier": payload["tier"],
+                "plan_id": payload["plan_id"],
+                "command_id": payload["command"]["command_id"],
+                "decision": self.decision,
+                "risk_level": "medium",
+                "reason_code": f"fixture_{self.decision}",
+                "reason": f"Fixture policy decision: {self.decision}.",
+            }
+        )
+
+
 class SummaryInvoker:
     def invoke(self, prompt: str, payload: dict, *, attempt: int, label: str) -> str:
         return json.dumps(task_summary_for(payload))

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy.py
@@ -1,0 +1,234 @@
+"""Tests for Harbor Fixer execution policy."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+if str(TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(TEST_DIR))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from fixer_test_support import (
+    FixerTestCase,
+    PolicyInvoker,
+    SequenceInvoker,
+    make_fix_plan,
+    write_json,
+)
+from harbor_fixer.policy import evaluate_t1, load_user_rules, run_policy_preflight
+
+
+class HarborFixerPolicyTest(FixerTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.workspace = self.root / "workspace"
+        self.workspace.mkdir()
+
+    def _run_preflight(
+        self,
+        plan: dict,
+        invoker: PolicyInvoker | SequenceInvoker | None,
+        *,
+        user_rules_path: Path | None = None,
+        writable_roots: list[Path] | None = None,
+    ) -> dict:
+        return run_policy_preflight(
+            plan,
+            self.workspace,
+            self.root / "policy",
+            invoker,
+            user_rules_path=user_rules_path,
+            writable_roots=writable_roots,
+        )
+
+    def test_t1_allows_narrow_reads_and_denies_destructive_commands(self) -> None:
+        for command in (
+            "docker ps --all",
+            "git status --short",
+            "cat pyproject.toml | grep dependency",
+        ):
+            with self.subTest(command=command):
+                decision = evaluate_t1(command, [])
+                self.assertEqual(
+                    (decision["tier"], decision["decision"]), ("T1", "allow")
+                )
+
+        for command in (
+            "rm -rf build",
+            "sudo -u root rm -f /tmp/item",
+            "bash -lc 'rm -rf build'",
+            "echo $(rm -f marker)",
+            "printf '%s\\n' marker | xargs rm -f",
+            "docker exec fixture rm -f /tmp/item",
+            "find . -delete",
+        ):
+            with self.subTest(command=command):
+                decision = evaluate_t1(command, [])
+                self.assertEqual(
+                    (decision["tier"], decision["decision"]), ("T1", "deny")
+                )
+
+        for command in (
+            "diff --output=change.patch old new",
+            "git diff --output=change.patch",
+        ):
+            with self.subTest(command=command):
+                self.assertIsNone(evaluate_t1(command, []))
+
+    def test_user_deny_precedes_allow_and_builtin_deny_cannot_be_overridden(
+        self,
+    ) -> None:
+        rules_path = self.root / "rules.json"
+        write_json(
+            rules_path,
+            {
+                "schema_version": 1,
+                "kind": "harbor_fixer_policy_rules",
+                "deny": [
+                    {
+                        "rule_id": "deny-docker-ps",
+                        "pattern": ["docker", "ps"],
+                        "match": "prefix",
+                    }
+                ],
+                "allow": [
+                    {
+                        "rule_id": "allow-docker-ps",
+                        "pattern": ["docker", "ps"],
+                        "match": "prefix",
+                    },
+                    {
+                        "rule_id": "attempt-allow-rm",
+                        "pattern": ["rm", "-rf"],
+                        "match": "prefix",
+                    },
+                    {
+                        "rule_id": "allow-pytest",
+                        "pattern": ["pytest", "-q"],
+                        "match": "prefix",
+                    },
+                ],
+            },
+        )
+        rules, source = load_user_rules(rules_path)
+        self.assertEqual(source, str(rules_path))
+        self.assertEqual(
+            evaluate_t1("docker ps -a", rules)["rule_id"], "deny-docker-ps"
+        )
+        self.assertEqual(
+            evaluate_t1("rm -rf disposable", rules)["source"],
+            "builtin_rule",
+        )
+        self.assertEqual(
+            evaluate_t1("pytest -q tests/unit", rules)["decision"],
+            "allow",
+        )
+
+    def test_preflight_routes_inside_writes_to_t2_and_other_operations_to_t3(
+        self,
+    ) -> None:
+        plan = make_fix_plan()
+        plan["plans"][0]["commands"] = [
+            {
+                "command_id": "inside-write",
+                "cwd": ".",
+                "command": "printf enabled > daemon.json",
+                "purpose": "Update the fixture daemon configuration.",
+                "expected_effect": "The daemon configuration is enabled.",
+            },
+            {
+                "command_id": "docker-build",
+                "cwd": ".",
+                "command": "docker build -t fixture .",
+                "purpose": "Build the repaired benchmark image.",
+                "expected_effect": "The repaired image exists.",
+            },
+        ]
+        invoker = PolicyInvoker()
+        result = self._run_preflight(plan, invoker)
+
+        self.assertEqual(result["status"], "allowed")
+        self.assertEqual(
+            [decision["tier"] for decision in result["decisions"]],
+            ["T2", "T3"],
+        )
+        self.assertEqual(
+            [record[1]["tier"] for record in invoker.records],
+            ["T2", "T3"],
+        )
+
+    def test_symlink_escape_routes_write_to_t3(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+        (self.workspace / "escape").symlink_to(outside, target_is_directory=True)
+        plan = make_fix_plan()
+        plan["plans"][0]["commands"][0].update(
+            {
+                "command": "touch escape/config.json",
+                "purpose": "Write through a symlink.",
+            }
+        )
+        invoker = PolicyInvoker()
+
+        result = self._run_preflight(plan, invoker)
+
+        decision = result["decisions"][0]
+        self.assertEqual(decision["tier"], "T3")
+        self.assertFalse(
+            decision["path_analysis"]["write_targets"][0]["inside_writable_roots"]
+        )
+
+    def test_additional_write_root_routes_outside_workspace_write_to_t2(self) -> None:
+        config_root = self.root / "daemon-config"
+        config_root.mkdir()
+        plan = make_fix_plan()
+        plan["plans"][0]["commands"][0]["command"] = (
+            f"touch {config_root / 'daemon.json'}"
+        )
+        invoker = PolicyInvoker()
+
+        result = self._run_preflight(
+            plan,
+            invoker,
+            writable_roots=[config_root],
+        )
+
+        self.assertEqual(result["decisions"][0]["tier"], "T2")
+        self.assertIn(str(config_root.resolve()), result["writable_roots"])
+
+    def test_policy_agent_invalid_output_retries_then_fails_closed(self) -> None:
+        plan = make_fix_plan()
+        plan["plans"][0]["commands"][0]["command"] = "docker build ."
+        invoker = SequenceInvoker(["not-json", json.dumps({"decision": "allow"})])
+
+        result = self._run_preflight(plan, invoker)
+
+        self.assertEqual(result["status"], "denied")
+        self.assertEqual(
+            result["decisions"][0]["reason_code"], "policy_agent_failed_closed"
+        )
+        self.assertEqual(invoker.calls, 2)
+        self.assertIn("Validation retry:", invoker.records[1][0])
+
+    def test_invalid_user_rules_fail_closed_before_t1_allow(self) -> None:
+        result = self._run_preflight(
+            make_fix_plan(),
+            None,
+            user_rules_path=self.root / "missing-rules.json",
+        )
+
+        self.assertEqual(result["status"], "denied")
+        self.assertEqual(
+            result["decisions"][0]["reason_code"],
+            "policy_configuration_error",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer needs an execution admission layer between generated fix plans and command execution. The fixer legitimately requires broad Docker and environment-management capabilities, but generated commands must still be prevented from performing unrelated destructive operations or unbounded writes.

This change adds a fail-closed policy boundary that handles narrow, deterministic cases locally and delegates ambiguous in-scope or broader operations to a dedicated policy agent before execution.

## 2. Summary of the change 

- Add a deny-first T1 policy with built-in and user rules for narrow command allow/deny decisions.
- Add deterministic command/path analysis and route unresolved commands to:
  - T2 for writes proven to stay within configured writable roots.
  - T3 for outside-root, dynamic, non-write, or otherwise unbounded operations.
- Add isolated, tool-disabled T2/T3 policy-agent evaluation with strict structured-output validation, retry handling, and fail-closed behavior.
- Atomically publish the execution policy decision artifact for downstream execution/reporting stages.
- Separate built-in rules and policy-agent prompts from policy orchestration.
- Document the policy interface and add coverage for T1/T2/T3 routing, user overrides, path handling, malformed agent output, retries, and artifact publication.

## 3. Other details

This PR is based on `main`, which includes fixer plan generation from #26. It adds one Policy commit and does not execute approved commands; execution and verification remain separate follow-up branches/PRs.

Validation:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_harbor_fixer*.py'` — 22 tests passed.
- Ruff 0.16.0 check against the changed Python/test files — passed.
- A real single-task Plan Generation + Policy run produced one candidate command and correctly denied its dynamic write outside the configured writable root. Full event-flow and test analysis: sii-system/tasks#115.
