### PR TITLE
fix(harbor): parenthesize summary message

### DIFF
--- a/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
+++ b/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
@@ -384,9 +384,11 @@ def _render_markdown(
     if coverage and 0 < coverage["analyzed"] < coverage["expected"]:
         lines.extend(
             [
-                "Analyzer results are incomplete: analysis is available for "
-                f"{coverage['analyzed']} of {coverage['expected']} final "
-                "failed/unknown/not-complete task(s).",
+                (
+                    "Analyzer results are incomplete: analysis is available for "
+                    f"{coverage['analyzed']} of {coverage['expected']} final "
+                    "failed/unknown/not-complete task(s)."
+                ),
                 "",
             ]
         )


### PR DESCRIPTION
## 1. Why the change?

The benchmark summary change merged in #76 introduced an `ISC004` Ruff violation in `write_benchmark_summary.py`: a list item implicitly concatenates plain strings and an f-string without explicit parentheses.

This causes the repository Ruff lint check to fail even though the rendered summary text is correct.

## 2. Summary of the change 

- Wrap the multi-line analyzer coverage message in parentheses.
- Preserve the generated text and runtime behavior exactly.

## 3. Other details

Validation:

- Ruff 0.16.0 check for `write_benchmark_summary.py` — passed.
- `python3 -m unittest Agents/utils/common/Harbor/tests/test_benchmark_summary.py` — 8 tests passed.
- `compileall` and `git diff --check` — passed.

The file has other pre-existing Ruff formatter suggestions unrelated to `ISC004`; they are intentionally left out to keep this follow-up minimal.
