### PR TITLE
feat(harbor): add deterministic fixer policy rules

### DIFF
--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/command_analysis.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/command_analysis.py
@@ -1,0 +1,209 @@
+"""Conservative shell-shape analysis for Harbor Fixer commands."""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SHELL_PUNCTUATION = frozenset("();&|<>")
+SHELL_RESERVED_WORDS = {
+    "!",
+    "case",
+    "do",
+    "done",
+    "elif",
+    "else",
+    "esac",
+    "fi",
+    "for",
+    "function",
+    "if",
+    "in",
+    "select",
+    "then",
+    "time",
+    "until",
+    "while",
+    "{",
+    "}",
+}
+
+
+@dataclass(frozen=True)
+class CommandAnalysis:
+    """Facts derived from a command without deciding whether to allow it."""
+
+    classification: str
+    argv: tuple[str, ...]
+    executable_token: str
+    interpreter: str
+    has_embedded_script: bool
+    shell_features: tuple[str, ...]
+    command_sha256: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "analysis_version": 1,
+            "classification": self.classification,
+            "argv": list(self.argv),
+            "executable_token": self.executable_token,
+            "interpreter": self.interpreter,
+            "has_embedded_script": self.has_embedded_script,
+            "shell_features": list(self.shell_features),
+            "command_sha256": self.command_sha256,
+        }
+
+
+def _shell_features(command: str) -> set[str]:
+    features: set[str] = set()
+    quote = ""
+    escaped = False
+    word_start = True
+    index = 0
+    while index < len(command):
+        character = command[index]
+        if escaped:
+            escaped = False
+            word_start = False
+            index += 1
+            continue
+        if character == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote:
+            if character == quote:
+                quote = ""
+            elif quote == '"' and character in "$`":
+                features.add("expansion")
+            index += 1
+            continue
+        if character in "'\"":
+            quote = character
+            word_start = False
+        elif character in "\r\n":
+            features.add("newline")
+            word_start = True
+        elif character.isspace():
+            word_start = True
+        elif character in ";&|()":
+            features.add("control_operator")
+            word_start = True
+        elif character in "<>":
+            features.add("redirection")
+            if command[index : index + 2] == "<<":
+                features.add("heredoc")
+            word_start = True
+        elif character in "$`":
+            features.add("expansion")
+            word_start = False
+        elif character in "*?[":
+            features.add("glob")
+            word_start = False
+        elif character in "{}":
+            features.add("brace_expansion")
+            word_start = False
+        elif character == "~" and word_start:
+            features.add("tilde_expansion")
+            word_start = False
+        elif character == "#" and word_start:
+            features.add("comment")
+            word_start = False
+        else:
+            word_start = False
+        index += 1
+    return features
+
+
+def _lex_tokens(command: str) -> list[str] | None:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars="();&|<>")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    try:
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def lex_single_command(command: str) -> list[str] | None:
+    """Lex one command, including dynamic words, without evaluating it."""
+
+    if not command or "\x00" in command or any(char in command for char in "\r\n"):
+        return None
+    tokens = _lex_tokens(command)
+    if (
+        not tokens
+        or tokens[0] in SHELL_RESERVED_WORDS
+        or any(token and set(token) <= SHELL_PUNCTUATION for token in tokens)
+    ):
+        return None
+    return tokens
+
+
+def _is_assignment(token: str) -> bool:
+    if "=" not in token or token.startswith("="):
+        return False
+    name = token.split("=", 1)[0]
+    return bool(name) and name.replace("_", "a").isalnum()
+
+
+def _interpreter_details(argv: list[str]) -> tuple[str, bool]:
+    if not argv:
+        return "", False
+    executable = Path(argv[0]).name
+    if executable.startswith(("python", "pypy")):
+        return "python", "-c" in argv[1:]
+    if executable in {"bash", "dash", "ksh", "sh", "zsh"}:
+        return "shell", any(
+            "c" in option[1:] for option in argv[1:] if option.startswith("-")
+        )
+    if executable == "node":
+        return "javascript", any(option in argv[1:] for option in ("-e", "--eval"))
+    if executable in {"perl", "ruby"}:
+        return executable, "-e" in argv[1:]
+    return "", False
+
+
+def analyze_command(command: str) -> CommandAnalysis:
+    """Classify a raw command as static argv, shell script, or invalid."""
+
+    digest = hashlib.sha256(command.encode("utf-8")).hexdigest()
+    features = _shell_features(command)
+    if not command.strip() or "\x00" in command or _lex_tokens(command) is None:
+        return CommandAnalysis(
+            classification="invalid",
+            argv=(),
+            executable_token="",
+            interpreter="",
+            has_embedded_script=False,
+            shell_features=tuple(sorted(features)),
+            command_sha256=digest,
+        )
+    lexical_argv = lex_single_command(command)
+    if lexical_argv is None:
+        return CommandAnalysis(
+            classification="shell_script",
+            argv=(),
+            executable_token="",
+            interpreter="",
+            has_embedded_script=False,
+            shell_features=tuple(sorted(features)),
+            command_sha256=digest,
+        )
+
+    if _is_assignment(lexical_argv[0]):
+        features.add("environment_assignment")
+    is_static = not features and lexical_argv[0] not in SHELL_RESERVED_WORDS
+    interpreter, embedded_script = _interpreter_details(lexical_argv)
+    return CommandAnalysis(
+        classification="static_argv" if is_static else "shell_script",
+        argv=tuple(lexical_argv) if is_static else (),
+        executable_token=lexical_argv[0],
+        interpreter=interpreter,
+        has_embedded_script=embedded_script,
+        shell_features=tuple(sorted(features)),
+        command_sha256=digest,
+    )

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/__init__.py
@@ -1,0 +1,12 @@
+"""Harbor Fixer execution policy interfaces."""
+
+from ..command_analysis import CommandAnalysis, analyze_command
+from .rules import PrefixRule, evaluate_t1, load_user_rules
+
+__all__ = [
+    "CommandAnalysis",
+    "PrefixRule",
+    "analyze_command",
+    "evaluate_t1",
+    "load_user_rules",
+]

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/builtin.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/builtin.py
@@ -1,0 +1,50 @@
+"""Built-in T1 allow and deny rules."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+_DENY_EXECUTABLES = {"rm", "rmdir", "shred", "unlink", "wipefs"}
+_READ_ONLY_COMMANDS = {
+    "cat",
+    "du",
+    "echo",
+    "grep",
+    "head",
+    "id",
+    "ls",
+    "printf",
+    "pwd",
+    "stat",
+    "test",
+    "true",
+    "uname",
+    "wc",
+    "which",
+}
+
+
+def destructive_reason(tokens: Sequence[str]) -> tuple[str, str] | None:
+    """Return the built-in denial reason for one unambiguous executable."""
+
+    if not tokens:
+        return None
+    executable = Path(tokens[0]).name
+    if executable in _DENY_EXECUTABLES or executable.startswith("mkfs"):
+        return "builtin_destructive_command", executable
+    return None
+
+
+def read_only_reason(command_tokens: Sequence[str]) -> tuple[str, str] | None:
+    """Return the built-in allow reason for one static bare executable."""
+
+    if not command_tokens:
+        return None
+    executable = command_tokens[0]
+    if Path(executable).name != executable or executable not in _READ_ONLY_COMMANDS:
+        return None
+    return (
+        f"builtin_read_only_{executable}",
+        f"built-in read-only command: {executable}",
+    )

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/rules.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/rules.py
@@ -1,0 +1,247 @@
+"""Deterministic T1 execution policy for simple commands."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..artifact_io import read_json
+from ..command_analysis import CommandAnalysis, analyze_command, lex_single_command
+from ..validation import (
+    ValidationError,
+    require_dict,
+    require_enum,
+    require_list,
+    require_string,
+)
+from .builtin import destructive_reason, read_only_reason
+
+AGENT_ONLY_EXECUTABLES = {
+    "bash",
+    "command",
+    "dash",
+    "docker",
+    "env",
+    "eval",
+    "exec",
+    "find",
+    "git",
+    "ksh",
+    "nohup",
+    "sh",
+    "su",
+    "sudo",
+    "timeout",
+    "xargs",
+    "zsh",
+}
+
+
+@dataclass(frozen=True)
+class PrefixRule:
+    rule_id: str
+    pattern: tuple[str, ...]
+    match: str
+    decision: str
+
+
+def _is_assignment(token: str) -> bool:
+    if "=" not in token or token.startswith("="):
+        return False
+    name = token.split("=", 1)[0]
+    return bool(name) and name.replace("_", "a").isalnum()
+
+
+def parse_simple_argv(command: str) -> list[str] | None:
+    """Return a static, expansion-free argv eligible for T1 allow."""
+
+    analysis = analyze_command(command)
+    return list(analysis.argv) if analysis.classification == "static_argv" else None
+
+
+def normalize_argv(argv: list[str]) -> list[str]:
+    """Unwrap narrow execution forms for deterministic deny matching."""
+
+    original = list(argv)
+    result = list(argv)
+    while result:
+        while result and _is_assignment(result[0]):
+            result.pop(0)
+        if not result:
+            break
+        wrapper = result[0]
+        if wrapper not in {"env", "sudo"}:
+            break
+        result.pop(0)
+        while result and result[0].startswith("-"):
+            option = result.pop(0)
+            if option == "--":
+                break
+            if (
+                wrapper == "env"
+                and option in {"-u", "--unset", "-C", "--chdir"}
+                and result
+            ) or (
+                wrapper == "sudo"
+                and option in {"-D", "--chdir", "-g", "--group", "-u", "--user"}
+                and result
+            ):
+                result.pop(0)
+            else:
+                return original
+    return result
+
+
+def _rule_argv(
+    command: str,
+    analysis: CommandAnalysis,
+) -> tuple[list[list[str]], list[str]] | None:
+    argv = lex_single_command(command)
+    if argv is None:
+        return None
+    normalized = normalize_argv(argv)
+    if not normalized:
+        return None
+    candidates = [argv]
+    if normalized != argv:
+        candidates.append(normalized)
+    static_argv = list(analysis.argv)
+    allow_argv = (
+        []
+        if static_argv is None
+        or _is_assignment(argv[0])
+        or analysis.has_embedded_script
+        or Path(argv[0]).name in AGENT_ONLY_EXECUTABLES
+        else static_argv
+    )
+    return candidates, allow_argv
+
+
+def _validate_rule(item: Any, name: str, decision: str) -> PrefixRule:
+    payload = require_dict(item, name)
+    pattern = tuple(
+        require_string(value, f"{name}.pattern[{index}]")
+        for index, value in enumerate(
+            require_list(payload.get("pattern"), f"{name}.pattern")
+        )
+    )
+    if not pattern:
+        raise ValidationError(f"{name}.pattern must be non-empty")
+    match = require_enum(
+        payload.get("match", "exact"), f"{name}.match", {"exact", "prefix"}
+    )
+    if decision == "allow" and match == "prefix" and len(pattern) < 2:
+        raise ValidationError(
+            f"{name} prefix allow pattern must contain at least two tokens"
+        )
+    return PrefixRule(
+        rule_id=require_string(payload.get("rule_id"), f"{name}.rule_id"),
+        pattern=pattern,
+        match=match,
+        decision=decision,
+    )
+
+
+def load_user_rules(path: Path | None) -> tuple[list[PrefixRule], str]:
+    if path is None:
+        return [], ""
+    payload = read_json(path)
+    if (
+        payload.get("schema_version") != 1
+        or payload.get("kind") != "harbor_fixer_policy_rules"
+    ):
+        raise ValidationError(
+            "policy rules must be harbor_fixer_policy_rules schema_version 1"
+        )
+    rules: list[PrefixRule] = []
+    for decision in ("deny", "allow"):
+        for index, item in enumerate(require_list(payload.get(decision, []), decision)):
+            rules.append(_validate_rule(item, f"{decision}[{index}]", decision))
+    return rules, str(path)
+
+
+def _matches(rule: PrefixRule, argv: list[str]) -> bool:
+    if rule.match == "exact":
+        return tuple(argv) == rule.pattern
+    return tuple(argv[: len(rule.pattern)]) == rule.pattern
+
+
+def evaluate_t1(
+    command: str,
+    user_rules: list[PrefixRule],
+    *,
+    analysis: CommandAnalysis | None = None,
+    executable_verified: bool = False,
+) -> dict[str, Any] | None:
+    """Return a deterministic T1 decision for a simple command, if available."""
+
+    command_sha256 = hashlib.sha256(command.encode("utf-8")).hexdigest()
+    command_analysis = (
+        analysis
+        if analysis is not None and analysis.command_sha256 == command_sha256
+        else analyze_command(command)
+    )
+    parsed = _rule_argv(command, command_analysis)
+    if parsed is None:
+        return None
+    candidates, allow_argv = parsed
+    if not candidates:
+        return None
+    for argv in candidates:
+        deny_reason = destructive_reason(argv)
+        if deny_reason is not None:
+            reason_code, executable = deny_reason
+            return {
+                "tier": "T1",
+                "decision": "deny",
+                "risk_level": "high",
+                "source": "builtin_rule",
+                "rule_id": reason_code,
+                "reason_code": reason_code,
+                "reason": f"built-in policy prohibits destructive command: {executable}",
+            }
+    for rule in (rule for rule in user_rules if rule.decision == "deny"):
+        if any(_matches(rule, argv) for argv in candidates):
+            return {
+                "tier": "T1",
+                "decision": "deny",
+                "risk_level": "high",
+                "source": "user_rule",
+                "rule_id": rule.rule_id,
+                "reason_code": "user_deny_rule",
+                "reason": f"command matches user deny rule {rule.rule_id}",
+            }
+    if not allow_argv or not executable_verified:
+        return None
+    user_allow = next(
+        (
+            rule
+            for rule in user_rules
+            if rule.decision == "allow" and _matches(rule, allow_argv)
+        ),
+        None,
+    )
+    if user_allow is not None:
+        return {
+            "tier": "T1",
+            "decision": "allow",
+            "risk_level": "low",
+            "source": "user_rule",
+            "rule_id": user_allow.rule_id,
+            "reason_code": "t1_allow_rule",
+            "reason": "command matches user allow rule",
+        }
+    builtin = read_only_reason(allow_argv)
+    if builtin is None:
+        return None
+    return {
+        "tier": "T1",
+        "decision": "allow",
+        "risk_level": "low",
+        "source": "builtin_rule",
+        "rule_id": builtin[0],
+        "reason_code": "t1_allow_rule",
+        "reason": builtin[1],
+    }

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy_rules.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy_rules.py
@@ -1,0 +1,112 @@
+"""Tests for deterministic Harbor Fixer policy rules."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+if str(TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(TEST_DIR))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from fixer_test_support import FixerTestCase, write_json
+from harbor_fixer.policy import analyze_command, evaluate_t1, load_user_rules
+
+
+def _prefix_rule(rule_id: str, *pattern: str) -> dict:
+    return {"rule_id": rule_id, "pattern": list(pattern), "match": "prefix"}
+
+
+class HarborFixerPolicyRulesTest(FixerTestCase):
+    def test_command_analysis_separates_argv_from_shell_scripts(self) -> None:
+        cases = {
+            "python3 -c 'print(\"x\" * 1000)'": ("static_argv", True),
+            "python3 - <<'EOF'\nprint('x')\nEOF": ("shell_script", False),
+            "docker ps | grep fixture": ("shell_script", False),
+            "echo '$HOME'": ("static_argv", False),
+            "echo 'unterminated": ("invalid", False),
+        }
+        for command, expected in cases.items():
+            with self.subTest(command=command):
+                analysis = analyze_command(command)
+                self.assertEqual(
+                    (analysis.classification, analysis.has_embedded_script),
+                    expected,
+                )
+                self.assertEqual(len(analysis.command_sha256), 64)
+
+    def test_builtin_rules(self) -> None:
+        cases = {
+            "docker ps --all": None,
+            "git status --short": None,
+            "find . -delete": None,
+            "ls workspace": "allow",
+            "rm -rf build": "deny",
+            "sudo -u root rm -f /tmp/item": "deny",
+            "FOO=bar rm -rf build": "deny",
+            "bash -lc 'rm -rf build'": None,
+            "echo $(rm -f marker)": None,
+            "printf '%s\\n' marker | xargs rm -f": None,
+            "PATH=$PWD:$PATH ls": None,
+            "rm -rf *": "deny",
+            "ls *": None,
+            "echo '$HOME'": "allow",
+        }
+        for command, expected in cases.items():
+            with self.subTest(command=command):
+                decision = evaluate_t1(command, [], executable_verified=True)
+                self.assertEqual(
+                    None if decision is None else decision["decision"], expected
+                )
+
+    def test_user_deny_precedes_allow_and_builtin_deny(self) -> None:
+        rules_path = self.root / "rules.json"
+        write_json(
+            rules_path,
+            {
+                "schema_version": 1,
+                "kind": "harbor_fixer_policy_rules",
+                "deny": [
+                    _prefix_rule("deny-docker-ps", "docker", "ps"),
+                ],
+                "allow": [
+                    _prefix_rule("allow-docker-ps", "docker", "ps"),
+                    _prefix_rule("allow-rm", "rm", "-rf"),
+                    _prefix_rule("allow-pytest", "pytest", "-q"),
+                    _prefix_rule("allow-python", "python3", "-c"),
+                ],
+            },
+        )
+        rules, _ = load_user_rules(rules_path)
+
+        self.assertEqual(
+            evaluate_t1("docker ps -a", rules)["rule_id"], "deny-docker-ps"
+        )
+        self.assertEqual(evaluate_t1("rm -rf build", rules)["source"], "builtin_rule")
+        self.assertIsNone(evaluate_t1("pytest -q $TESTS", rules))
+        self.assertIsNone(
+            evaluate_t1("python3 -c 'print(1)'", rules, executable_verified=True)
+        )
+        self.assertEqual(
+            evaluate_t1("pytest -q tests/unit", rules, executable_verified=True)[
+                "decision"
+            ],
+            "allow",
+        )
+        self.assertIsNone(
+            evaluate_t1(
+                "curl https://example.test",
+                [],
+                analysis=analyze_command("ls"),
+                executable_verified=True,
+            )
+        )
+        self.assertIsNone(evaluate_t1("ls", []))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer needs a small deterministic policy layer before any model-backed command review. Narrow read-only commands should be admitted locally, clearly destructive commands should be rejected locally, and user rules need a strict deny-first precedence without allowing them to override built-in safety denials.

This PR is the first half of the Policy work tracked in [sii-system/tasks#115](https://github.com/sii-system/tasks/issues/115). It intentionally contains no Policy Agent, writable-root routing, command execution, or verification behavior.

## 2. Summary of the change 

- Add a dedicated `harbor_fixer.policy` package.
- Add built-in T1 read-only allow rules and narrow destructive deny rules.
- Add strict user prefix/exact allow and deny rule loading.
- Normalize shell segments, wrappers, nested shells, substitutions, and redirections before rule evaluation.
- Expose `evaluate_t1()`, which returns a deterministic decision or `None` for later policy tiers.
- Add compact tests for built-in rules, nested destructive commands, output-producing commands, and deny-first user-rule precedence.

## 3. Other details

This PR is independently testable and is the required base for the follow-up T2/T3 Policy Agent PR.

Validation:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_harbor_fixer*.py'` — 19 tests passed.
- Ruff 0.16.0 lint and format checks — passed.
- `compileall` and `git diff --check` — passed.
