### PR TITLE
refactor(harbor): split monitor and controller control flow

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -181,7 +181,10 @@ ROLLOUT=1 bash start.sh
 including detached zellij runs and command-mode runs such as
 `bash start.sh ./harboropik.sh`. Set `HARBOR_MONITOR_ENABLED=0` to disable it.
 The monitor reads Fleet queue artifacts for local datasets and Harbor job/trial
-results for registry datasets.
+results for registry datasets. Internally, `harbor_monitor` produces the
+observation while `harbor_controller` selects the state-appropriate action and
+retains run-local command execution behind a separate boundary. Restart and
+stop are not executed automatically from observations.
 
 Equivalent queue monitor command:
 
@@ -200,10 +203,11 @@ python3 Agents/utils/common/Harbor/scripts/monitor.py \
 ```
 
 Omit `--follow` for one sample. Control commands are optional executable files
-inside `RUN_DIR`; arguments are allowed but shell syntax is not. If absent or
-failed, the action becomes `notify`.
+inside `RUN_DIR`; arguments are allowed but shell syntax is not. They are
+retained for a subsequent explicit user-decision flow and are not invoked by
+the observation policy.
 
-For automatic runs, optional run-local controls can be set with
+Optional run-local controls can be set with
 `HARBOR_MONITOR_RESTART_CMD` and `HARBOR_MONITOR_STOP_CMD`.
 
 | Output | Used by | Content |
@@ -219,12 +223,16 @@ All files are refreshed on each sample. The actual action is
 
 | Observed state | Action |
 | --- | --- |
-| Worker active, including `suspected_stalled` | `wait` |
-| Worker active past `--configured-timeout` | `notify` and continue monitoring |
-| Tasks unfinished with no live worker | `restart`; after `--max-retries`, `notify` |
-| Every task has a terminal queue record | `stop` |
+| Worker active and making progress | `wait` |
+| Worker active past `--configured-timeout` | `notify`; allowed decisions are `wait`, `stop` |
+| Worker active after the confirmed stall duration | `notify`; allowed decisions are `wait`, `stop` |
+| Tasks unfinished with no live worker | `notify`; `restart` is allowed below `--max-retries` |
+| Every task has a terminal queue record | `wait`; finish the monitor loop without external control |
 
-Automatic restart is only used when tasks remain and no worker is alive.
+The monitor does not consume restart attempts or execute restart/stop commands
+without an explicit user decision. The bidirectional decision channel is not
+part of this structural refactor; `allowed_decisions` records what a later
+decision flow may safely execute.
 
 ## Harbor Analyzer
 

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -28,9 +28,13 @@ Agents/utils/common/Harbor/
     ├── harbor_monitor/
     │   ├── artifacts.py        # Queue, result, manifest, environment, and state I/O
     │   ├── classification.py   # Task and benchmark status classification
-    │   ├── evaluator.py        # Compose one monitor sample
+    │   ├── evaluator.py        # Compose one control-free monitor observation
     │   ├── contracts.py        # User, analyzer, and runner output contracts
-    │   └── runner.py           # Control commands, retries, and follow loop
+    │   └── runner.py           # Observation and follow-loop orchestration
+    ├── harbor_controller/
+    │   ├── policy.py           # Select wait/notify and state-safe user choices
+    │   ├── executor.py         # Validate and execute user-approved run-local controls
+    │   └── analyzer_dispatch.py # Deduplicate and spool Analyzer handovers
     ├── online_rule_analyzer.py # Optional console-only online analysis
     └── write_harbor_registry_summary.py # Native registry summary writer
 ```

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/__init__.py
@@ -1,0 +1,2 @@
+"""Harbor benchmark control policy and execution boundary."""
+

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/analyzer_dispatch.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/analyzer_dispatch.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from harbor_monitor.contracts import build_analyzer_handover_for_tasks
 
@@ -47,4 +48,3 @@ def dispatch_analyzer_handover(
                     spooled | set(new_fingerprints)
                 )
     write_json(latest_output, handover)
-

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/analyzer_dispatch.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/analyzer_dispatch.py
@@ -1,0 +1,50 @@
+"""Dispatch deduplicated Analyzer handovers selected from monitor output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from harbor_monitor.contracts import build_analyzer_handover_for_tasks
+
+
+def dispatch_analyzer_handover(
+    handover: dict[str, Any],
+    *,
+    latest_output: Path | None,
+    state: dict[str, Any],
+    write_json: Callable[[Path | None, dict[str, Any]], None],
+) -> None:
+    """Write new terminal task handovers once, then update the latest snapshot."""
+
+    if latest_output and handover.get("should_run_analyzer"):
+        spooled_raw = state.get("analyzer_spooled_terminal_fingerprints")
+        spooled = (
+            {str(value) for value in spooled_raw if isinstance(value, str) and value}
+            if isinstance(spooled_raw, list)
+            else set()
+        )
+        tasks = handover.get("tasks")
+        new_tasks: list[dict[str, Any]] = []
+        new_fingerprints: list[str] = []
+        if isinstance(tasks, list):
+            for task in tasks:
+                if not isinstance(task, dict):
+                    continue
+                fingerprint = str(task.get("terminal_fingerprint") or "")
+                if not fingerprint or fingerprint in spooled:
+                    continue
+                new_tasks.append(task)
+                new_fingerprints.append(fingerprint)
+        if new_tasks:
+            dispatch = build_analyzer_handover_for_tasks(handover, new_tasks)
+            handover_id = str(dispatch.get("handover_id") or "")
+            if handover_id:
+                spool_path = latest_output.parent / "analyzer-handoffs" / f"{handover_id}.json"
+                if not spool_path.exists():
+                    write_json(spool_path, dispatch)
+                state["analyzer_spooled_terminal_fingerprints"] = sorted(
+                    spooled | set(new_fingerprints)
+                )
+    write_json(latest_output, handover)
+

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/executor.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/executor.py
@@ -1,0 +1,305 @@
+"""Execute configured run-local Harbor controller actions."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ControllerResult:
+    """One controller action result returned to the monitor loop."""
+
+    action: dict[str, Any]
+    history: list[dict[str, Any]]
+    control_stdout: str | None = None
+
+
+def build_control_argv(
+    control_cmd: str,
+    run_dir: Path,
+    label: str,
+) -> tuple[list[str] | None, str | None]:
+    try:
+        parts = shlex.split(control_cmd)
+    except ValueError as exc:
+        return None, f"{label}_cmd_parse_error={exc}"
+    if not parts:
+        return None, f"{label}_cmd_empty"
+    if parts[0] in {"bash", "sh", "python", "python3"}:
+        return None, f"{label}_cmd_interpreter_prefixed"
+
+    run_root = run_dir.resolve()
+    executable = Path(parts[0])
+    if not executable.is_absolute():
+        executable = run_root / executable
+    try:
+        resolved = executable.resolve()
+        resolved.relative_to(run_root)
+    except (OSError, ValueError):
+        return None, f"{label}_cmd_not_run_specific"
+    if not resolved.exists():
+        return None, f"{label}_cmd_missing"
+    if not resolved.is_file():
+        return None, f"{label}_cmd_not_file"
+    if not os.access(resolved, os.X_OK):
+        return None, f"{label}_cmd_not_executable"
+    return [str(resolved), *parts[1:]], None
+
+
+def _notify_action(
+    *,
+    state: dict[str, Any],
+    reason: str,
+    control_type: str,
+    attempted: bool,
+    performed: bool,
+    exit_code: int | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    action: dict[str, Any] = {
+        "type": "notify",
+        "retry_count": state.get("retry_count", 0),
+        "reason": reason,
+        "control_type": control_type,
+        "control_attempted": attempted,
+        "external_control_performed": performed,
+    }
+    if exit_code is not None:
+        action["control_exit_code"] = exit_code
+    if error is not None:
+        action["control_error"] = error
+    return action
+
+
+def _run_command(argv: list[str], run_dir: Path, timeout_seconds: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=run_dir,
+        shell=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+
+def _execute_restart(
+    requested_action: dict[str, Any],
+    *,
+    restart_cmd: str | None,
+    run_dir: Path,
+    state: dict[str, Any],
+    observation: dict[str, Any],
+    history: list[dict[str, Any]],
+    timeout_seconds: int,
+) -> ControllerResult:
+    if not restart_cmd:
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason="restart_needed_but_restart_cmd_missing",
+                control_type="restart",
+                attempted=False,
+                performed=False,
+            ),
+            history=history,
+        )
+
+    argv, control_error = build_control_argv(restart_cmd, run_dir, "restart")
+    if control_error or argv is None:
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason=control_error or "restart_cmd_invalid",
+                control_type="restart",
+                attempted=False,
+                performed=False,
+            ),
+            history=history,
+        )
+
+    state["retry_count"] = state.get("retry_count", 0) + 1
+    try:
+        result = _run_command(argv, run_dir, timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason="restart_failed_timeout",
+                control_type="restart",
+                attempted=True,
+                performed=True,
+                error=str(exc),
+            ),
+            history=history,
+        )
+    except Exception as exc:  # noqa: BLE001 - control boundary reports failures
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason="restart_failed_exception",
+                control_type="restart",
+                attempted=True,
+                performed=False,
+                error=str(exc),
+            ),
+            history=history,
+        )
+
+    if result.returncode != 0:
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason=f"restart_failed_exit_code={result.returncode}",
+                control_type="restart",
+                attempted=True,
+                performed=True,
+                exit_code=result.returncode,
+            ),
+            history=history,
+            control_stdout=result.stdout[-2000:],
+        )
+
+    control_ts = time.time()
+    state["last_progress_ts"] = control_ts
+    state["run_start_ts"] = control_ts
+    restart_history = [
+        {
+            "ts": control_ts,
+            "finished": observation["finished"],
+            "running": observation["running"],
+            "remaining": observation.get("unclaimed_remaining"),
+            "unfinished": observation.get("unfinished"),
+            "status": "restart_executed",
+        }
+    ]
+    action = {
+        "type": "restart",
+        "retry_count": state["retry_count"],
+        "reason": requested_action["reason"],
+        "control_type": "restart",
+        "control_exit_code": result.returncode,
+        "control_attempted": True,
+        "external_control_performed": True,
+    }
+    return ControllerResult(
+        action=action,
+        history=restart_history,
+        control_stdout=result.stdout[-2000:],
+    )
+
+
+def _execute_stop(
+    requested_action: dict[str, Any],
+    *,
+    stop_cmd: str | None,
+    run_dir: Path,
+    state: dict[str, Any],
+    history: list[dict[str, Any]],
+    timeout_seconds: int,
+) -> ControllerResult:
+    if not stop_cmd:
+        return ControllerResult(action=requested_action, history=history)
+
+    argv, control_error = build_control_argv(stop_cmd, run_dir, "stop")
+    if control_error or argv is None:
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason=control_error or "stop_cmd_invalid",
+                control_type="stop",
+                attempted=False,
+                performed=False,
+            ),
+            history=history,
+        )
+
+    try:
+        result = _run_command(argv, run_dir, timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason="stop_failed_timeout",
+                control_type="stop",
+                attempted=True,
+                performed=True,
+                error=str(exc),
+            ),
+            history=history,
+        )
+    except Exception as exc:  # noqa: BLE001 - control boundary reports failures
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason="stop_failed_exception",
+                control_type="stop",
+                attempted=True,
+                performed=False,
+                error=str(exc),
+            ),
+            history=history,
+        )
+
+    action = {
+        "type": "stop" if result.returncode == 0 else "notify",
+        "retry_count": state.get("retry_count", 0),
+        "reason": (
+            requested_action["reason"]
+            if result.returncode == 0
+            else f"stop_failed_exit_code={result.returncode}"
+        ),
+        "control_type": "stop",
+        "control_exit_code": result.returncode,
+        "control_attempted": True,
+        "external_control_performed": True,
+    }
+    return ControllerResult(
+        action=action,
+        history=history,
+        control_stdout=result.stdout[-2000:],
+    )
+
+
+def execute_action(
+    requested_action: dict[str, Any],
+    *,
+    restart_cmd: str | None,
+    stop_cmd: str | None,
+    run_dir: Path,
+    state: dict[str, Any],
+    observation: dict[str, Any],
+    history: list[dict[str, Any]],
+    timeout_seconds: int = 120,
+) -> ControllerResult:
+    """Execute a selected controller action with existing compatibility semantics."""
+
+    action_type = requested_action.get("type")
+    if action_type == "restart":
+        return _execute_restart(
+            requested_action,
+            restart_cmd=restart_cmd,
+            run_dir=run_dir,
+            state=state,
+            observation=observation,
+            history=history,
+            timeout_seconds=timeout_seconds,
+        )
+    if action_type == "stop":
+        return _execute_stop(
+            requested_action,
+            stop_cmd=stop_cmd,
+            run_dir=run_dir,
+            state=state,
+            history=history,
+            timeout_seconds=timeout_seconds,
+        )
+    return ControllerResult(action=requested_action, history=history)
+

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/policy.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/policy.py
@@ -1,0 +1,68 @@
+"""Select a controller action from one Harbor monitor observation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def decide_action(
+    observation: dict[str, Any],
+    *,
+    retry_count: int,
+    max_retries: int,
+) -> dict[str, Any]:
+    """Select an observation action without executing human control decisions."""
+
+    benchmark_status = observation.get("benchmark_status")
+    reason = str(observation.get("status_reason") or "")
+    running = int(observation.get("running") or 0)
+    unfinished = int(observation.get("unfinished") or 0)
+    stalled_duration_reached = bool(observation.get("stalled_duration_reached"))
+    action_type = "wait"
+    allowed_decisions: list[str] = []
+    if (
+        benchmark_status == "blocked"
+        and reason == "abnormal_exit"
+        and running == 0
+        and unfinished > 0
+    ):
+        action_type = "notify"
+        if retry_count < max_retries:
+            allowed_decisions = ["restart"]
+        else:
+            reason = f"restart_limit_reached(max_retries={max_retries})"
+    elif (
+        benchmark_status == "running"
+        and running > 0
+        and unfinished > 0
+        and (
+            reason == "timeout_reached"
+            or (reason == "suspected_stalled" and stalled_duration_reached)
+        )
+    ):
+        action_type = "notify"
+        allowed_decisions = ["wait", "stop"]
+    elif benchmark_status == "blocked":
+        action_type = "notify"
+
+    if benchmark_status == "completed":
+        controller_status = "completed"
+    elif action_type == "notify":
+        controller_status = "awaiting_user_decision"
+    else:
+        controller_status = "observing"
+
+    action = {
+        "type": action_type,
+        "retry_count": retry_count,
+        "reason": reason,
+        "allowed_decisions": allowed_decisions,
+        "decision_required": action_type == "notify",
+        "controller_status": controller_status,
+        "external_control_performed": False,
+        "compatibility_note": (
+            "Harbor controller decisions are command-based and runner-neutral; "
+            "restart and stop require an explicit user decision."
+        ),
+    }
+    return action

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/contracts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/contracts.py
@@ -35,6 +35,8 @@ def suggested_user_checks(benchmark_status: str, status_reason: str, action: dic
     action_type = str(action.get("type") or "wait")
     if status_reason == "timeout_reached":
         checks.append("Review the configured monitoring SLA and current Harbor worker state before intervening.")
+    elif status_reason == "suspected_stalled":
+        checks.append("Review worker output and the confirmed stall duration before choosing wait or stop.")
     elif status_reason == "abnormal_exit":
         checks.extend(
             [
@@ -71,6 +73,11 @@ def build_user_notify(
     action_type = str(action.get("type") or "wait")
     task_summary = output.get("task_summary") if isinstance(output.get("task_summary"), dict) else {}
     retry_count = int(action.get("retry_count") or 0)
+    allowed_decisions = [
+        str(decision)
+        for decision in action.get("allowed_decisions", [])
+        if isinstance(decision, str)
+    ]
 
     control_failed = action.get("control_exit_code") not in (None, 0) or bool(action.get("control_error"))
     required = action_type in {"restart", "stop", "notify"} or status_reason in {"degraded", "unknown_or_conflicting_fields"} or control_failed
@@ -91,12 +98,16 @@ def build_user_notify(
         message_parts.append(f"control_exit_code={action.get('control_exit_code')}")
     message = "; ".join(message_parts)
 
-    if action_type == "notify" or control_failed or status_reason == "unknown_or_conflicting_fields":
+    if allowed_decisions == ["restart"]:
+        human_action_needed = "Review the abnormal exit and choose whether to restart the Harbor benchmark."
+    elif allowed_decisions == ["wait", "stop"]:
+        human_action_needed = "Choose whether to keep waiting or stop the running Harbor benchmark."
+    elif action_type == "notify" or control_failed or status_reason == "unknown_or_conflicting_fields":
         human_action_needed = "Human review is required for the Harbor queue, worker, Docker/API, and disk evidence."
     elif action_type == "restart":
-        human_action_needed = "No human action is currently required; the monitor executed the Harbor restart command."
+        human_action_needed = "The user-approved Harbor restart command was executed."
     elif action_type == "stop":
-        human_action_needed = "No human action is required; the monitor finalized the completed Harbor run."
+        human_action_needed = "The user-approved Harbor stop command was executed."
     else:
         human_action_needed = "No human action is required."
 
@@ -112,6 +123,8 @@ def build_user_notify(
         "status_reason": status_reason,
         "monitor_action_type": action_type,
         "runner_action_type": action_type,
+        "controller_status": action.get("controller_status", "observing"),
+        "allowed_decisions": allowed_decisions,
         "retry_count": retry_count,
         "max_retries": max_retries,
         "task_summary": task_summary,
@@ -248,6 +261,11 @@ def build_runner_action(
     control_attempted = bool(action.get("control_attempted"))
     control_performed = bool(action.get("external_control_performed"))
     retry_count = int(action.get("retry_count", 0) or 0)
+    allowed_decisions = [
+        str(decision)
+        for decision in action.get("allowed_decisions", [])
+        if isinstance(decision, str)
+    ]
     return {
         "audience": "harbor_runner_control",
         "kind": "harbor_control_action",
@@ -258,6 +276,8 @@ def build_runner_action(
         "stop_attempted_by_monitor": control_type == "stop" and control_attempted,
         "stop_auto_retry": action_type in {"stop", "notify"} or control_failed,
         "requires_human": action_type == "notify" or control_failed,
+        "controller_status": action.get("controller_status", "observing"),
+        "allowed_decisions": allowed_decisions,
         "benchmark_status": benchmark_status,
         "status_reason": status_reason,
         "evidence": evidence,
@@ -270,12 +290,12 @@ def build_runner_action(
         "restart_exit_code": action.get("control_exit_code") if control_type == "restart" else None,
         "restart_error": action.get("control_error") if control_type == "restart" else None,
         "external_control_performed": control_performed,
-        "auto_retry_supported": action_type == "restart" and control_performed and retry_count < max_retries,
-        "compatibility_note": "Harbor control is command-based and runner-neutral; monitor does not know or call runner-specific commands.",
+        "auto_retry_supported": False,
+        "compatibility_note": "Harbor control is command-based and runner-neutral; restart and stop require an explicit user decision.",
         "contract": {
             "wait": "Harbor run is still observable; sample Harbor artifacts again after interval.",
-            "restart": "Monitor executes only the configured run-local Harbor restart command with shell=False; recovery is confirmed by later samples.",
-            "stop": "Monitor executes the configured run-local Harbor stop command when provided, then stops the follow loop.",
-            "notify": "Harbor artifacts indicate blocked or ambiguous state that was not automatically recovered; surface user_notify and wait for human decision.",
+            "restart": "After explicit user approval, execute only the configured run-local Harbor restart command with shell=False.",
+            "stop": "After explicit user approval, execute the configured run-local Harbor stop command.",
+            "notify": "Surface user_notify with the state-appropriate allowed_decisions; no external control is executed automatically.",
         },
     }

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/evaluator.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/evaluator.py
@@ -31,13 +31,12 @@ def evaluate_once(
     S: int,
     startup_grace: int,
     configured_timeout: int | None,
-    max_retries: int,
     state: dict[str, Any],
     include_unknown_not_complete: bool,
     task_records: dict[str, TaskInput] | None = None,
     terminal_artifacts_missing: bool | None = None,
     run_finalized: bool = True,
-) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
     environment_events = parse_environment_events(environment_events_raw)
     queue_files_missing = (
         not done_path.exists() or not failed_path.exists()
@@ -218,19 +217,6 @@ def evaluate_once(
         if status == "not_complete":
             continue
 
-    action_type = "wait"
-    if benchmark_status == "blocked" and reason == "abnormal_exit":
-        if state.get("retry_count", 0) >= max_retries:
-            action_type = "notify"
-        else:
-            action_type = "restart"
-    elif benchmark_status == "running" and reason == "timeout_reached":
-        action_type = "notify"
-    elif benchmark_status == "completed":
-        action_type = "stop"
-    elif benchmark_status == "blocked":
-        action_type = "notify"
-
     return_data = {
         "benchmark_status": benchmark_status,
         "status_reason": reason,
@@ -270,13 +256,7 @@ def evaluate_once(
             "environment_events": environment_events,
         },
     }
-    action = {
-        "type": action_type,
-        "retry_count": state.get("retry_count", 0),
-        "reason": reason,
-        "external_control_performed": False,
-        "compatibility_note": "Harbor monitor control is command-based and runner-neutral; no runner-specific control is performed.",
+    return return_data, history, {
+        "last_progress_ts": last_progress_ts,
+        "run_start_ts": run_start_ts,
     }
-    if action_type == "notify" and benchmark_status == "blocked" and reason == "abnormal_exit":
-        action["reason"] = f"restart_retries_exhausted(max_retries={max_retries})"
-    return return_data, action, history, {"last_progress_ts": last_progress_ts, "run_start_ts": run_start_ts}

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
@@ -6,7 +6,6 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import Any
 
 from harbor_controller.analyzer_dispatch import dispatch_analyzer_handover
 from harbor_controller.executor import execute_action

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import os
-import shlex
-import subprocess
 import time
 from pathlib import Path
 from typing import Any
+
+from harbor_controller.analyzer_dispatch import dispatch_analyzer_handover
+from harbor_controller.executor import execute_action
+from harbor_controller.policy import decide_action
 
 from .artifacts import (
     load_harbor_job_snapshot,
@@ -22,40 +24,11 @@ from .artifacts import (
 )
 from .contracts import (
     build_analyzer_handover,
-    build_analyzer_handover_for_tasks,
     build_notify_incident_key,
     build_runner_action,
     build_user_notify,
 )
-from .evaluator import evaluate_once, now_ts
-
-
-def build_control_argv(control_cmd: str, run_dir: Path, label: str) -> tuple[list[str] | None, str | None]:
-    try:
-        parts = shlex.split(control_cmd)
-    except ValueError as exc:
-        return None, f"{label}_cmd_parse_error={exc}"
-    if not parts:
-        return None, f"{label}_cmd_empty"
-    if parts[0] in {"bash", "sh", "python", "python3"}:
-        return None, f"{label}_cmd_interpreter_prefixed"
-
-    run_root = run_dir.resolve()
-    executable = Path(parts[0])
-    if not executable.is_absolute():
-        executable = run_root / executable
-    try:
-        resolved = executable.resolve()
-        resolved.relative_to(run_root)
-    except (OSError, ValueError):
-        return None, f"{label}_cmd_not_run_specific"
-    if not resolved.exists():
-        return None, f"{label}_cmd_missing"
-    if not resolved.is_file():
-        return None, f"{label}_cmd_not_file"
-    if not os.access(resolved, os.X_OK):
-        return None, f"{label}_cmd_not_executable"
-    return [str(resolved), *parts[1:]], None
+from .evaluator import evaluate_once
 
 
 def count_running_workers(queue_dir: Path) -> int:
@@ -218,7 +191,7 @@ def run_loop(
                 run_dir / "online-analysis" / "environment-summary.json",
             ]
         )
-        output, action, history, extras = evaluate_once(
+        output, history, extras = evaluate_once(
             run_dir=run_dir,
             done_path=done_path,
             failed_path=failed_path,
@@ -231,7 +204,6 @@ def run_loop(
             S=adaptive_S,
             startup_grace=startup_grace,
             configured_timeout=configured_timeout,
-            max_retries=max_retries,
             state=state,
             include_unknown_not_complete=include_unknown_not_complete,
             task_records=task_records,
@@ -252,151 +224,24 @@ def run_loop(
         state["adaptive_S"] = adaptive_S
         state["consecutive_stall"] = consecutive_stall
 
-        if action["type"] == "restart":
-            if not restart_cmd:
-                    output["action"] = {
-                        "type": "notify",
-                        "retry_count": state.get("retry_count", 0),
-                        "reason": "restart_needed_but_restart_cmd_missing",
-                        "control_type": "restart",
-                        "control_attempted": False,
-                        "external_control_performed": False,
-                    }
-            else:
-                control_argv, control_error = build_control_argv(restart_cmd, run_dir, "restart")
-                if control_error or control_argv is None:
-                    output["action"] = {
-                        "type": "notify",
-                        "retry_count": state.get("retry_count", 0),
-                        "reason": control_error or "restart_cmd_invalid",
-                        "control_type": "restart",
-                        "control_attempted": False,
-                        "external_control_performed": False,
-                    }
-                else:
-                    state["retry_count"] = state.get("retry_count", 0) + 1
-                    try:
-                        result = subprocess.run(
-                            control_argv,
-                            cwd=run_dir,
-                            shell=False,
-                            text=True,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT,
-                            timeout=120,
-                            check=False,
-                        )
-                        if result.returncode == 0:
-                            control_ts = now_ts()
-                            state["last_progress_ts"] = control_ts
-                            history = [
-                                {
-                                    "ts": control_ts,
-                                    "finished": output["finished"],
-                                    "running": output["running"],
-                                    "remaining": output.get("unclaimed_remaining"),
-                                    "unfinished": output.get("unfinished"),
-                                    "status": "restart_executed",
-                                }
-                            ]
-                            state["run_start_ts"] = control_ts
-                            output["action"] = {
-                                "type": "restart",
-                                "retry_count": state["retry_count"],
-                                "reason": action["reason"],
-                                "control_type": "restart",
-                                "control_exit_code": result.returncode,
-                                "control_attempted": True,
-                                "external_control_performed": True,
-                            }
-                        else:
-                            output["action"] = {
-                                "type": "notify",
-                                "retry_count": state["retry_count"],
-                                "reason": f"restart_failed_exit_code={result.returncode}",
-                                "control_type": "restart",
-                                "control_exit_code": result.returncode,
-                                "control_attempted": True,
-                                "external_control_performed": True,
-                            }
-                        output["control_stdout"] = result.stdout[-2000:]
-                    except subprocess.TimeoutExpired as exc:
-                        output["action"] = {
-                            "type": "notify",
-                            "retry_count": state["retry_count"],
-                            "reason": "restart_failed_timeout",
-                            "control_type": "restart",
-                            "control_error": str(exc),
-                            "control_attempted": True,
-                            "external_control_performed": True,
-                        }
-                    except Exception as exc:  # noqa: BLE001 - control boundary reports failures
-                        output["action"] = {
-                            "type": "notify",
-                            "retry_count": state["retry_count"],
-                            "reason": "restart_failed_exception",
-                            "control_type": "restart",
-                            "control_error": str(exc),
-                            "control_attempted": True,
-                            "external_control_performed": False,
-                        }
-        elif action["type"] == "stop":
-            output["action"] = action
-            if stop_cmd:
-                control_argv, control_error = build_control_argv(stop_cmd, run_dir, "stop")
-                if control_error or control_argv is None:
-                    output["action"] = {
-                        "type": "notify",
-                        "retry_count": state.get("retry_count", 0),
-                        "reason": control_error or "stop_cmd_invalid",
-                        "control_type": "stop",
-                        "control_attempted": False,
-                        "external_control_performed": False,
-                    }
-                else:
-                    try:
-                        result = subprocess.run(
-                            control_argv,
-                            cwd=run_dir,
-                            shell=False,
-                            text=True,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT,
-                            timeout=120,
-                            check=False,
-                        )
-                        output["action"] = {
-                            "type": "stop" if result.returncode == 0 else "notify",
-                            "retry_count": state.get("retry_count", 0),
-                            "reason": action["reason"] if result.returncode == 0 else f"stop_failed_exit_code={result.returncode}",
-                            "control_type": "stop",
-                            "control_exit_code": result.returncode,
-                            "control_attempted": True,
-                            "external_control_performed": True,
-                        }
-                        output["control_stdout"] = result.stdout[-2000:]
-                    except subprocess.TimeoutExpired as exc:
-                        output["action"] = {
-                            "type": "notify",
-                            "retry_count": state.get("retry_count", 0),
-                            "reason": "stop_failed_timeout",
-                            "control_type": "stop",
-                            "control_error": str(exc),
-                            "control_attempted": True,
-                            "external_control_performed": True,
-                        }
-                    except Exception as exc:  # noqa: BLE001 - control boundary reports failures
-                        output["action"] = {
-                            "type": "notify",
-                            "retry_count": state.get("retry_count", 0),
-                            "reason": "stop_failed_exception",
-                            "control_type": "stop",
-                            "control_error": str(exc),
-                            "control_attempted": True,
-                            "external_control_performed": False,
-                        }
-        else:
-            output["action"] = action
+        requested_action = decide_action(
+            output,
+            retry_count=int(state.get("retry_count", 0) or 0),
+            max_retries=max_retries,
+        )
+        controller_result = execute_action(
+            requested_action,
+            restart_cmd=restart_cmd,
+            stop_cmd=stop_cmd,
+            run_dir=run_dir,
+            state=state,
+            observation=output,
+            history=history,
+        )
+        output["action"] = controller_result.action
+        history = controller_result.history
+        if controller_result.control_stdout is not None:
+            output["control_stdout"] = controller_result.control_stdout
 
         output["user_notify"] = build_user_notify(
             output=output,
@@ -452,10 +297,12 @@ def run_loop(
         if previous_notify and action_type != "notify":
             output["previous_action_required_notify"] = previous_notify
 
-        if action_type in {"wait", "restart"}:
+        if output.get("benchmark_status") == "completed":
+            output["monitor_follow_decision"] = "stop_completed"
+        elif action_type in {"wait", "restart"}:
             output["monitor_follow_decision"] = "continue"
         elif action_type == "stop":
-            output["monitor_follow_decision"] = "stop_completed"
+            output["monitor_follow_decision"] = "stop_user_requested"
         elif (
             action_type == "notify"
             and output.get("benchmark_status") == "running"
@@ -488,42 +335,22 @@ def run_loop(
             output_path.write_text(output_json + "\n", encoding="utf-8")
         write_json(user_report_output, output["user_notify"])
         analyzer_handover = output["analyzer_handover"]
-        if analyzer_handover_output and analyzer_handover.get("should_run_analyzer"):
-            spooled_raw = state.get("analyzer_spooled_terminal_fingerprints")
-            spooled = {
-                str(value)
-                for value in spooled_raw
-                if isinstance(value, str) and value
-            } if isinstance(spooled_raw, list) else set()
-            tasks = analyzer_handover.get("tasks")
-            new_tasks: list[dict[str, Any]] = []
-            new_fingerprints: list[str] = []
-            if isinstance(tasks, list):
-                for task in tasks:
-                    if not isinstance(task, dict):
-                        continue
-                    fingerprint = str(task.get("terminal_fingerprint") or "")
-                    if not fingerprint or fingerprint in spooled:
-                        continue
-                    new_tasks.append(task)
-                    new_fingerprints.append(fingerprint)
-            if new_tasks:
-                handoff = build_analyzer_handover_for_tasks(analyzer_handover, new_tasks)
-                handover_id = str(handoff.get("handover_id") or "")
-                if handover_id:
-                    spool_path = analyzer_handover_output.parent / "analyzer-handoffs" / f"{handover_id}.json"
-                    if not spool_path.exists():
-                        write_json(spool_path, handoff)
-                    state["analyzer_spooled_terminal_fingerprints"] = sorted(
-                        spooled | set(new_fingerprints)
-                    )
-        write_json(analyzer_handover_output, analyzer_handover)
+        dispatch_analyzer_handover(
+            analyzer_handover,
+            latest_output=analyzer_handover_output,
+            state=state,
+            write_json=write_json,
+        )
         write_json(runner_action_output, output["runner_action"])
         print(output_json)
         save_state(state_path, state)
 
         if loop_once:
             break
-        if output["monitor_follow_decision"] in {"stop_completed", "stop_action_required"}:
+        if output["monitor_follow_decision"] in {
+            "stop_completed",
+            "stop_action_required",
+            "stop_user_requested",
+        }:
             break
         time.sleep(poll_interval)

--- a/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
+++ b/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
@@ -384,9 +384,11 @@ def _render_markdown(
     if coverage and 0 < coverage["analyzed"] < coverage["expected"]:
         lines.extend(
             [
-                "Analyzer results are incomplete: analysis is available for "
-                f"{coverage['analyzed']} of {coverage['expected']} final "
-                "failed/unknown/not-complete task(s).",
+                (
+                    "Analyzer results are incomplete: analysis is available for "
+                    f"{coverage['analyzed']} of {coverage['expected']} final "
+                    "failed/unknown/not-complete task(s)."
+                ),
                 "",
             ]
         )

--- a/Agents/utils/common/Harbor/tests/test_harbor_controller.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_controller.py
@@ -1,0 +1,237 @@
+"""Tests for the extracted Harbor controller boundary."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from harbor_controller.analyzer_dispatch import dispatch_analyzer_handover
+from harbor_controller.executor import build_control_argv, execute_action
+from harbor_controller.policy import decide_action
+
+
+def _observation(
+    status: str,
+    reason: str,
+    *,
+    running: int = 0,
+    unfinished: int = 1,
+    stalled_duration_reached: bool = False,
+) -> dict[str, object]:
+    return {
+        "benchmark_status": status,
+        "status_reason": reason,
+        "finished": 0,
+        "running": running,
+        "unclaimed_remaining": 1,
+        "unfinished": unfinished,
+        "stalled_duration_reached": stalled_duration_reached,
+    }
+
+
+class HarborControllerPolicyTest(unittest.TestCase):
+    def test_observations_never_execute_control_without_user_decision(self) -> None:
+        cases = [
+            (_observation("running", "progressing", running=1), 0, "wait", []),
+            (_observation("blocked", "abnormal_exit"), 0, "notify", ["restart"]),
+            (_observation("completed", "completed", unfinished=0), 0, "wait", []),
+            (
+                _observation("running", "timeout_reached", running=1),
+                0,
+                "notify",
+                ["wait", "stop"],
+            ),
+            (
+                _observation(
+                    "running",
+                    "suspected_stalled",
+                    running=1,
+                    stalled_duration_reached=True,
+                ),
+                0,
+                "notify",
+                ["wait", "stop"],
+            ),
+            (_observation("blocked", "abnormal_exit"), 3, "notify", []),
+        ]
+        for observation, retries, expected, allowed in cases:
+            with self.subTest(expected=expected, retries=retries):
+                action = decide_action(
+                    observation,
+                    retry_count=retries,
+                    max_retries=3,
+                )
+                self.assertEqual(action["type"], expected)
+                self.assertEqual(action["allowed_decisions"], allowed)
+
+    def test_stall_below_decision_threshold_waits(self) -> None:
+        action = decide_action(
+            _observation("running", "suspected_stalled", running=1),
+            retry_count=0,
+            max_retries=3,
+        )
+        self.assertEqual(action["type"], "wait")
+        self.assertEqual(action["allowed_decisions"], [])
+
+    def test_restart_is_not_offered_while_a_worker_is_live(self) -> None:
+        action = decide_action(
+            _observation("blocked", "abnormal_exit", running=1),
+            retry_count=0,
+            max_retries=3,
+        )
+        self.assertEqual(action["type"], "notify")
+        self.assertEqual(action["allowed_decisions"], [])
+
+    def test_stop_is_not_offered_without_a_live_worker(self) -> None:
+        action = decide_action(
+            _observation("running", "timeout_reached"),
+            retry_count=0,
+            max_retries=3,
+        )
+        self.assertEqual(action["type"], "wait")
+        self.assertEqual(action["allowed_decisions"], [])
+
+    def test_completed_observation_marks_controller_completed(self) -> None:
+        action = decide_action(
+            _observation("completed", "completed", unfinished=0),
+            retry_count=0,
+            max_retries=3,
+        )
+        self.assertEqual(action["controller_status"], "completed")
+
+
+class HarborControllerExecutorTest(unittest.TestCase):
+    def test_rejects_commands_outside_run_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            argv, error = build_control_argv("/bin/true", Path(root), "restart")
+            self.assertIsNone(argv)
+            self.assertEqual(error, "restart_cmd_not_run_specific")
+
+    def test_executes_real_run_local_restart_command(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            command = run_dir / "restart.sh"
+            command.write_text("#!/usr/bin/env bash\nprintf 'restarted\\n'\ntouch restarted.marker\n")
+            command.chmod(0o755)
+            state: dict[str, object] = {"retry_count": 0}
+            requested = {"type": "restart", "reason": "user_approved", "retry_count": 0}
+
+            result = execute_action(
+                requested,
+                restart_cmd="restart.sh",
+                stop_cmd=None,
+                run_dir=run_dir,
+                state=state,
+                observation=_observation("blocked", "abnormal_exit"),
+                history=[],
+            )
+
+            self.assertEqual(result.action["type"], "restart")
+            self.assertEqual(result.action["control_exit_code"], 0)
+            self.assertEqual(state["retry_count"], 1)
+            self.assertEqual(result.control_stdout, "restarted\n")
+            self.assertTrue((run_dir / "restarted.marker").is_file())
+            self.assertEqual(result.history[0]["status"], "restart_executed")
+
+    def test_missing_restart_command_becomes_notify(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            observation = _observation("blocked", "abnormal_exit")
+            requested = {"type": "restart", "reason": "user_approved", "retry_count": 0}
+            result = execute_action(
+                requested,
+                restart_cmd=None,
+                stop_cmd=None,
+                run_dir=Path(root),
+                state={"retry_count": 0},
+                observation=observation,
+                history=[],
+            )
+            self.assertEqual(result.action["type"], "notify")
+            self.assertEqual(
+                result.action["reason"],
+                "restart_needed_but_restart_cmd_missing",
+            )
+
+    def test_executes_real_run_local_stop_command(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            command = run_dir / "stop.sh"
+            command.write_text("#!/usr/bin/env bash\nprintf 'stopped\\n'\ntouch stopped.marker\n")
+            command.chmod(0o755)
+            requested = {"type": "stop", "reason": "user_approved", "retry_count": 0}
+
+            result = execute_action(
+                requested,
+                restart_cmd=None,
+                stop_cmd="stop.sh",
+                run_dir=run_dir,
+                state={"retry_count": 0},
+                observation=_observation("running", "timeout_reached", running=1),
+                history=[],
+            )
+
+            self.assertEqual(result.action["type"], "stop")
+            self.assertEqual(result.action["control_exit_code"], 0)
+            self.assertEqual(result.control_stdout, "stopped\n")
+            self.assertTrue((run_dir / "stopped.marker").is_file())
+
+
+class HarborControllerAnalyzerDispatchTest(unittest.TestCase):
+    def test_spools_each_terminal_fingerprint_once(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            latest = root_path / "analyzer-handover-latest.json"
+            state: dict[str, object] = {}
+            handover = {
+                "run_id": "run-1",
+                "should_run_analyzer": True,
+                "tasks": [
+                    {
+                        "task_index": "1",
+                        "task_name": "task-a",
+                        "terminal_fingerprint": "sha256-task-a",
+                    }
+                ],
+            }
+
+            def write_json(path: Path | None, payload: dict[str, object]) -> None:
+                if path is None:
+                    return
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(json.dumps(payload), encoding="utf-8")
+
+            dispatch_analyzer_handover(
+                handover,
+                latest_output=latest,
+                state=state,
+                write_json=write_json,
+            )
+            first_spool = list((root_path / "analyzer-handoffs").glob("*.json"))
+            dispatch_analyzer_handover(
+                handover,
+                latest_output=latest,
+                state=state,
+                write_json=write_json,
+            )
+
+            self.assertEqual(len(first_spool), 1)
+            self.assertEqual(
+                list((root_path / "analyzer-handoffs").glob("*.json")),
+                first_spool,
+            )
+            self.assertEqual(
+                state["analyzer_spooled_terminal_fingerprints"],
+                ["sha256-task-a"],
+            )
+            self.assertEqual(json.loads(latest.read_text())["run_id"], "run-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_harbor_monitor_controller_integration.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_monitor_controller_integration.py
@@ -1,0 +1,133 @@
+"""CLI integration tests for monitor observations and controller actions."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HARBOR_DIR = Path(__file__).resolve().parents[1]
+MONITOR = HARBOR_DIR / "scripts" / "monitor.py"
+
+
+class MonitorControllerIntegrationTest(unittest.TestCase):
+    def _run_monitor(
+        self,
+        root: Path,
+        *,
+        extra_args: list[str],
+        done: str = "",
+        failed: str = "",
+    ) -> dict[str, object]:
+        queue = root / "queue" / "claude-code"
+        queue.mkdir(parents=True)
+        (root / "tasks.txt").write_text("task-a\n", encoding="utf-8")
+        (queue / "done.txt").write_text(done, encoding="utf-8")
+        (queue / "failed.txt").write_text(failed, encoding="utf-8")
+        (queue / "next_index").write_text("2\n", encoding="utf-8")
+        monitor_dir = root / "monitor"
+        command = [
+            sys.executable,
+            str(MONITOR),
+            "--run-dir",
+            str(root),
+            "--queue-dir",
+            str(queue),
+            "--task-file",
+            str(root / "tasks.txt"),
+            "--output",
+            str(monitor_dir / "monitor-latest.json"),
+            "--user-report-output",
+            str(monitor_dir / "user-notify-latest.json"),
+            "--analyzer-handover-output",
+            str(monitor_dir / "analyzer-handover-latest.json"),
+            "--runner-action-output",
+            str(monitor_dir / "runner-action-latest.json"),
+            "--startup-grace",
+            "0",
+            *extra_args,
+        ]
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=10,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        return json.loads((monitor_dir / "monitor-latest.json").read_text())
+
+    def test_wait_action_for_live_worker(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            output = self._run_monitor(
+                Path(root),
+                extra_args=["--total", "1", "--claimed", "1", "--remaining", "0", "--running", "1"],
+            )
+            self.assertEqual(output["action"]["type"], "wait")
+
+    def test_notify_action_for_live_worker_past_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            output = self._run_monitor(
+                Path(root),
+                extra_args=[
+                    "--total",
+                    "1",
+                    "--claimed",
+                    "1",
+                    "--remaining",
+                    "0",
+                    "--running",
+                    "1",
+                    "--configured-timeout",
+                    "0",
+                ],
+            )
+            self.assertEqual(output["action"]["type"], "notify")
+            self.assertEqual(output["status_reason"], "timeout_reached")
+            self.assertEqual(output["action"]["allowed_decisions"], ["wait", "stop"])
+            self.assertEqual(output["user_notify"]["allowed_decisions"], ["wait", "stop"])
+
+    def test_abnormal_exit_offers_restart_without_executing_command(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            command = run_dir / "restart.sh"
+            command.write_text(
+                "#!/usr/bin/env bash\nprintf 'controller-restarted\\n'\ntouch restart.marker\n",
+                encoding="utf-8",
+            )
+            command.chmod(0o755)
+            output = self._run_monitor(
+                run_dir,
+                extra_args=["--restart-cmd", "restart.sh"],
+            )
+            self.assertEqual(output["action"]["type"], "notify")
+            self.assertEqual(output["action"]["allowed_decisions"], ["restart"])
+            self.assertEqual(output["state"]["retry_count"], 0)
+            self.assertFalse((run_dir / "restart.marker").exists())
+
+    def test_completion_stops_monitor_without_executing_stop_command(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            command = run_dir / "stop.sh"
+            command.write_text(
+                "#!/usr/bin/env bash\nprintf 'controller-stopped\\n'\ntouch stop.marker\n",
+                encoding="utf-8",
+            )
+            command.chmod(0o755)
+            output = self._run_monitor(
+                run_dir,
+                extra_args=["--stop-cmd", "stop.sh"],
+                done="1\ttask-a\t1.0\n",
+            )
+            self.assertEqual(output["action"]["type"], "wait")
+            self.assertEqual(output["monitor_follow_decision"], "stop_completed")
+            self.assertEqual(output["user_notify"]["controller_status"], "completed")
+            self.assertFalse((run_dir / "stop.marker").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- separate Harbor observation/evaluation from controller policy and execution while preserving the existing runner entry point
- keep wait and notify behavior distinct from restart/stop decisions, with restart and stop exposed as user-selectable actions instead of automatic commands
- isolate analyzer dispatch behind the controller boundary and document the minimal-change structure
- add controller unit coverage and monitor/controller integration coverage

## Validation

- Harbor unittest suite: 81 tests passed
- real benchmark run exercised the monitor follow flow and wait/notify decision paths
- verified restart commands are not automatically triggered by the refactored flow