### PR TITLE
feat(harbor): add fixer policy agents

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -275,7 +275,14 @@ control the benchmark run. Before using the default analyzer path, configure
 `HARBOR_ANALYZER_MODEL` overrides. If no analyzer model gateway should be used
 for a run, set `HARBOR_ANALYZER_ENABLED=0`.
 
-## Harbor Fixer: Plan Generation
+## Harbor Fixer
+
+Harbor Fixer consumes Analyzer artifacts in stages. Plan Generation proposes
+actions but does not execute them; Execution Policy independently decides
+whether each proposed action may proceed. Later execution and verification
+stages consume these artifacts without weakening the preceding boundary.
+
+### Stage 1: Planning Context and Plan Generation
 
 `scripts/fixer.py` reads Analyzer output artifacts and generates a validated
 `fix-plan-latest.json`. From `analyzer-artifacts-latest.json`, Fixer selects
@@ -381,6 +388,53 @@ immediately before an atomic write.
 Commands that invoke a shell or Python to modify files remain command actions
 and must be assessed by the policy agent instead of inheriting `file_edit`
 approval.
+
+### Stage 2: Execution Policy
+
+`harbor_fixer.policy` independently evaluates a complete Fix Plan before an
+executor consumes it. T1 applies deny-first rules to an unambiguous executable,
+but grants allow only to exact structured argv from a narrow read-only list or
+an explicit user rule. Docker, Git, find, execution wrappers, and explicit
+shell or interpreter payloads are left to an isolated Policy Agent. T2 handles
+only `file_edit` actions whose literal target is proven to remain inside an
+explicitly user-authorized writable root. The default authorized-root list is
+empty: the workspace and repository source are not implicitly writable. T3
+handles all remaining actions.
+
+The standalone Policy API accepts any number of authorized roots:
+
+```python
+from pathlib import Path
+
+from harbor_fixer.policy import run_policy_preflight
+
+decision = run_policy_preflight(
+    fix_plan,
+    workspace_root=Path("/path/to/workspace"),
+    output_dir=Path("/path/to/fixer-output/policy"),
+    invoker=policy_invoker,
+    writable_roots=[
+        Path("/path/to/authorized/benchmark-config"),
+        Path("/path/to/authorized/dockerfiles"),
+    ],
+)
+```
+
+Omit `writable_roots` (or pass an empty list) to disable T2 routing. Supplying a
+root authorizes only Policy evaluation at T2; it does not itself approve or
+execute the action. `workspace_root` supplies path-resolution context only and
+never grants write permission. The T3 agent must deny direct, path-addressed
+host writes that cannot be proven to stay within the explicit roots. Internal
+Docker, package-manager, and service-manager state changes remain eligible for
+T3 evaluation, but explicit host writes, copies, or mounts still use the root
+boundary.
+
+The Policy Agent reuses the Fixer Pi invocation contract without tools. Invalid
+output, invocation failure, configuration errors, or any denied action fail
+closed. The complete decision is atomically written to
+`execution-policy-decision.json`, together with the exact Fix Plan and per-action
+SHA-256 bindings. Policy is admission and audit, not an OS sandbox, and does
+not execute actions.
 
 ## More Details
 

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -45,6 +45,7 @@ Agents/utils/common/Harbor/
     │   ├── artifact_io.py      # JSON, JSONL, and text artifact I/O
     │   ├── plan_generation.py  # Task summary and plan generation flow
     │   ├── planning_context/   # Runtime inventory and workspace evidence
+    │   ├── policy/             # T1 rules, path routing, and T2/T3 Agent policy
     │   ├── prompts.py          # Task and plan agent contracts
     │   └── validation.py       # Analyzer, task-summary, and Fix Plan validation
     ├── online_rule_analyzer.py # Optional console-only online analysis
@@ -59,22 +60,6 @@ in the environment as `HARBOR_ANALYZER_*` variables.
 JSON-event validation, final JSON extraction, and provenance shared by Harbor
 Pi callers. Analyzer-specific tool access, path gating, prompts, artifact
 locations, and error compatibility remain in `harbor_analyzer/pi.py`.
-
-## Harbor Fixer Plan Generation
-
-The Fixer foundation validates Analyzer handoff artifacts and builds a bounded,
-redacted planning context without invoking an agent. It records runtime
-inventory and selected workspace evidence for later plan generation. Analyzer
-inputs are selected through `analyzer-artifacts-latest.json`; Fixer reads the
-current env/infra and evidence snapshot for every selected handover without
-depending on the deprecated flat latest-report files.
-
-Plan generation is independently usable and produces
-`target-environment.json`, `target-context.json`, `main-agent-input.json`, and
-`fix-plan-latest.json`. It performs bounded deterministic inspection before
-dispatching isolated no-tool Pi agents. Tests are split between
-`test_harbor_fixer_plan.py` and `test_harbor_fixer_runtime_context.py`, with
-shared fixtures in the non-discovered `fixer_test_support.py`.
 
 ## Path Resolution
 

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/__init__.py
@@ -1,12 +1,16 @@
 """Harbor Fixer execution policy interfaces."""
 
 from ..command_analysis import CommandAnalysis, analyze_command
+from .paths import analyze_paths
+from .preflight import run_policy_preflight
 from .rules import PrefixRule, evaluate_t1, load_user_rules
 
 __all__ = [
     "CommandAnalysis",
     "PrefixRule",
     "analyze_command",
+    "analyze_paths",
     "evaluate_t1",
     "load_user_rules",
+    "run_policy_preflight",
 ]

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/agent.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/agent.py
@@ -1,0 +1,120 @@
+"""Isolated T2 and T3 Policy Agent evaluation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..agent_invocation import AgentInvoker
+from ..prompts import build_validation_retry_prompt
+from ..validation import (
+    ValidationError,
+    parse_strict_json_object,
+    require_enum,
+    require_string,
+)
+from .prompts import T2_POLICY_AGENT_PROMPT, T3_POLICY_AGENT_PROMPT
+
+POLICY_DECISIONS = {"allow", "deny"}
+RISK_LEVELS = {"low", "medium", "high"}
+
+
+def _validate_decision(
+    payload: dict[str, Any],
+    *,
+    tier: str,
+    plan_id: str,
+    action_id: str,
+) -> None:
+    expected_fields = {
+        "schema_version",
+        "kind",
+        "tier",
+        "plan_id",
+        "action_id",
+        "decision",
+        "risk_level",
+        "reason_code",
+        "reason",
+    }
+    if set(payload) != expected_fields:
+        raise ValidationError("policy agent decision fields do not match contract")
+    if payload.get("schema_version") != 1:
+        raise ValidationError("policy agent decision schema_version must be 1")
+    if payload.get("kind") != "harbor_fixer_policy_agent_decision":
+        raise ValidationError("policy agent decision kind is invalid")
+    if payload.get("tier") != tier:
+        raise ValidationError("policy agent decision tier does not match input")
+    if payload.get("plan_id") != plan_id or payload.get("action_id") != action_id:
+        raise ValidationError("policy agent decision identity does not match input")
+    require_enum(payload.get("decision"), "decision", POLICY_DECISIONS)
+    require_enum(payload.get("risk_level"), "risk_level", RISK_LEVELS)
+    reason_code = require_string(payload.get("reason_code"), "reason_code")
+    if re.fullmatch(r"[a-z][a-z0-9_]*", reason_code) is None:
+        raise ValidationError("reason_code must be lower snake_case")
+    require_string(payload.get("reason"), "reason")
+
+
+def evaluate_agent(
+    invoker: AgentInvoker | None,
+    policy_input: dict[str, Any],
+) -> dict[str, Any]:
+    """Return an Agent verdict or a fail-closed fallback decision."""
+
+    tier = policy_input["tier"]
+    plan_id = policy_input["plan_id"]
+    action_id = policy_input["action"]["action_id"]
+    base_prompt = T2_POLICY_AGENT_PROMPT if tier == "T2" else T3_POLICY_AGENT_PROMPT
+    if invoker is None:
+        return {
+            "tier": tier,
+            "decision": "deny",
+            "risk_level": "high",
+            "source": "policy_agent_fallback",
+            "rule_id": "",
+            "reason_code": "policy_agent_unavailable",
+            "reason": "policy agent is required for actions not resolved by T1",
+        }
+    prompt = base_prompt
+    previous_output = ""
+    for attempt in (1, 2):
+        try:
+            raw = invoker.invoke(
+                prompt,
+                policy_input,
+                attempt=attempt,
+                label=f"policy-{tier.lower()}-{plan_id}-{action_id}",
+            )
+            previous_output = raw
+            decision = parse_strict_json_object(raw)
+            _validate_decision(
+                decision,
+                tier=tier,
+                plan_id=plan_id,
+                action_id=action_id,
+            )
+            return {
+                "tier": tier,
+                "decision": decision["decision"],
+                "risk_level": decision["risk_level"],
+                "source": "policy_agent",
+                "rule_id": "",
+                "reason_code": decision["reason_code"],
+                "reason": decision["reason"],
+            }
+        except Exception as exc:  # noqa: BLE001 - policy errors must fail closed
+            last_error = f"{exc.__class__.__name__}: {exc}"
+            prompt = build_validation_retry_prompt(
+                base_prompt=base_prompt,
+                previous_output=previous_output,
+                validation_error=last_error,
+            )
+    return {
+        "tier": tier,
+        "decision": "deny",
+        "risk_level": "high",
+        "source": "policy_agent_fallback",
+        "rule_id": "",
+        "reason_code": "policy_agent_failed_closed",
+        "reason": last_error,
+    }

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/paths.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/paths.py
@@ -1,0 +1,57 @@
+"""Literal file-edit path analysis for Policy Agent routing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def analyze_paths(
+    action: dict[str, Any],
+    cwd: Path,
+    writable_roots: list[Path],
+    *,
+    path_resolution_stable: bool = True,
+) -> dict[str, Any]:
+    """Route only a stable, inside-root file_edit to T2."""
+
+    if action.get("action_type") != "file_edit":
+        return {
+            "classification": "not_file_edit",
+            "write_targets": [],
+            "analysis_complete": False,
+            "path_resolution_stable": path_resolution_stable,
+            "reason": "command actions require command policy evaluation",
+        }
+
+    raw = action.get("path")
+    if not isinstance(raw, str) or not raw or "\x00" in raw:
+        return {
+            "classification": "unknown_or_outside",
+            "write_targets": [],
+            "analysis_complete": False,
+            "path_resolution_stable": path_resolution_stable,
+            "reason": "file_edit path is invalid",
+        }
+    path = Path(raw)
+    resolved = (path if path.is_absolute() else cwd / path).resolve()
+    inside = any(resolved.is_relative_to(root) for root in writable_roots)
+    target = {
+        "raw": raw,
+        "resolved": str(resolved),
+        "inside_writable_roots": inside,
+    }
+    contained = path_resolution_stable and inside
+    return {
+        "classification": (
+            "inside_writable_roots" if contained else "unknown_or_outside"
+        ),
+        "write_targets": [target],
+        "analysis_complete": True,
+        "path_resolution_stable": path_resolution_stable,
+        "reason": (
+            "stable file_edit target resolves inside writable roots"
+            if contained
+            else "file_edit target is outside the authorized boundary or unstable"
+        ),
+    }

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/preflight.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/preflight.py
@@ -1,0 +1,237 @@
+"""Execution-policy routing and artifact publication."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+from ..agent_invocation import AgentInvoker
+from ..artifact_io import write_json_atomic
+from ..command_analysis import CommandAnalysis, analyze_command
+from ..validation import ValidationError
+from .agent import evaluate_agent
+from .paths import analyze_paths
+from .rules import evaluate_t1, load_user_rules
+
+POLICY_VERSION = "fixer-policy-v2"
+TRUSTED_T1_EXECUTABLE_DIRS = {
+    Path("/bin").resolve(),
+    Path("/usr/bin").resolve(),
+    Path("/usr/sbin").resolve(),
+}
+
+
+def _json_sha256(value: Any) -> str:
+    serialized = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _resolved_cwd(action: dict[str, Any], workspace_root: Path) -> Path:
+    value = Path(action["cwd"])
+    return (value if value.is_absolute() else workspace_root / value).resolve()
+
+
+def _resolved_executable(executable_token: str, cwd: Path) -> str:
+    if not executable_token:
+        return ""
+    if "/" in executable_token:
+        path = Path(executable_token)
+        return str((path if path.is_absolute() else cwd / path).resolve())
+    match = shutil.which(executable_token)
+    return str(Path(match).resolve()) if match else ""
+
+
+def _is_trusted_t1_executable(resolved_executable: str) -> bool:
+    return bool(resolved_executable) and Path(resolved_executable).parent in (
+        TRUSTED_T1_EXECUTABLE_DIRS
+    )
+
+
+def _command_analysis(action: dict[str, Any]) -> CommandAnalysis | None:
+    return analyze_command(action) if action.get("action_type") == "command" else None
+
+
+def _configuration_denials(
+    fix_plan: dict[str, Any],
+    workspace_root: Path,
+    error: Exception,
+) -> list[dict[str, Any]]:
+    decisions = []
+    for plan in fix_plan["plans"]:
+        for action in plan["actions"]:
+            analysis = _command_analysis(action)
+            decisions.append(
+                {
+                    "plan_id": plan["plan_id"],
+                    "action_id": action["action_id"],
+                    "action_sha256": _json_sha256(action),
+                    "tier": "T1",
+                    "decision": "deny",
+                    "risk_level": "high",
+                    "source": "policy_configuration",
+                    "rule_id": "",
+                    "reason_code": "policy_configuration_error",
+                    "reason": f"{error.__class__.__name__}: {error}",
+                    "path_analysis": {},
+                    "command_analysis": analysis.as_dict() if analysis else None,
+                    "resolved_executable": "",
+                    "resolved_cwd": str(_resolved_cwd(action, workspace_root)),
+                }
+            )
+    return decisions
+
+
+def run_policy_preflight(
+    fix_plan: dict[str, Any],
+    workspace_root: Path,
+    output_dir: Path,
+    invoker: AgentInvoker | None,
+    *,
+    user_rules_path: Path | None = None,
+    writable_roots: list[Path] | None = None,
+) -> dict[str, Any]:
+    """Evaluate a complete Fix Plan without executing its actions."""
+
+    resolved_roots = list(
+        dict.fromkeys(root.resolve() for root in (writable_roots or []))
+    )
+    fix_plan_sha256 = _json_sha256(fix_plan)
+    try:
+        user_rules, rules_source = load_user_rules(user_rules_path)
+    except (OSError, ValidationError) as exc:
+        decisions = _configuration_denials(fix_plan, workspace_root, exc)
+        rules_source = str(user_rules_path or "")
+        serialized_rules: list[dict[str, Any]] = []
+    else:
+        serialized_rules = [
+            {
+                "rule_id": rule.rule_id,
+                "pattern": list(rule.pattern),
+                "match": rule.match,
+                "decision": rule.decision,
+            }
+            for rule in user_rules
+        ]
+        decisions = []
+        path_resolution_stable = True
+        for plan in fix_plan["plans"]:
+            for action in plan["actions"]:
+                action_sha256 = _json_sha256(action)
+                cwd = _resolved_cwd(action, workspace_root)
+                path_analysis = analyze_paths(
+                    action,
+                    cwd,
+                    resolved_roots,
+                    path_resolution_stable=path_resolution_stable,
+                )
+                command_analysis = _command_analysis(action)
+                resolved_executable = (
+                    _resolved_executable(command_analysis.executable_token, cwd)
+                    if command_analysis is not None
+                    and command_analysis.classification == "static_argv"
+                    else ""
+                )
+                decision = None
+                if command_analysis is not None:
+                    if command_analysis.classification == "invalid":
+                        decision = {
+                            "tier": "T1",
+                            "decision": "deny",
+                            "risk_level": "high",
+                            "source": "builtin_rule",
+                            "rule_id": "invalid_command_action",
+                            "reason_code": "invalid_command_action",
+                            "reason": "command action does not contain a valid argv",
+                        }
+                    else:
+                        decision = evaluate_t1(
+                            action,
+                            user_rules,
+                            analysis=command_analysis,
+                            executable_verified=_is_trusted_t1_executable(
+                                resolved_executable
+                            ),
+                        )
+                if decision is None:
+                    tier = (
+                        "T2"
+                        if path_analysis["classification"]
+                        == "inside_writable_roots"
+                        else "T3"
+                    )
+                    decision = evaluate_agent(
+                        invoker,
+                        {
+                            "schema_version": 2,
+                            "kind": "harbor_fixer_policy_agent_input",
+                            "policy_version": POLICY_VERSION,
+                            "tier": tier,
+                            "plan_id": plan["plan_id"],
+                            "action": action,
+                            "fix_plan_sha256": fix_plan_sha256,
+                            "action_sha256": action_sha256,
+                            "plan_context": {
+                                "fix_scope": plan["fix_scope"],
+                                "analyzer_scope_comparison": plan[
+                                    "analyzer_scope_comparison"
+                                ],
+                                "task_list": plan["task_list"],
+                                "fix_reason": plan["fix_reason"],
+                            },
+                            "workspace_root": str(workspace_root),
+                            "writable_roots": [str(root) for root in resolved_roots],
+                            "resolved_cwd": str(cwd),
+                            "command_analysis": (
+                                command_analysis.as_dict()
+                                if command_analysis is not None
+                                else None
+                            ),
+                            "resolved_executable": resolved_executable,
+                            "user_rules": serialized_rules,
+                            "path_analysis": path_analysis,
+                        },
+                    )
+                decisions.append(
+                    {
+                        "plan_id": plan["plan_id"],
+                        "action_id": action["action_id"],
+                        "action_sha256": action_sha256,
+                        **decision,
+                        "path_analysis": path_analysis,
+                        "command_analysis": (
+                            command_analysis.as_dict()
+                            if command_analysis is not None
+                            else None
+                        ),
+                        "resolved_cwd": str(cwd),
+                        "resolved_executable": resolved_executable,
+                    }
+                )
+                if decision["tier"] == "T3":
+                    path_resolution_stable = False
+    result = {
+        "schema_version": 2,
+        "kind": "harbor_fixer_execution_policy_decision",
+        "policy_version": POLICY_VERSION,
+        "fix_plan_sha256": fix_plan_sha256,
+        "status": (
+            "allowed"
+            if all(decision["decision"] == "allow" for decision in decisions)
+            else "denied"
+        ),
+        "workspace_root": str(workspace_root.resolve()),
+        "writable_roots": [str(root) for root in resolved_roots],
+        "user_rules_path": rules_source,
+        "user_rules": serialized_rules,
+        "decisions": decisions,
+    }
+    write_json_atomic(output_dir / "execution-policy-decision.json", result)
+    return result

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/prompts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/prompts.py
@@ -1,0 +1,78 @@
+"""T2 and T3 Policy Agent prompts."""
+
+T2_POLICY_AGENT_PROMPT = """You are the Harbor Fixer T2 execution policy agent.
+
+Evaluate exactly one file_edit action whose literal target currently resolves inside an
+explicitly user-authorized writable root. T2 never receives command actions. Return JSON
+only and use only the supplied input.
+
+The action contract describes an exact replacement in one existing UTF-8 file. Confirm
+that its purpose, target, old_text, new_text, and expected_replacements are specific,
+necessary, and proportionate to repairing the supplied dependency, Docker, benchmark, or
+host-environment failure. Deny credential access, policy modification, unrelated
+persistence, source changes unrelated to the repair, or an edit whose effect is unclear.
+
+path_analysis is a routing fact, not permission by itself. T2 requires
+analysis_complete=true, path_resolution_stable=true, and classification equal to
+inside_writable_roots. The executor must still reject symlinks, re-resolve containment,
+verify the exact replacement count, and write atomically immediately before mutation.
+Treat user_rules as authoritative when applicable; an allow rule does not override these
+safety requirements.
+
+Return exactly:
+{
+  "schema_version": 1,
+  "kind": "harbor_fixer_policy_agent_decision",
+  "tier": "T2",
+  "plan_id": "<copy input.plan_id>",
+  "action_id": "<copy input.action.action_id>",
+  "decision": "allow | deny",
+  "risk_level": "low | medium | high",
+  "reason_code": "<stable snake_case code>",
+  "reason": "<concise evidence-based reason>"
+}
+"""
+
+T3_POLICY_AGENT_PROMPT = """You are the Harbor Fixer T3 execution policy agent.
+
+Evaluate exactly one action that was not resolved by T1 and was not admitted to T2. T3
+receives all unresolved command actions and file_edit actions whose target is outside an
+explicit writable root or whose path resolution is not stable. Return JSON only and use
+only the supplied input.
+
+For a command action, command_analysis.argv is copied directly from executable and
+arguments; no shell splitting or expansion is implied. An explicit shell or interpreter
+payload remains opaque, high-capability code. Inspect that payload and the original action
+instead of treating it as ordinary argv. resolved_executable records the executable
+selected during preflight. Treat user_rules as authoritative: deny an operation matching
+an explicit deny rule. An allow rule does not override this tier's safety requirements.
+
+The writable_roots list is the only authorization boundary for direct host-file writes;
+workspace_root is context only. Deny file_edit outside that boundary or when
+path_resolution_stable is false. A command that uses Python, a shell, or another utility
+to modify host files may be allowed only when every target and effect are explicit,
+necessary, and confined to writable_roots; otherwise deny it. Writes internal to Docker,
+package managers, or service managers are managed-system effects and may be evaluated
+normally. Explicit host paths used for copies, writes, or mounts still require the
+writable-root boundary.
+
+Harbor Fixer legitimately needs broad Docker and environment-repair capabilities. Allow
+such operations when their effects are specific, necessary, and proportionate. Deny
+generic filesystem deletion, credential access, policy modification, unrelated
+persistence, destructive host-wide cleanup, or obscured operations whose effects cannot
+be bounded from the input. Do not deny Docker access merely because it is powerful;
+evaluate the concrete executable and arguments.
+
+Return exactly:
+{
+  "schema_version": 1,
+  "kind": "harbor_fixer_policy_agent_decision",
+  "tier": "T3",
+  "plan_id": "<copy input.plan_id>",
+  "action_id": "<copy input.action.action_id>",
+  "decision": "allow | deny",
+  "risk_level": "low | medium | high",
+  "reason_code": "<stable snake_case code>",
+  "reason": "<concise evidence-based reason>"
+}
+"""

--- a/Agents/utils/common/Harbor/tests/fixer_test_support.py
+++ b/Agents/utils/common/Harbor/tests/fixer_test_support.py
@@ -186,6 +186,27 @@ class SequenceInvoker:
         return self.outputs[index]
 
 
+class PolicyInvoker:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, dict, int, str]] = []
+
+    def invoke(self, prompt: str, payload: dict, *, attempt: int, label: str) -> str:
+        self.records.append((prompt, payload, attempt, label))
+        return json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "harbor_fixer_policy_agent_decision",
+                "tier": payload["tier"],
+                "plan_id": payload["plan_id"],
+                "action_id": payload["action"]["action_id"],
+                "decision": "allow",
+                "risk_level": "medium",
+                "reason_code": "fixture_allow",
+                "reason": "Fixture policy decision: allow.",
+            }
+        )
+
+
 class SummaryInvoker:
     def invoke(self, prompt: str, payload: dict, *, attempt: int, label: str) -> str:
         return json.dumps(task_summary_for(payload))

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy.py
@@ -1,0 +1,178 @@
+"""Tests for Harbor Fixer Policy Agent routing."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+if str(TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(TEST_DIR))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from fixer_test_support import (
+    FixerTestCase,
+    PolicyInvoker,
+    SequenceInvoker,
+    make_fix_plan,
+)
+from harbor_fixer.policy import run_policy_preflight
+
+
+def _command(template: dict, action_id: str, executable: str, *arguments: str) -> dict:
+    return {
+        **template,
+        "action_id": action_id,
+        "executable": executable,
+        "arguments": list(arguments),
+    }
+
+
+def _file_edit(action_id: str, cwd: str, path: str) -> dict:
+    return {
+        "action_id": action_id,
+        "action_type": "file_edit",
+        "cwd": cwd,
+        "path": path,
+        "edit": {
+            "kind": "replace_text",
+            "old_text": "false",
+            "new_text": "true",
+            "expected_replacements": 1,
+        },
+        "purpose": "Enable the fixture.",
+        "expected_effect": "The fixture is enabled.",
+    }
+
+
+class HarborFixerPolicyTest(FixerTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.workspace = self.root / "workspace"
+        self.workspace.mkdir()
+
+    def _run(
+        self,
+        plan: dict,
+        invoker: PolicyInvoker | SequenceInvoker | None,
+        *,
+        user_rules_path: Path | None = None,
+        writable_roots: list[Path] | None = None,
+    ) -> dict:
+        return run_policy_preflight(
+            plan,
+            self.workspace,
+            self.root / "policy-output",
+            invoker,
+            user_rules_path=user_rules_path,
+            writable_roots=writable_roots,
+        )
+
+    def test_routes_file_edits_to_t2_and_commands_to_t3(self) -> None:
+        allowed_root = self.root / "config"
+        allowed_root.mkdir()
+        plan = make_fix_plan()
+        template = plan["plans"][0]["actions"][0]
+        plan["plans"][0]["actions"] = [
+            _file_edit("authorized-edit", ".", str(allowed_root / "daemon.json")),
+            _file_edit("workspace-edit", ".", "workspace.json"),
+            _command(template, "docker-build", "docker", "build", "-t", "fixture", "."),
+            _command(template, "explicit-shell", "bash", "-c", "echo ok && docker ps"),
+        ]
+        invoker = PolicyInvoker()
+
+        result = self._run(plan, invoker, writable_roots=[allowed_root])
+
+        self.assertEqual(
+            [decision["tier"] for decision in result["decisions"]],
+            ["T2", "T3", "T3", "T3"],
+        )
+        self.assertEqual(len(result["fix_plan_sha256"]), 64)
+        self.assertEqual(len(result["decisions"][0]["action_sha256"]), 64)
+        self.assertIsNone(result["decisions"][0]["command_analysis"])
+        shell_input = invoker.records[-1][1]
+        self.assertEqual(shell_input["action"]["action_id"], "explicit-shell")
+        self.assertTrue(shell_input["command_analysis"]["has_embedded_script"])
+        self.assertEqual(
+            shell_input["action_sha256"],
+            shell_input["command_analysis"]["action_sha256"],
+        )
+
+        previous_plan_digest = result["fix_plan_sha256"]
+        previous_digest = result["decisions"][0]["action_sha256"]
+        plan["plans"][0]["actions"][0]["edit"]["new_text"] = "enabled"
+        changed = self._run(plan, invoker, writable_roots=[allowed_root])
+        self.assertNotEqual(changed["fix_plan_sha256"], previous_plan_digest)
+        self.assertNotEqual(changed["decisions"][0]["action_sha256"], previous_digest)
+
+    def test_t3_action_makes_later_file_edit_path_unstable(self) -> None:
+        allowed_root = self.root / "config"
+        allowed_root.mkdir()
+        plan = make_fix_plan()
+        template = plan["plans"][0]["actions"][0]
+        first_plan = plan["plans"][0]
+        second_plan = json.loads(json.dumps(first_plan))
+        first_plan["actions"] = [
+            _command(template, "link-change", "ln", "-s", "/etc", str(allowed_root / "link")),
+        ]
+        second_plan["plan_id"] = "fix-002"
+        second_plan["task_list"][0]["task_index"] = "2"
+        second_plan["task_list"][0]["task_name"] = "task-2"
+        second_plan["verification_hint"]["target_task_indexes"] = ["2"]
+        second_plan["actions"] = [
+            _file_edit("later-edit", ".", str(allowed_root / "link/config"))
+        ]
+        plan["plans"] = [first_plan, second_plan]
+        result = self._run(plan, PolicyInvoker(), writable_roots=[allowed_root])
+
+        self.assertEqual([item["tier"] for item in result["decisions"]], ["T3", "T3"])
+        self.assertFalse(
+            result["decisions"][1]["path_analysis"]["path_resolution_stable"]
+        )
+
+    def test_t1_requires_trusted_executable_and_invalid_argv_is_denied(self) -> None:
+        plan = make_fix_plan()
+        action = plan["plans"][0]["actions"][0]
+        action.update({"executable": "ls", "arguments": []})
+        with mock.patch(
+            "harbor_fixer.policy.preflight.shutil.which", return_value="/tmp/ls"
+        ):
+            result = self._run(plan, PolicyInvoker())
+        self.assertEqual(result["decisions"][0]["tier"], "T3")
+
+        action["executable"] = "invalid executable"
+        result = self._run(plan, None)
+        self.assertEqual(
+            result["decisions"][0]["reason_code"], "invalid_command_action"
+        )
+
+    def test_agent_and_configuration_fail_closed(self) -> None:
+        plan = make_fix_plan()
+        plan["plans"][0]["actions"][0].update(
+            {"executable": "docker", "arguments": ["build", "."]}
+        )
+        result = self._run(
+            plan,
+            SequenceInvoker(["not-json", json.dumps({"decision": "allow"})]),
+        )
+        self.assertEqual(
+            result["decisions"][0]["reason_code"], "policy_agent_failed_closed"
+        )
+
+        result = self._run(
+            make_fix_plan(),
+            None,
+            user_rules_path=self.root / "missing-rules.json",
+        )
+        self.assertEqual(
+            result["decisions"][0]["reason_code"], "policy_configuration_error"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Commands that deterministic T1 rules cannot decide still need a fail-closed admission boundary before execution. Harbor Fixer requires legitimate Docker, dependency, and service-management capabilities, while direct host-file writes must remain constrained by explicit user authorization.

This PR is the second half of the Policy work tracked in [sii-system/tasks#115](https://github.com/sii-system/tasks/issues/115). It depends on the deterministic T1 Policy Rules PR.

## 2. Summary of the change 

- Add direct host-path analysis and symlink-aware resolution.
- Route bounded writes inside explicitly supplied writable roots to T2; roots may be repeated and default to an empty list.
- Route all other commands unresolved by T1 to T3 without treating `workspace_root` as write authorization.
- Distinguish direct host-path writes from Docker, package-manager, and service-manager internal state effects in the T3 contract.
- Add isolated, tool-disabled Policy Agent evaluation with strict schema and identity validation, two validation attempts, and fail-closed fallback decisions.
- Atomically publish `execution-policy-decision.json` for downstream execution and reporting.
- Consolidate Harbor Fixer documentation in README by stage and keep STRUCT limited to directory structure.
- Add compact routing, retry, configuration, explicit-root, and symlink-boundary tests.

## 3. Other details

Dependency: [#81](https://github.com/sii-system/agent-fleet/pull/81)

The branch is stacked on the Rules commit. Until the dependency merges, GitHub's comparison against `main` may temporarily show both commits; after the dependency lands, this PR can be rebased to expose only the T2/T3 Agent commit.

This PR performs admission and audit only. It does not execute Fix Plan commands.

Validation:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_harbor_fixer*.py'` — 22 tests passed.
- Ruff 0.16.0 lint and format checks — passed.
- `compileall` and `git diff --check` — passed.
