### PR TITLE
fix(harbor): handle empty analyzer summary groups

### DIFF
--- a/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
+++ b/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
@@ -26,7 +26,9 @@ Return exactly one JSON object with this shape:
 Include every supplied analysis group exactly once in analysis_summary. For an
 analysis_failed group, explain why Analyzer failed; do not claim that this is
 the benchmark task's root cause. Use at most three recommended actions. Do not
-return Markdown."""
+return Markdown. When analysis_groups is empty, return empty analysis_summary
+and recommended_actions arrays. Do not create run-level actions or actions with
+empty group_ids."""
 
 FINDING_LABELS = {
     "success": "No failure found",
@@ -282,6 +284,16 @@ def _validate_model_output(
     return payload
 
 
+def _normalize_model_output(
+    payload: dict[str, Any],
+    groups: list[dict[str, Any]],
+) -> dict[str, Any]:
+    normalized = dict(payload)
+    if not groups and isinstance(normalized.get("recommended_actions"), list):
+        normalized["recommended_actions"] = []
+    return normalized
+
+
 def _run_summary_model(
     payload: dict[str, Any],
     summary_dir: Path,
@@ -315,7 +327,11 @@ def _run_summary_model(
     if result.block_reason or result.output_json is None:
         return None, result
     try:
-        return _validate_model_output(result.output_json, payload["analysis_groups"]), result
+        normalized = _normalize_model_output(
+            result.output_json,
+            payload["analysis_groups"],
+        )
+        return _validate_model_output(normalized, payload["analysis_groups"]), result
     except (TypeError, ValueError) as exc:
         result.block_reason = f"pi_summary_output_invalid:{exc}"
         return None, result

--- a/Agents/utils/common/Harbor/tests/test_benchmark_summary.py
+++ b/Agents/utils/common/Harbor/tests/test_benchmark_summary.py
@@ -524,6 +524,75 @@ class BenchmarkSummaryTests(unittest.TestCase):
                 clean_output.read_text(encoding="utf-8"),
             )
 
+    def test_empty_analysis_groups_drop_unscoped_recommended_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            monitor_path = root_path / "monitor-latest.json"
+            output_path = root_path / "benchmark-summary.md"
+            _write_json(
+                monitor_path,
+                {
+                    "benchmark_status": "blocked",
+                    "status_reason": "abnormal_exit",
+                    "evidence": {"elapsed_since_run_start": 1},
+                    "task_summary": {
+                        "complete_success": 0,
+                        "complete_failed": 0,
+                        "complete_unknown": 0,
+                        "not_complete": 1,
+                        "total_evaluated": 1,
+                    },
+                    "task_handover": [
+                        {
+                            "task_index": "pending-1",
+                            "task_name": "",
+                            "task_complete_status": "not_complete",
+                        }
+                    ],
+                },
+            )
+            model_output = {
+                "summary": "The benchmark runner exited before the task started.",
+                "analysis_summary": [],
+                "recommended_actions": [
+                    {
+                        "group_ids": [],
+                        "action": "Re-run Analyzer.",
+                    }
+                ],
+            }
+
+            with mock.patch.object(
+                summary_writer,
+                "run_pi_json_process",
+                return_value=_pi_result(model_output),
+            ):
+                summary_writer.write_benchmark_summary(
+                    monitor_path,
+                    root_path / "missing-manifest.json",
+                    output_path,
+                )
+
+            summary = output_path.read_text(encoding="utf-8")
+            self.assertIn(
+                "The benchmark runner exited before the task started.",
+                summary,
+            )
+            self.assertNotIn("automated narrative summary is unavailable", summary)
+            self.assertIn(
+                "Analyzer results are unavailable for 1 failed/unknown/not-complete task(s)",
+                summary,
+            )
+            self.assertIn("No additional action was generated.", summary)
+            self.assertEqual(
+                json.loads(
+                    (root_path / "benchmark-summary" / "summary-output.json").read_text(
+                        encoding="utf-8"
+                    )
+                )["recommended_actions"],
+                [],
+            )
+
     def test_reports_partial_analyzer_coverage(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             root_path = Path(root)


### PR DESCRIPTION
## Summary

- require empty analysis and action arrays when Analyzer provides no groups
- discard unscoped summary actions before validation while preserving the generated narrative
- add an abnormal-exit regression test for empty Analyzer evidence

## Validation

- python3 -m unittest Agents/utils/common/Harbor/tests/test_benchmark_summary.py
- python3 .github/scripts/tests/test_ruff_workflow.py
- ruff 0.16.0 check --config .github/ruff.toml