### PR TITLE
Refactor Harbor env helpers into Python

### DIFF
--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -10,7 +10,7 @@ keeps the shared entry point and Harbor runner wrappers.
 Agents/utils/common/Harbor/
 ├── start.sh                    # Main zellij launcher
 ├── env.sh                      # Path resolution and runtime defaults
-├── env.py                      # JSON builders invoked by env.sh
+├── env.py                      # JSON and data/cache helpers invoked by env.sh
 ├── gen_harbor_zellij_layout.sh # zellij layout generator
 ├── monitor_harbor.sh           # Run monitor pane
 ├── run_harbor_worker.sh        # Worker loop for one zellij pane

--- a/Agents/utils/common/Harbor/env.py
+++ b/Agents/utils/common/Harbor/env.py
@@ -149,7 +149,7 @@ def url_is_reachable(url: str) -> None:
     try:
         with urllib.request.urlopen(url, timeout=2) as response:
             raise SystemExit(0 if response.status < 400 else 1)
-    except Exception:
+    except Exception:  # noqa: BLE001 - any failed probe is not reachable.
         raise SystemExit(1) from None
 
 
@@ -158,7 +158,7 @@ def manifest_url_ready(url: str) -> None:
         with urllib.request.urlopen(url, timeout=2) as response:
             content = response.read(1024 * 64).decode("utf-8", "replace")
         raise SystemExit(0 if "cache_schema=3\n" in content else 1)
-    except Exception:
+    except Exception:  # noqa: BLE001 - any failed probe is not ready.
         raise SystemExit(1) from None
 
 

--- a/Agents/utils/common/Harbor/env.py
+++ b/Agents/utils/common/Harbor/env.py
@@ -2,7 +2,11 @@ import argparse
 import json
 import math
 import os
+import sys
+import tarfile
+import urllib.request
 from collections.abc import Callable
+from pathlib import Path
 
 
 def parse_finite_float(name: str, value: str) -> float:
@@ -88,22 +92,121 @@ def build_opencode_config() -> dict[str, object]:
     return payload
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Build Harbor environment JSON")
-    parser.add_argument(
-        "command",
-        choices=("llm-kwargs", "model-info", "opencode-config"),
+def generate_task_file(dataset: Path, destination: Path) -> None:
+    tasks = []
+    for task_dir in dataset.iterdir():
+        if not task_dir.is_dir():
+            continue
+        instruction = task_dir / "instruction.md"
+        task_yaml = task_dir / "task.yaml"
+        if instruction.is_file():
+            try:
+                if instruction.read_text(errors="ignore").strip():
+                    tasks.append(task_dir.name)
+            except OSError:
+                continue
+        elif task_yaml.is_file():
+            tasks.append(task_dir.name)
+    destination.write_text("\n".join(sorted(tasks)) + ("\n" if tasks else ""))
+
+
+def filter_task_file(source: Path, destination: Path, raw_tasks: str) -> None:
+    requested = []
+    seen = set()
+    for part in raw_tasks.split(","):
+        task = part.strip()
+        if task and task not in seen:
+            requested.append(task)
+            seen.add(task)
+
+    available = {
+        line.strip()
+        for line in source.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+    missing = [task for task in requested if task not in available]
+    if missing:
+        print("[ERROR] unknown task(s): " + ", ".join(missing), file=sys.stderr)
+        raise SystemExit(2)
+
+    destination.write_text(
+        "\n".join(requested) + ("\n" if requested else ""),
+        encoding="utf-8",
     )
+
+
+def tar_file_ready(path: Path) -> None:
+    if not path.is_file():
+        raise SystemExit(1)
+    try:
+        with tarfile.open(path) as archive:
+            archive.getmembers()
+    except (EOFError, OSError, tarfile.TarError):
+        raise SystemExit(1) from None
+
+
+def url_is_reachable(url: str) -> None:
+    try:
+        with urllib.request.urlopen(url, timeout=2) as response:
+            raise SystemExit(0 if response.status < 400 else 1)
+    except Exception:
+        raise SystemExit(1) from None
+
+
+def manifest_url_ready(url: str) -> None:
+    try:
+        with urllib.request.urlopen(url, timeout=2) as response:
+            content = response.read(1024 * 64).decode("utf-8", "replace")
+        raise SystemExit(0 if "cache_schema=3\n" in content else 1)
+    except Exception:
+        raise SystemExit(1) from None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Harbor environment helpers")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("llm-kwargs", "model-info", "opencode-config"):
+        subparsers.add_parser(command)
+    generate_parser = subparsers.add_parser("generate-task-file")
+    generate_parser.add_argument("dataset", type=Path)
+    generate_parser.add_argument("destination", type=Path)
+    filter_parser = subparsers.add_parser("filter-task-file")
+    filter_parser.add_argument("source", type=Path)
+    filter_parser.add_argument("destination", type=Path)
+    filter_parser.add_argument("tasks")
+    tar_parser = subparsers.add_parser("tar-file-ready")
+    tar_parser.add_argument("path", type=Path)
+    url_parser = subparsers.add_parser("url-reachable")
+    url_parser.add_argument("url")
+    manifest_parser = subparsers.add_parser("manifest-url-ready")
+    manifest_parser.add_argument("url")
     return parser.parse_args()
 
 
 def main() -> None:
+    args = parse_args()
+    if args.command == "generate-task-file":
+        generate_task_file(args.dataset, args.destination)
+        return
+    if args.command == "filter-task-file":
+        filter_task_file(args.source, args.destination, args.tasks)
+        return
+    if args.command == "tar-file-ready":
+        tar_file_ready(args.path)
+        return
+    if args.command == "url-reachable":
+        url_is_reachable(args.url)
+        return
+    if args.command == "manifest-url-ready":
+        manifest_url_ready(args.url)
+        return
+
     builders: dict[str, Callable[[], dict[str, object]]] = {
         "llm-kwargs": build_llm_kwargs,
         "model-info": build_model_info,
         "opencode-config": build_opencode_config,
     }
-    payload = builders[parse_args().command]()
+    payload = builders[args.command]()
     print(json.dumps(payload, separators=(",", ":")))
 
 

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -720,63 +720,12 @@ harbor_generate_task_file() {
   # Harbor local datasets are one task per top-level directory.  SWE-smith uses
   # instruction.md, while SETA/Terminal-Bench tasks use task.yaml.  Keep this
   # scan format-neutral so the same zellij runner can handle both datasets.
-  python3 - "$DATASET_PATH" "$destination" <<'PY'
-import sys
-from pathlib import Path
-
-dataset = Path(sys.argv[1])
-task_file = Path(sys.argv[2])
-tasks = []
-for task_dir in dataset.iterdir():
-    if not task_dir.is_dir():
-        continue
-    instruction = task_dir / "instruction.md"
-    task_yaml = task_dir / "task.yaml"
-    if instruction.is_file():
-        try:
-            if instruction.read_text(errors="ignore").strip():
-                tasks.append(task_dir.name)
-        except OSError:
-            continue
-    elif task_yaml.is_file():
-        tasks.append(task_dir.name)
-task_file.write_text("\n".join(sorted(tasks)) + ("\n" if tasks else ""))
-PY
+  python3 "$SCRIPT_DIR/env.py" generate-task-file "$DATASET_PATH" "$destination"
 }
 
 harbor_filter_task_file() {
   local source_file="$1" destination="$2"
-  python3 - "$source_file" "$destination" "$FLEET_TASKS" <<'PY'
-import sys
-from pathlib import Path
-
-source = Path(sys.argv[1])
-destination = Path(sys.argv[2])
-raw = sys.argv[3]
-
-requested = []
-seen = set()
-for part in raw.split(","):
-    task = part.strip()
-    if task and task not in seen:
-        requested.append(task)
-        seen.add(task)
-
-available = {
-    line.strip()
-    for line in source.read_text(encoding="utf-8").splitlines()
-    if line.strip()
-}
-missing = [task for task in requested if task not in available]
-if missing:
-    print("[ERROR] unknown task(s): " + ", ".join(missing), file=sys.stderr)
-    raise SystemExit(2)
-
-destination.write_text(
-    "\n".join(requested) + ("\n" if requested else ""),
-    encoding="utf-8",
-)
-PY
+  python3 "$SCRIPT_DIR/env.py" filter-task-file "$source_file" "$destination" "$FLEET_TASKS"
 }
 
 harbor_validate_local_task_selection() {
@@ -1094,29 +1043,12 @@ harbor_ensure_local_wheels_server() {
 
 harbor_url_is_reachable() {
   local url="$1"
-  TARGET_URL="$url" python3 - <<'PY'
-import os
-import urllib.request
-try:
-    with urllib.request.urlopen(os.environ["TARGET_URL"], timeout=2) as response:
-        raise SystemExit(0 if response.status < 400 else 1)
-except Exception:
-    raise SystemExit(1)
-PY
+  python3 "$SCRIPT_DIR/env.py" url-reachable "$url"
 }
 
 harbor_manifest_url_ready() {
   local url="$1"
-  TARGET_URL="$url" python3 - <<'PY'
-import os
-import urllib.request
-try:
-    with urllib.request.urlopen(os.environ["TARGET_URL"], timeout=2) as response:
-        content = response.read(1024 * 64).decode("utf-8", "replace")
-    raise SystemExit(0 if "cache_schema=3\n" in content else 1)
-except Exception:
-    raise SystemExit(1)
-PY
+  python3 "$SCRIPT_DIR/env.py" manifest-url-ready "$url"
 }
 
 harbor_gzip_file_ready() {
@@ -1126,14 +1058,7 @@ harbor_gzip_file_ready() {
 
 harbor_tar_file_ready() {
   local path="$1"
-  [[ -f "$path" ]] || return 1
-  python3 - "$path" <<'PY' >/dev/null 2>&1
-import sys
-import tarfile
-
-with tarfile.open(sys.argv[1]) as archive:
-    archive.getmembers()
-PY
+  python3 "$SCRIPT_DIR/env.py" tar-file-ready "$path" >/dev/null 2>&1
 }
 
 harbor_local_cache_ready() {

--- a/Agents/utils/common/Harbor/tests/test_env_helpers.py
+++ b/Agents/utils/common/Harbor/tests/test_env_helpers.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import subprocess
+import tarfile
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+HARBOR_DIR = Path(__file__).parents[1]
+ENV_PY = HARBOR_DIR / "env.py"
+
+
+class _CacheHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        body = b"cache_schema=3\n" if self.path == "/manifest.txt" else b"ready\n"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+class HarborEnvHelperTests(unittest.TestCase):
+    def test_generate_task_file_lists_supported_tasks_in_sorted_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            dataset = root / "dataset"
+            output = root / "tasks.txt"
+            (dataset / "yaml-task").mkdir(parents=True)
+            (dataset / "yaml-task" / "task.yaml").write_text("version: 1\n")
+            (dataset / "text-task").mkdir()
+            (dataset / "text-task" / "instruction.md").write_text("Do the task.\n")
+            (dataset / "empty-task").mkdir()
+            (dataset / "empty-task" / "instruction.md").write_text("\n")
+            (dataset / "not-a-task").mkdir()
+            (dataset / "not-a-task" / "README.md").write_text("not a task\n")
+            (dataset / "not-a-directory").write_text("ignore\n")
+
+            result = subprocess.run(
+                ["python3", str(ENV_PY), "generate-task-file", str(dataset), str(output)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(output.read_text(), "text-task\nyaml-task\n")
+
+    def test_filter_task_file_preserves_requested_order_and_rejects_missing_tasks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source.txt"
+            output = root / "selected.txt"
+            source.write_text("task-a\ntask-b\ntask-c\n")
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(ENV_PY),
+                    "filter-task-file",
+                    str(source),
+                    str(output),
+                    "task-c, task-a, task-c",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(output.read_text(), "task-c\ntask-a\n")
+
+            missing = subprocess.run(
+                [
+                    "python3",
+                    str(ENV_PY),
+                    "filter-task-file",
+                    str(source),
+                    str(root / "missing.txt"),
+                    "missing-a,task-a,missing-b",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(missing.returncode, 2)
+            self.assertIn("unknown task(s): missing-a, missing-b", missing.stderr)
+            self.assertFalse((root / "missing.txt").exists())
+
+    def test_tar_file_ready_accepts_valid_archives_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            valid = root / "runtime.tar.xz"
+            invalid = root / "invalid.tar.xz"
+            with tarfile.open(valid, "w:xz") as archive:
+                archive.addfile(tarfile.TarInfo("runtime/bin/python"))
+            invalid.write_text("not a tar archive")
+
+            ready = subprocess.run(
+                ["python3", str(ENV_PY), "tar-file-ready", str(valid)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            not_ready = subprocess.run(
+                ["python3", str(ENV_PY), "tar-file-ready", str(invalid)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(ready.returncode, 0, ready.stderr)
+            self.assertNotEqual(not_ready.returncode, 0)
+
+    def test_url_helpers_check_reachability_and_manifest_schema(self) -> None:
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _CacheHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            base_url = f"http://127.0.0.1:{server.server_port}"
+            reachable = subprocess.run(
+                ["python3", str(ENV_PY), "url-reachable", f"{base_url}/agent.tgz"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            manifest = subprocess.run(
+                ["python3", str(ENV_PY), "manifest-url-ready", f"{base_url}/manifest.txt"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            invalid_manifest = subprocess.run(
+                ["python3", str(ENV_PY), "manifest-url-ready", f"{base_url}/agent.tgz"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+        self.assertEqual(reachable.returncode, 0, reachable.stderr)
+        self.assertEqual(manifest.returncode, 0, manifest.stderr)
+        self.assertNotEqual(invalid_manifest.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_env_helpers.py
+++ b/Agents/utils/common/Harbor/tests/test_env_helpers.py
@@ -12,6 +12,15 @@ HARBOR_DIR = Path(__file__).parents[1]
 ENV_PY = HARBOR_DIR / "env.py"
 
 
+def run_env_helper(*args: str | Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(ENV_PY), *(str(arg) for arg in args)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 class _CacheHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         body = b"cache_schema=3\n" if self.path == "/manifest.txt" else b"ready\n"
@@ -40,12 +49,7 @@ class HarborEnvHelperTests(unittest.TestCase):
             (dataset / "not-a-task" / "README.md").write_text("not a task\n")
             (dataset / "not-a-directory").write_text("ignore\n")
 
-            result = subprocess.run(
-                ["python3", str(ENV_PY), "generate-task-file", str(dataset), str(output)],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            result = run_env_helper("generate-task-file", dataset, output)
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(output.read_text(), "text-task\nyaml-task\n")
@@ -57,35 +61,21 @@ class HarborEnvHelperTests(unittest.TestCase):
             output = root / "selected.txt"
             source.write_text("task-a\ntask-b\ntask-c\n")
 
-            result = subprocess.run(
-                [
-                    "python3",
-                    str(ENV_PY),
-                    "filter-task-file",
-                    str(source),
-                    str(output),
-                    "task-c, task-a, task-c",
-                ],
-                capture_output=True,
-                text=True,
-                check=False,
+            result = run_env_helper(
+                "filter-task-file",
+                source,
+                output,
+                "task-c, task-a, task-c",
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(output.read_text(), "task-c\ntask-a\n")
 
-            missing = subprocess.run(
-                [
-                    "python3",
-                    str(ENV_PY),
-                    "filter-task-file",
-                    str(source),
-                    str(root / "missing.txt"),
-                    "missing-a,task-a,missing-b",
-                ],
-                capture_output=True,
-                text=True,
-                check=False,
+            missing = run_env_helper(
+                "filter-task-file",
+                source,
+                root / "missing.txt",
+                "missing-a,task-a,missing-b",
             )
 
             self.assertEqual(missing.returncode, 2)
@@ -101,18 +91,8 @@ class HarborEnvHelperTests(unittest.TestCase):
                 archive.addfile(tarfile.TarInfo("runtime/bin/python"))
             invalid.write_text("not a tar archive")
 
-            ready = subprocess.run(
-                ["python3", str(ENV_PY), "tar-file-ready", str(valid)],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            not_ready = subprocess.run(
-                ["python3", str(ENV_PY), "tar-file-ready", str(invalid)],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            ready = run_env_helper("tar-file-ready", valid)
+            not_ready = run_env_helper("tar-file-ready", invalid)
 
             self.assertEqual(ready.returncode, 0, ready.stderr)
             self.assertNotEqual(not_ready.returncode, 0)
@@ -123,23 +103,12 @@ class HarborEnvHelperTests(unittest.TestCase):
         thread.start()
         try:
             base_url = f"http://127.0.0.1:{server.server_port}"
-            reachable = subprocess.run(
-                ["python3", str(ENV_PY), "url-reachable", f"{base_url}/agent.tgz"],
-                capture_output=True,
-                text=True,
-                check=False,
+            reachable = run_env_helper("url-reachable", f"{base_url}/agent.tgz")
+            manifest = run_env_helper(
+                "manifest-url-ready", f"{base_url}/manifest.txt"
             )
-            manifest = subprocess.run(
-                ["python3", str(ENV_PY), "manifest-url-ready", f"{base_url}/manifest.txt"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            invalid_manifest = subprocess.run(
-                ["python3", str(ENV_PY), "manifest-url-ready", f"{base_url}/agent.tgz"],
-                capture_output=True,
-                text=True,
-                check=False,
+            invalid_manifest = run_env_helper(
+                "manifest-url-ready", f"{base_url}/agent.tgz"
             )
         finally:
             server.shutdown()


### PR DESCRIPTION
## 1. Why the change?

`Agents/utils/common/Harbor/env.sh` contained several embedded Python implementations alongside shell configuration and lifecycle logic. This made the launcher harder to read and left Python behavior outside the existing `env.py` helper boundary.

## 2. Summary of the change

- Move task-file generation and filtering, URL/manifest checks, and tar archive validation into `env.py` subcommands.
- Keep the existing shell function interfaces and exit-code behavior while making `env.sh` delegate to those helpers.
- Add regression tests for task discovery, exact task selection, archive validation, and local HTTP checks; update the Harbor structure map.

## 3. Other details

Validation:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` — 105 tests passed.
- `uvx ruff@0.16.0 check --config .github/ruff.toml Agents/utils/common/Harbor/env.py Agents/utils/common/Harbor/tests/test_env_helpers.py` — passed.
- `bash -n Agents/utils/common/Harbor/env.sh`
- `python3 -m py_compile Agents/utils/common/Harbor/env.py Agents/utils/common/Harbor/tests/test_env_helpers.py`
- `git diff --check`

The repository-wide Ruff workflow also reports an existing `ISC004` in `Agents/utils/common/Harbor/scripts/write_benchmark_summary.py`, which is outside this diff. The existing `test_harboropik_extra_compose.sh` remains a macOS baseline failure because its fixture assumes Linux `/proc/<pid>/stat` and a compatible system Python; it reproduces on untouched `main` and is unrelated to this change.
