### PR TITLE
feat(harbor): add explicit controller user decisions

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -220,9 +220,26 @@ python3 Agents/utils/common/Harbor/scripts/monitor.py \
 ```
 
 Omit `--follow` for one sample. Control commands are optional executable files
-inside `RUN_DIR`; arguments are allowed but shell syntax is not. They are
-retained for a subsequent explicit user-decision flow and are not invoked by
-the observation policy.
+inside `RUN_DIR`; arguments are allowed but shell syntax is not. The observation
+policy never invokes them by itself. When the controller is awaiting a decision,
+the user can explicitly choose an allowed action with the run-local decision
+CLI:
+
+```bash
+python3 Agents/utils/common/Harbor/scripts/controller.py \
+  --run-dir "$RUN_DIR" status
+python3 Agents/utils/common/Harbor/scripts/controller.py \
+  --run-dir "$RUN_DIR" decide wait --wait-seconds 300
+python3 Agents/utils/common/Harbor/scripts/controller.py \
+  --run-dir "$RUN_DIR" decide stop
+```
+
+`restart` is accepted instead of `stop` after an abnormal exit when it appears
+in `allowed_decisions`. The CLI atomically writes
+`monitor/user-decision.json`; the already-running monitor validates the run,
+incident, allowed action, and unique decision ID before using the existing
+controller executor. `wait` defers the incident without external control.
+`restart` and `stop` execute only their configured run-local command.
 
 Optional run-local controls can be set with
 `HARBOR_MONITOR_RESTART_CMD` and `HARBOR_MONITOR_STOP_CMD`.
@@ -231,6 +248,7 @@ Optional run-local controls can be set with
 | --- | --- | --- |
 | `monitor-latest.json` | Debugging | Full state and evidence |
 | `user-notify-latest.json` | User | Objective status and required human action |
+| `user-decision.json` | Monitor/controller | Explicit decision submitted for the current notification |
 | `analyzer-handover-latest.json` | Analyzer | Tasks requiring deeper analysis |
 | `runner-action-latest.json` | Runner | `wait`, `restart`, `stop`, or `notify`, plus execution result |
 
@@ -246,10 +264,13 @@ All files are refreshed on each sample. The actual action is
 | Tasks unfinished with no live worker | `notify`; `restart` is allowed below `--max-retries` |
 | Every task has a terminal queue record | `wait`; finish the monitor loop without external control |
 
+The interaction path is available whenever `HARBOR_MONITOR_ENABLED=1`; it has
+no separate feature flag or daemon. The monitor reads the decision file only
+while `controller_status=awaiting_user_decision`. Normal progressing and
+completed samples do not read it. The CLI and controller do not call zellij or
+Opik APIs, so their existing lifecycle and telemetry paths remain unchanged.
 The monitor does not consume restart attempts or execute restart/stop commands
-without an explicit user decision. The bidirectional decision channel is not
-part of this structural refactor; `allowed_decisions` records what a later
-decision flow may safely execute.
+without a matching explicit user decision.
 
 ## Harbor Analyzer
 

--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -259,9 +259,9 @@ All files are refreshed on each sample. The actual action is
 | Observed state | Action |
 | --- | --- |
 | Worker active and making progress | `wait` |
-| Worker active past `--configured-timeout` | `notify`; allowed decisions are `wait`, `stop` |
-| Worker active after the confirmed stall duration | `notify`; allowed decisions are `wait`, `stop` |
-| Tasks unfinished with no live worker | `notify`; `restart` is allowed below `--max-retries` |
+| Worker active past `--configured-timeout` | `notify`; `wait` is allowed, and `stop` is allowed when a stop command is configured |
+| Worker active after the confirmed stall duration | `notify`; `wait` is allowed, and `stop` is allowed when a stop command is configured |
+| Tasks unfinished with no live worker | `notify`; `restart` is allowed below `--max-retries` when a restart command is configured |
 | Every task has a terminal queue record | `wait`; finish the monitor loop without external control |
 
 The interaction path is available whenever `HARBOR_MONITOR_ENABLED=1`; it has

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -25,6 +25,7 @@ Agents/utils/common/Harbor/
 ├── prebuild_opensandbox_dataset.sh # Batch prebuild/publish local dataset images
 └── scripts/
     ├── monitor.py              # Monitor CLI entrypoint and path resolution
+    ├── controller.py           # Inspect notifications and submit explicit user decisions
     ├── analyzer_subagent.py    # Analyzer entrypoint for Pi/GLM-5.2 root-cause analysis
     ├── harbor_analyzer/        # Analyzer policy, Pi adapter, contracts, and output validation
     ├── harbor_pi_runtime/      # Shared isolated Pi process and JSON-event helper
@@ -36,6 +37,7 @@ Agents/utils/common/Harbor/
     │   └── runner.py           # Observation and follow-loop orchestration
     ├── harbor_controller/
     │   ├── policy.py           # Select wait/notify and state-safe user choices
+    │   ├── decision.py         # Validate, deduplicate, and defer user decisions
     │   ├── executor.py         # Validate and execute user-approved run-local controls
     │   └── analyzer_dispatch.py # Deduplicate and spool Analyzer handovers
     ├── fixer.py                # Fix Plan Generation CLI

--- a/Agents/utils/common/Harbor/scripts/controller.py
+++ b/Agents/utils/common/Harbor/scripts/controller.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Submit and inspect Harbor controller user decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected a JSON object in {path}")
+    return payload
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw_tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp_path = Path(raw_tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _notification_path(run_dir: Path) -> Path:
+    return run_dir / "monitor" / "user-notify-latest.json"
+
+
+def _decision_path(run_dir: Path) -> Path:
+    return run_dir / "monitor" / "user-decision.json"
+
+
+def _status(run_dir: Path) -> int:
+    notification = _load_json(_notification_path(run_dir))
+    fields = {
+        "run_id": notification.get("run_id", run_dir.name),
+        "controller_status": notification.get("controller_status"),
+        "status_reason": notification.get("status_reason"),
+        "allowed_decisions": notification.get("allowed_decisions", []),
+        "decision_request_id": notification.get("decision_request_id"),
+        "decision_status": notification.get("decision_status"),
+        "submitted_decision": notification.get("submitted_decision"),
+        "external_control_performed": notification.get("external_control_performed"),
+    }
+    print(json.dumps(fields, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _decide(run_dir: Path, decision: str, wait_seconds: int) -> int:
+    notification = _load_json(_notification_path(run_dir))
+    allowed = notification.get("allowed_decisions")
+    allowed_decisions = [str(value) for value in allowed] if isinstance(allowed, list) else []
+    if notification.get("controller_status") != "awaiting_user_decision":
+        raise ValueError("controller is not awaiting a user decision")
+    if decision not in allowed_decisions:
+        raise ValueError(
+            f"decision {decision!r} is not allowed; allowed decisions: "
+            f"{', '.join(allowed_decisions) or '<none>'}"
+        )
+    request_id = str(notification.get("decision_request_id") or "")
+    if not request_id:
+        raise ValueError("notification has no decision_request_id")
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "kind": "harbor_user_decision",
+        "run_id": str(notification.get("run_id") or run_dir.name),
+        "decision_id": f"decision-{uuid.uuid4()}",
+        "decision_request_id": request_id,
+        "decision": decision,
+    }
+    if decision == "wait":
+        if wait_seconds <= 0:
+            raise ValueError("wait-seconds must be positive")
+        payload["wait_seconds"] = wait_seconds
+    path = _decision_path(run_dir)
+    _write_json_atomic(path, payload)
+    print(json.dumps({"status": "submitted", "path": str(path), **payload}, indent=2))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Harbor controller user interaction")
+    parser.add_argument("--run-dir", required=True, type=Path)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("status")
+    decide = subparsers.add_parser("decide")
+    decide.add_argument("decision", choices=("wait", "restart", "stop"))
+    decide.add_argument("--wait-seconds", type=int, default=300)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "status":
+            return _status(args.run_dir)
+        return _decide(args.run_dir, args.decision, args.wait_seconds)
+    except (TypeError, ValueError) as exc:
+        print(f"controller decision rejected: {exc}", file=os.sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/decision.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/decision.py
@@ -1,0 +1,165 @@
+"""Validate and consume explicit Harbor user decisions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def build_decision_request_id(run_id: str, incident_key: str) -> str:
+    encoded = f"{run_id}\0{incident_key}".encode()
+    return f"sha256-{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _read_decision(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _consumed_decisions(state: dict[str, Any]) -> list[str]:
+    raw = state.get("consumed_user_decision_ids")
+    if not isinstance(raw, list):
+        return []
+    return [str(value) for value in raw if isinstance(value, str) and value]
+
+
+def _record_consumed(state: dict[str, Any], decision_id: str) -> None:
+    consumed = _consumed_decisions(state)
+    if decision_id not in consumed:
+        consumed.append(decision_id)
+    state["consumed_user_decision_ids"] = consumed[-100:]
+
+
+def _wait_action(
+    requested_action: dict[str, Any],
+    *,
+    decision_id: str,
+    request_id: str,
+) -> dict[str, Any]:
+    return {
+        "type": "wait",
+        "retry_count": requested_action.get("retry_count", 0),
+        "reason": "user_approved_wait",
+        "allowed_decisions": [],
+        "decision_required": False,
+        "controller_status": "observing",
+        "external_control_performed": False,
+        "decision_id": decision_id,
+        "decision_request_id": request_id,
+        "submitted_decision": "wait",
+        "decision_status": "executed",
+    }
+
+
+def resolve_user_decision(
+    requested_action: dict[str, Any],
+    *,
+    decision_path: Path,
+    request_id: str | None,
+    run_id: str,
+    state: dict[str, Any],
+    now: float | None = None,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Return a user-selected action only for the current notification."""
+
+    if requested_action.get("type") != "notify" or not request_id:
+        return requested_action, None
+    allowed = requested_action.get("allowed_decisions")
+    if not isinstance(allowed, list) or not allowed:
+        return requested_action, None
+
+    current_time = time.time() if now is None else now
+    deferred = state.get("deferred_user_wait")
+    if isinstance(deferred, dict) and deferred.get("decision_request_id") == request_id:
+        try:
+            wait_until = float(deferred.get("wait_until"))
+        except (TypeError, ValueError):
+            wait_until = 0
+        if current_time < wait_until:
+            decision_id = str(deferred.get("decision_id") or "")
+            return (
+                _wait_action(
+                    requested_action,
+                    decision_id=decision_id,
+                    request_id=request_id,
+                ),
+                {
+                    "decision_id": decision_id,
+                    "decision_request_id": request_id,
+                    "decision": "wait",
+                    "status": "executed",
+                    "wait_until": wait_until,
+                },
+            )
+        state["deferred_user_wait"] = None
+
+    payload = _read_decision(decision_path)
+    if payload is None:
+        return requested_action, None
+    decision_id = str(payload.get("decision_id") or "")
+    decision = str(payload.get("decision") or "")
+    if not decision_id or decision_id in _consumed_decisions(state):
+        return requested_action, None
+
+    record: dict[str, Any] = {
+        "decision_id": decision_id,
+        "decision_request_id": str(payload.get("decision_request_id") or ""),
+        "decision": decision,
+        "status": "rejected",
+    }
+    if payload.get("run_id") != run_id:
+        record["reason"] = "run_id_mismatch"
+        return requested_action, record
+    if payload.get("decision_request_id") != request_id:
+        record["reason"] = "decision_request_id_mismatch"
+        return requested_action, record
+    if decision not in allowed:
+        record["reason"] = "decision_not_allowed"
+        return requested_action, record
+
+    if decision == "wait":
+        wait_seconds = payload.get("wait_seconds", 300)
+        if not isinstance(wait_seconds, int) or wait_seconds <= 0:
+            record["status"] = "rejected"
+            record["reason"] = "wait_seconds_invalid"
+            return requested_action, record
+        _record_consumed(state, decision_id)
+        wait_until = current_time + min(wait_seconds, 86400)
+        state["deferred_user_wait"] = {
+            "decision_id": decision_id,
+            "decision_request_id": request_id,
+            "wait_until": wait_until,
+        }
+        record["status"] = "executed"
+        record["wait_until"] = wait_until
+        return (
+            _wait_action(
+                requested_action,
+                decision_id=decision_id,
+                request_id=request_id,
+            ),
+            record,
+        )
+
+    _record_consumed(state, decision_id)
+    record["status"] = "accepted"
+    action = {
+        "type": decision,
+        "retry_count": requested_action.get("retry_count", 0),
+        "reason": "user_approved",
+        "allowed_decisions": [],
+        "decision_required": False,
+        "controller_status": "executing_user_decision",
+        "external_control_performed": False,
+        "decision_id": decision_id,
+        "decision_request_id": request_id,
+        "submitted_decision": decision,
+        "decision_status": "accepted",
+    }
+    return action, record

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/executor.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/executor.py
@@ -206,7 +206,16 @@ def _execute_stop(
     timeout_seconds: int,
 ) -> ControllerResult:
     if not stop_cmd:
-        return ControllerResult(action=requested_action, history=history)
+        return ControllerResult(
+            action=_notify_action(
+                state=state,
+                reason="stop_needed_but_stop_cmd_missing",
+                control_type="stop",
+                attempted=False,
+                performed=False,
+            ),
+            history=history,
+        )
 
     argv, control_error = build_control_argv(stop_cmd, run_dir, "stop")
     if control_error or argv is None:
@@ -302,4 +311,3 @@ def execute_action(
             timeout_seconds=timeout_seconds,
         )
     return ControllerResult(action=requested_action, history=history)
-

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/contracts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/contracts.py
@@ -67,6 +67,7 @@ def build_user_notify(
     run_dir: Path,
     queue_dir: Path | None,
     output_path: Path | None,
+    decision_path: Path,
 ) -> dict[str, Any]:
     benchmark_status = str(output.get("benchmark_status") or "blocked")
     status_reason = str(output.get("status_reason") or "")
@@ -112,6 +113,7 @@ def build_user_notify(
         human_action_needed = "No human action is required."
 
     return {
+        "run_id": run_dir.name,
         "audience": "user",
         "kind": "notify_report",
         "required": required,
@@ -125,6 +127,12 @@ def build_user_notify(
         "runner_action_type": action_type,
         "controller_status": action.get("controller_status", "observing"),
         "allowed_decisions": allowed_decisions,
+        "decision_request_id": action.get("decision_request_id"),
+        "decision_id": action.get("decision_id"),
+        "decision_status": action.get("decision_status"),
+        "decision_error": action.get("decision_error"),
+        "submitted_decision": action.get("submitted_decision"),
+        "external_control_performed": bool(action.get("external_control_performed")),
         "retry_count": retry_count,
         "max_retries": max_retries,
         "task_summary": task_summary,
@@ -133,6 +141,7 @@ def build_user_notify(
             "run_dir": str(run_dir),
             "queue_dir": str(queue_dir) if queue_dir else None,
             "monitor_output": str(output_path) if output_path else None,
+            "user_decision_input": str(decision_path),
         },
     }
 
@@ -278,6 +287,12 @@ def build_runner_action(
         "requires_human": action_type == "notify" or control_failed,
         "controller_status": action.get("controller_status", "observing"),
         "allowed_decisions": allowed_decisions,
+        "decision_request_id": action.get("decision_request_id"),
+        "decision_id": action.get("decision_id"),
+        "decision_status": action.get("decision_status"),
+        "decision_error": action.get("decision_error"),
+        "submitted_decision": action.get("submitted_decision"),
+        "external_control_performed": control_performed,
         "benchmark_status": benchmark_status,
         "status_reason": status_reason,
         "evidence": evidence,
@@ -289,7 +304,6 @@ def build_runner_action(
         "control_error": action.get("control_error"),
         "restart_exit_code": action.get("control_exit_code") if control_type == "restart" else None,
         "restart_error": action.get("control_error") if control_type == "restart" else None,
-        "external_control_performed": control_performed,
         "auto_retry_supported": False,
         "compatibility_note": "Harbor control is command-based and runner-neutral; restart and stop require an explicit user decision.",
         "contract": {

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
@@ -80,6 +80,46 @@ def read_exit_code(exit_file: Path | None) -> int | None:
         return None
 
 
+def _prepare_user_decision_request(
+    output: dict[str, object],
+    action: dict[str, object],
+    *,
+    run_id: str,
+    restart_cmd: str | None,
+    stop_cmd: str | None,
+) -> tuple[dict[str, object], str | None]:
+    """Expose only decisions backed by the configured run-local controls."""
+
+    restart_available = bool(restart_cmd and restart_cmd.strip())
+    stop_available = bool(stop_cmd and stop_cmd.strip())
+    allowed = action.get("allowed_decisions")
+    action["allowed_decisions"] = [
+        decision
+        for decision in allowed
+        if isinstance(decision, str)
+        and (
+            decision == "wait"
+            or (decision == "restart" and restart_available)
+            or (decision == "stop" and stop_available)
+        )
+    ] if isinstance(allowed, list) else []
+    has_decisions = action.get("type") == "notify" and bool(
+        action["allowed_decisions"]
+    )
+    action["decision_required"] = has_decisions
+    if not has_decisions:
+        action.pop("decision_request_id", None)
+        if action.get("type") == "notify":
+            action["controller_status"] = "action_required"
+        return action, None
+
+    action["controller_status"] = "awaiting_user_decision"
+    incident_key = build_notify_incident_key(output, action)
+    decision_request_id = build_decision_request_id(run_id, incident_key)
+    action["decision_request_id"] = decision_request_id
+    return action, decision_request_id
+
+
 def run_loop(
     run_dir: Path,
     done_path: Path,
@@ -237,13 +277,13 @@ def run_loop(
             retry_count=int(state.get("retry_count", 0) or 0),
             max_retries=max_retries,
         )
-        decision_request_id = None
-        if requested_action.get("type") == "notify" and requested_action.get(
-            "allowed_decisions"
-        ):
-            incident_key = build_notify_incident_key(output, requested_action)
-            decision_request_id = build_decision_request_id(run_dir.name, incident_key)
-            requested_action["decision_request_id"] = decision_request_id
+        requested_action, decision_request_id = _prepare_user_decision_request(
+            output,
+            requested_action,
+            run_id=run_dir.name,
+            restart_cmd=restart_cmd,
+            stop_cmd=stop_cmd,
+        )
         selected_action, user_decision = resolve_user_decision(
             requested_action,
             decision_path=decision_path,
@@ -283,15 +323,31 @@ def run_loop(
             elif decision_status == "executed" and submitted_decision == "stop":
                 controller_result.action["controller_status"] = "stopped"
             elif decision_status in {"failed", "rejected"}:
-                controller_result.action["controller_status"] = (
-                    "awaiting_user_decision"
+                retry_action, retry_request_id = _prepare_user_decision_request(
+                    output,
+                    decide_action(
+                        output,
+                        retry_count=int(state.get("retry_count", 0) or 0),
+                        max_retries=max_retries,
+                    ),
+                    run_id=run_dir.name,
+                    restart_cmd=restart_cmd,
+                    stop_cmd=stop_cmd,
                 )
-                controller_result.action["allowed_decisions"] = requested_action.get(
-                    "allowed_decisions", []
+                controller_result.action.update(
+                    {
+                        "controller_status": retry_action["controller_status"],
+                        "allowed_decisions": retry_action["allowed_decisions"],
+                        "decision_required": retry_action["decision_required"],
+                        "decision_request_id": retry_request_id,
+                    }
                 )
-                controller_result.action["decision_request_id"] = decision_request_id
-                if user_decision.get("reason"):
-                    controller_result.action["decision_error"] = user_decision["reason"]
+                controller_result.action["decision_error"] = (
+                    user_decision.get("reason")
+                    or controller_result.action.get("reason")
+                    or controller_result.action.get("control_error")
+                    or "control execution failed"
+                )
         output["action"] = controller_result.action
         history = controller_result.history
         if controller_result.control_stdout is not None:
@@ -320,7 +376,18 @@ def run_loop(
             run_dir=run_dir,
             queue_dir=queue_dir,
         )
-        if (
+        restart_decision_pending = (
+            output["action"].get("controller_status") == "awaiting_user_decision"
+            and "restart" in output["action"].get("allowed_decisions", [])
+        )
+        if restart_decision_pending:
+            output["analyzer_handover"]["should_run_analyzer"] = False
+            output["analyzer_handover"]["tasks"] = []
+            output["analyzer_handover"]["instruction"] = (
+                "A restart decision is pending; wait for the user's decision before "
+                "running Analyzer."
+            )
+        elif (
             output["action"].get("type") == "restart"
             and output["action"].get("external_control_performed") is True
             and output["action"].get("control_exit_code") == 0

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 
 from harbor_controller.analyzer_dispatch import dispatch_analyzer_handover
+from harbor_controller.decision import build_decision_request_id, resolve_user_decision
 from harbor_controller.executor import execute_action
 from harbor_controller.policy import decide_action
 
@@ -120,6 +121,14 @@ def run_loop(
     state.setdefault("notify_recheck_key", None)
     state.setdefault("last_action_required_notify", None)
     state.setdefault("analyzer_spooled_terminal_fingerprints", [])
+    state.setdefault("consumed_user_decision_ids", [])
+    state.setdefault("deferred_user_wait", None)
+
+    decision_path = (
+        user_report_output.parent / "user-decision.json"
+        if user_report_output is not None
+        else run_dir / "monitor" / "user-decision.json"
+    )
 
     tasks_manifest = load_manifest(task_manifest_path)
     if not tasks_manifest:
@@ -228,8 +237,22 @@ def run_loop(
             retry_count=int(state.get("retry_count", 0) or 0),
             max_retries=max_retries,
         )
-        controller_result = execute_action(
+        decision_request_id = None
+        if requested_action.get("type") == "notify" and requested_action.get(
+            "allowed_decisions"
+        ):
+            incident_key = build_notify_incident_key(output, requested_action)
+            decision_request_id = build_decision_request_id(run_dir.name, incident_key)
+            requested_action["decision_request_id"] = decision_request_id
+        selected_action, user_decision = resolve_user_decision(
             requested_action,
+            decision_path=decision_path,
+            request_id=decision_request_id,
+            run_id=run_dir.name,
+            state=state,
+        )
+        controller_result = execute_action(
+            selected_action,
             restart_cmd=restart_cmd,
             stop_cmd=stop_cmd,
             run_dir=run_dir,
@@ -237,10 +260,51 @@ def run_loop(
             observation=output,
             history=history,
         )
+        if user_decision is not None:
+            decision_status = str(user_decision.get("status") or "")
+            submitted_decision = str(user_decision.get("decision") or "")
+            if decision_status == "accepted":
+                control_succeeded = (
+                    controller_result.action.get("type") == submitted_decision
+                    and controller_result.action.get("control_exit_code") == 0
+                    and controller_result.action.get("external_control_performed") is True
+                )
+                decision_status = "executed" if control_succeeded else "failed"
+            controller_result.action.update(
+                {
+                    "decision_id": user_decision.get("decision_id"),
+                    "decision_request_id": user_decision.get("decision_request_id"),
+                    "submitted_decision": submitted_decision,
+                    "decision_status": decision_status,
+                }
+            )
+            if decision_status == "executed" and submitted_decision == "restart":
+                controller_result.action["controller_status"] = "observing"
+            elif decision_status == "executed" and submitted_decision == "stop":
+                controller_result.action["controller_status"] = "stopped"
+            elif decision_status in {"failed", "rejected"}:
+                controller_result.action["controller_status"] = (
+                    "awaiting_user_decision"
+                )
+                controller_result.action["allowed_decisions"] = requested_action.get(
+                    "allowed_decisions", []
+                )
+                controller_result.action["decision_request_id"] = decision_request_id
+                if user_decision.get("reason"):
+                    controller_result.action["decision_error"] = user_decision["reason"]
         output["action"] = controller_result.action
         history = controller_result.history
         if controller_result.control_stdout is not None:
             output["control_stdout"] = controller_result.control_stdout
+
+        if (
+            output["action"].get("type") == "stop"
+            and output["action"].get("external_control_performed") is True
+            and output["action"].get("control_exit_code") == 0
+        ):
+            output["benchmark_status"] = "stopped"
+            output["status_reason"] = "stopped_by_user"
+            output["running"] = 0
 
         output["user_notify"] = build_user_notify(
             output=output,
@@ -249,12 +313,24 @@ def run_loop(
             run_dir=run_dir,
             queue_dir=queue_dir,
             output_path=output_path,
+            decision_path=decision_path,
         )
         output["analyzer_handover"] = build_analyzer_handover(
             output,
             run_dir=run_dir,
             queue_dir=queue_dir,
         )
+        if (
+            output["action"].get("type") == "restart"
+            and output["action"].get("external_control_performed") is True
+            and output["action"].get("control_exit_code") == 0
+        ):
+            output["analyzer_handover"]["should_run_analyzer"] = False
+            output["analyzer_handover"]["tasks"] = []
+            output["analyzer_handover"]["instruction"] = (
+                "The user-approved restart was executed; wait for terminal evidence "
+                "from the new attempt before running Analyzer."
+            )
         output["runner_action"] = build_runner_action(
             action=output["action"],
             benchmark_status=str(output.get("benchmark_status") or "blocked"),
@@ -302,12 +378,8 @@ def run_loop(
             output["monitor_follow_decision"] = "continue"
         elif action_type == "stop":
             output["monitor_follow_decision"] = "stop_user_requested"
-        elif (
-            action_type == "notify"
-            and output.get("benchmark_status") == "running"
-            and output.get("status_reason") == "timeout_reached"
-        ):
-            output["monitor_follow_decision"] = "continue"
+        elif action_type == "notify" and output["action"].get("allowed_decisions"):
+            output["monitor_follow_decision"] = "continue_awaiting_user_decision"
         elif notify_recheck_allowed:
             state["notify_recheck_count"] = int(state.get("notify_recheck_count", 0) or 0) + 1
             output["notify_recheck"] = {

--- a/Agents/utils/common/Harbor/tests/test_harbor_controller.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_controller.py
@@ -13,6 +13,7 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from harbor_controller.analyzer_dispatch import dispatch_analyzer_handover
+from harbor_controller.decision import build_decision_request_id, resolve_user_decision
 from harbor_controller.executor import build_control_argv, execute_action
 from harbor_controller.policy import decide_action
 
@@ -181,6 +182,157 @@ class HarborControllerExecutorTest(unittest.TestCase):
             self.assertEqual(result.action["control_exit_code"], 0)
             self.assertEqual(result.control_stdout, "stopped\n")
             self.assertTrue((run_dir / "stopped.marker").is_file())
+
+    def test_missing_stop_command_becomes_notify(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            result = execute_action(
+                {"type": "stop", "reason": "user_approved", "retry_count": 0},
+                restart_cmd=None,
+                stop_cmd=None,
+                run_dir=Path(root),
+                state={"retry_count": 0},
+                observation=_observation("running", "timeout_reached", running=1),
+                history=[],
+            )
+
+            self.assertEqual(result.action["type"], "notify")
+            self.assertEqual(result.action["reason"], "stop_needed_but_stop_cmd_missing")
+            self.assertFalse(result.action["external_control_performed"])
+
+
+class HarborControllerDecisionTest(unittest.TestCase):
+    def _requested(self) -> dict[str, object]:
+        return {
+            "type": "notify",
+            "retry_count": 0,
+            "allowed_decisions": ["wait", "stop"],
+            "controller_status": "awaiting_user_decision",
+        }
+
+    def test_request_id_is_stable_and_incident_specific(self) -> None:
+        first = build_decision_request_id("run-1", "incident-1")
+        self.assertEqual(first, build_decision_request_id("run-1", "incident-1"))
+        self.assertNotEqual(first, build_decision_request_id("run-1", "incident-2"))
+
+    def test_valid_wait_is_consumed_and_deferred(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "user-decision.json"
+            request_id = build_decision_request_id("run-1", "incident")
+            path.write_text(
+                json.dumps(
+                    {
+                        "run_id": "run-1",
+                        "decision_id": "decision-1",
+                        "decision_request_id": request_id,
+                        "decision": "wait",
+                        "wait_seconds": 30,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            state: dict[str, object] = {}
+
+            action, record = resolve_user_decision(
+                self._requested(),
+                decision_path=path,
+                request_id=request_id,
+                run_id="run-1",
+                state=state,
+                now=100.0,
+            )
+
+            self.assertEqual(action["type"], "wait")
+            self.assertEqual(record["status"], "executed")
+            self.assertEqual(state["consumed_user_decision_ids"], ["decision-1"])
+            self.assertEqual(state["deferred_user_wait"]["wait_until"], 130.0)
+
+    def test_stale_and_wrong_run_decisions_are_rejected(self) -> None:
+        cases = [
+            ("other-run", "request-current", "run_id_mismatch"),
+            ("run-1", "request-stale", "decision_request_id_mismatch"),
+        ]
+        for run_id, payload_request, expected_reason in cases:
+            with self.subTest(reason=expected_reason), tempfile.TemporaryDirectory() as root:
+                path = Path(root) / "user-decision.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "run_id": run_id,
+                            "decision_id": "decision-1",
+                            "decision_request_id": payload_request,
+                            "decision": "stop",
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                action, record = resolve_user_decision(
+                    self._requested(),
+                    decision_path=path,
+                    request_id="request-current",
+                    run_id="run-1",
+                    state={},
+                )
+                self.assertEqual(action["type"], "notify")
+                self.assertEqual(record["reason"], expected_reason)
+
+    def test_duplicate_decision_is_not_replayed(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "user-decision.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "run_id": "run-1",
+                        "decision_id": "decision-1",
+                        "decision_request_id": "request-1",
+                        "decision": "stop",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            state: dict[str, object] = {}
+            first, _ = resolve_user_decision(
+                self._requested(),
+                decision_path=path,
+                request_id="request-1",
+                run_id="run-1",
+                state=state,
+            )
+            second, record = resolve_user_decision(
+                self._requested(),
+                decision_path=path,
+                request_id="request-1",
+                run_id="run-1",
+                state=state,
+            )
+            self.assertEqual(first["type"], "stop")
+            self.assertEqual(second["type"], "notify")
+            self.assertIsNone(record)
+
+    def test_invalid_wait_is_not_consumed(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "user-decision.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "run_id": "run-1",
+                        "decision_id": "decision-1",
+                        "decision_request_id": "request-1",
+                        "decision": "wait",
+                        "wait_seconds": 0,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            state: dict[str, object] = {}
+            _, record = resolve_user_decision(
+                self._requested(),
+                decision_path=path,
+                request_id="request-1",
+                run_id="run-1",
+                state=state,
+            )
+            self.assertEqual(record["reason"], "wait_seconds_invalid")
+            self.assertEqual(state.get("consumed_user_decision_ids", []), [])
 
 
 class HarborControllerAnalyzerDispatchTest(unittest.TestCase):

--- a/Agents/utils/common/Harbor/tests/test_harbor_monitor_controller_integration.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_monitor_controller_integration.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 HARBOR_DIR = Path(__file__).resolve().parents[1]
 MONITOR = HARBOR_DIR / "scripts" / "monitor.py"
+CONTROLLER = HARBOR_DIR / "scripts" / "controller.py"
 
 
 class MonitorControllerIntegrationTest(unittest.TestCase):
@@ -23,7 +24,7 @@ class MonitorControllerIntegrationTest(unittest.TestCase):
         failed: str = "",
     ) -> dict[str, object]:
         queue = root / "queue" / "claude-code"
-        queue.mkdir(parents=True)
+        queue.mkdir(parents=True, exist_ok=True)
         (root / "tasks.txt").write_text("task-a\n", encoding="utf-8")
         (queue / "done.txt").write_text(done, encoding="utf-8")
         (queue / "failed.txt").write_text(failed, encoding="utf-8")
@@ -61,6 +62,34 @@ class MonitorControllerIntegrationTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout)
         return json.loads((monitor_dir / "monitor-latest.json").read_text())
 
+    def _decide(
+        self,
+        run_dir: Path,
+        decision: str,
+        *,
+        wait_seconds: int | None = None,
+    ) -> dict[str, object]:
+        command = [
+            sys.executable,
+            str(CONTROLLER),
+            "--run-dir",
+            str(run_dir),
+            "decide",
+            decision,
+        ]
+        if wait_seconds is not None:
+            command.extend(["--wait-seconds", str(wait_seconds)])
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=10,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        return json.loads(result.stdout)
+
     def test_wait_action_for_live_worker(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             output = self._run_monitor(
@@ -90,6 +119,73 @@ class MonitorControllerIntegrationTest(unittest.TestCase):
             self.assertEqual(output["status_reason"], "timeout_reached")
             self.assertEqual(output["action"]["allowed_decisions"], ["wait", "stop"])
             self.assertEqual(output["user_notify"]["allowed_decisions"], ["wait", "stop"])
+            self.assertEqual(
+                output["monitor_follow_decision"],
+                "continue_awaiting_user_decision",
+            )
+
+    def test_timeout_wait_then_user_stop_executes_run_local_control(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            stop = run_dir / "stop.sh"
+            stop.write_text("#!/usr/bin/env bash\ntouch stopped.marker\n", encoding="utf-8")
+            stop.chmod(0o755)
+            args = [
+                "--total",
+                "1",
+                "--claimed",
+                "1",
+                "--remaining",
+                "0",
+                "--running",
+                "1",
+                "--configured-timeout",
+                "0",
+                "--stop-cmd",
+                "stop.sh",
+            ]
+            notified = self._run_monitor(run_dir, extra_args=args)
+            self.assertEqual(notified["action"]["type"], "notify")
+
+            self._decide(run_dir, "wait", wait_seconds=60)
+            waiting = self._run_monitor(run_dir, extra_args=args)
+            self.assertEqual(waiting["action"]["type"], "wait")
+            self.assertEqual(waiting["action"]["decision_status"], "executed")
+            self.assertFalse((run_dir / "stopped.marker").exists())
+
+            state_path = run_dir / ".monitor_state.json"
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            state["deferred_user_wait"]["wait_until"] = 0
+            state_path.write_text(json.dumps(state), encoding="utf-8")
+            notified_again = self._run_monitor(run_dir, extra_args=args)
+            self.assertEqual(notified_again["action"]["type"], "notify")
+
+            self._decide(run_dir, "stop")
+            stopped = self._run_monitor(run_dir, extra_args=args)
+            self.assertEqual(stopped["action"]["type"], "stop")
+            self.assertEqual(stopped["action"]["decision_status"], "executed")
+            self.assertTrue(stopped["action"]["external_control_performed"])
+            self.assertEqual(stopped["benchmark_status"], "stopped")
+            self.assertEqual(stopped["status_reason"], "stopped_by_user")
+            self.assertTrue((run_dir / "stopped.marker").is_file())
+
+    def test_abnormal_exit_user_restart_executes_and_defers_analyzer(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            restart = run_dir / "restart.sh"
+            restart.write_text("#!/usr/bin/env bash\ntouch restart.marker\n", encoding="utf-8")
+            restart.chmod(0o755)
+            args = ["--restart-cmd", "restart.sh"]
+            notified = self._run_monitor(run_dir, extra_args=args)
+            self.assertEqual(notified["action"]["allowed_decisions"], ["restart"])
+
+            self._decide(run_dir, "restart")
+            restarted = self._run_monitor(run_dir, extra_args=args)
+            self.assertEqual(restarted["action"]["type"], "restart")
+            self.assertEqual(restarted["action"]["decision_status"], "executed")
+            self.assertEqual(restarted["state"]["retry_count"], 1)
+            self.assertTrue((run_dir / "restart.marker").is_file())
+            self.assertFalse(restarted["analyzer_handover"]["should_run_analyzer"])
 
     def test_abnormal_exit_offers_restart_without_executing_command(self) -> None:
         with tempfile.TemporaryDirectory() as root:

--- a/Agents/utils/common/Harbor/tests/test_harbor_monitor_controller_integration.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_monitor_controller_integration.py
@@ -98,7 +98,7 @@ class MonitorControllerIntegrationTest(unittest.TestCase):
             )
             self.assertEqual(output["action"]["type"], "wait")
 
-    def test_notify_action_for_live_worker_past_timeout(self) -> None:
+    def test_timeout_without_stop_command_only_offers_wait(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             output = self._run_monitor(
                 Path(root),
@@ -117,8 +117,8 @@ class MonitorControllerIntegrationTest(unittest.TestCase):
             )
             self.assertEqual(output["action"]["type"], "notify")
             self.assertEqual(output["status_reason"], "timeout_reached")
-            self.assertEqual(output["action"]["allowed_decisions"], ["wait", "stop"])
-            self.assertEqual(output["user_notify"]["allowed_decisions"], ["wait", "stop"])
+            self.assertEqual(output["action"]["allowed_decisions"], ["wait"])
+            self.assertEqual(output["user_notify"]["allowed_decisions"], ["wait"])
             self.assertEqual(
                 output["monitor_follow_decision"],
                 "continue_awaiting_user_decision",
@@ -178,6 +178,8 @@ class MonitorControllerIntegrationTest(unittest.TestCase):
             args = ["--restart-cmd", "restart.sh"]
             notified = self._run_monitor(run_dir, extra_args=args)
             self.assertEqual(notified["action"]["allowed_decisions"], ["restart"])
+            self.assertFalse(notified["analyzer_handover"]["should_run_analyzer"])
+            self.assertFalse((run_dir / "monitor" / "analyzer-handoffs").exists())
 
             self._decide(run_dir, "restart")
             restarted = self._run_monitor(run_dir, extra_args=args)
@@ -186,6 +188,74 @@ class MonitorControllerIntegrationTest(unittest.TestCase):
             self.assertEqual(restarted["state"]["retry_count"], 1)
             self.assertTrue((run_dir / "restart.marker").is_file())
             self.assertFalse(restarted["analyzer_handover"]["should_run_analyzer"])
+
+    def test_abnormal_exit_without_restart_command_has_no_decision_request(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            output = self._run_monitor(Path(root), extra_args=[])
+
+            self.assertEqual(output["action"]["allowed_decisions"], [])
+            self.assertFalse(output["action"]["decision_required"])
+            self.assertEqual(output["action"]["controller_status"], "action_required")
+            self.assertIsNone(output["action"].get("decision_request_id"))
+            self.assertEqual(output["monitor_follow_decision"], "continue")
+
+    def test_failed_final_restart_clears_restart_and_reports_error(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            restart = run_dir / "restart.sh"
+            restart.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+            restart.chmod(0o755)
+            args = ["--restart-cmd", "restart.sh", "--max-retries", "1"]
+            notified = self._run_monitor(run_dir, extra_args=args)
+            self.assertEqual(notified["action"]["allowed_decisions"], ["restart"])
+            self.assertFalse(notified["analyzer_handover"]["should_run_analyzer"])
+
+            self._decide(run_dir, "restart")
+            failed = self._run_monitor(run_dir, extra_args=args)
+
+            self.assertEqual(failed["action"]["type"], "notify")
+            self.assertEqual(failed["action"]["decision_status"], "failed")
+            self.assertEqual(failed["action"]["decision_error"], "restart_failed_exit_code=1")
+            self.assertEqual(failed["action"]["allowed_decisions"], [])
+            self.assertFalse(failed["action"]["decision_required"])
+            self.assertEqual(failed["action"]["controller_status"], "action_required")
+            self.assertIsNone(failed["action"].get("decision_request_id"))
+            self.assertEqual(failed["state"]["retry_count"], 1)
+            self.assertTrue(failed["analyzer_handover"]["should_run_analyzer"])
+
+    def test_failed_stop_reports_error_and_offers_another_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root)
+            stop = run_dir / "stop.sh"
+            stop.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+            stop.chmod(0o755)
+            args = [
+                "--total",
+                "1",
+                "--claimed",
+                "1",
+                "--remaining",
+                "0",
+                "--running",
+                "1",
+                "--configured-timeout",
+                "0",
+                "--stop-cmd",
+                "stop.sh",
+            ]
+            self._run_monitor(run_dir, extra_args=args)
+            self._decide(run_dir, "stop")
+            failed = self._run_monitor(run_dir, extra_args=args)
+
+            self.assertEqual(failed["action"]["type"], "notify")
+            self.assertEqual(failed["action"]["decision_status"], "failed")
+            self.assertEqual(failed["action"]["decision_error"], "stop_failed_exit_code=1")
+            self.assertEqual(failed["action"]["allowed_decisions"], ["wait", "stop"])
+            self.assertTrue(failed["action"]["decision_required"])
+            self.assertEqual(
+                failed["action"]["controller_status"], "awaiting_user_decision"
+            )
+            self.assertIsNotNone(failed["action"].get("decision_request_id"))
 
     def test_abnormal_exit_offers_restart_without_executing_command(self) -> None:
         with tempfile.TemporaryDirectory() as root:


### PR DESCRIPTION
## Summary
- add a run-local controller CLI for status and explicit wait, restart, or stop decisions
- validate decision run/incident identity, prevent replay, and keep monitor sampling non-blocking
- execute only configured run-local controls while leaving normal monitor, Analyzer, zellij, and Opik paths unchanged

## Tests
- python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p test_*.py (146 tests; socket-only test rerun outside sandbox)
- python3 -m unittest Agents/utils/common/Harbor/tests/test_env_helpers.py
- ruff check --config .github/ruff.toml
- python3 .github/scripts/tests/test_ruff_workflow.py
- bash Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
- bash Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
- bash Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh