### PR TITLE
Refactor Harbor Fixer plans into structured actions

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -336,6 +336,52 @@ with no env/infra tasks produces an empty fix plan without invoking Pi.
 Starting generation removes any stale `fix-plan-latest.json`; if no task
 summary succeeds, Fixer writes a diagnostic empty plan and exits nonzero.
 
+### Fix Plan action contract
+
+Fix Plan schema version 2 stores each plan's work as an ordered `actions`
+array. A command action separates the executable from its literal arguments;
+policy can inspect the resulting argv without splitting a shell command string.
+Execution must pass that argv directly without an implicit shell:
+
+```json
+{
+  "action_id": "action-001",
+  "action_type": "command",
+  "cwd": "/workspace",
+  "executable": "docker",
+  "arguments": ["build", "--tag", "benchmark-image", "."],
+  "purpose": "Build the benchmark image",
+  "expected_effect": "The benchmark image is available locally"
+}
+```
+
+File content changes use a separate exact-replacement contract:
+
+```json
+{
+  "action_id": "action-002",
+  "action_type": "file_edit",
+  "cwd": "/workspace",
+  "path": "config/daemon.json",
+  "edit": {
+    "kind": "replace_text",
+    "old_text": "\"enabled\": false",
+    "new_text": "\"enabled\": true",
+    "expected_replacements": 1
+  },
+  "purpose": "Enable the required daemon integration",
+  "expected_effect": "The daemon configuration enables the integration"
+}
+```
+
+`file_edit` is limited to existing UTF-8 files and literal paths. Creation,
+deletion, renaming, and dynamic edits are not represented by this action.
+The future executor must confirm the literal target and exact replacement count
+immediately before an atomic write.
+Commands that invoke a shell or Python to modify files remain command actions
+and must be assessed by the policy agent instead of inheriting `file_edit`
+approval.
+
 ## More Details
 
 Architecture, script roles, task resolution, and full variable descriptions are in [STRUCT.md](./STRUCT.md).

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/command_analysis.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/command_analysis.py
@@ -1,209 +1,95 @@
-"""Conservative shell-shape analysis for Harbor Fixer commands."""
+"""Deterministic analysis of structured Harbor Fixer command actions."""
 
 from __future__ import annotations
 
 import hashlib
-import shlex
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-SHELL_PUNCTUATION = frozenset("();&|<>")
-SHELL_RESERVED_WORDS = {
-    "!",
-    "case",
-    "do",
-    "done",
-    "elif",
-    "else",
-    "esac",
-    "fi",
-    "for",
-    "function",
-    "if",
-    "in",
-    "select",
-    "then",
-    "time",
-    "until",
-    "while",
-    "{",
-    "}",
-}
-
 
 @dataclass(frozen=True)
 class CommandAnalysis:
-    """Facts derived from a command without deciding whether to allow it."""
+    """Facts copied or derived from a command action without a policy verdict."""
 
     classification: str
     argv: tuple[str, ...]
     executable_token: str
     interpreter: str
     has_embedded_script: bool
-    shell_features: tuple[str, ...]
-    command_sha256: str
+    action_sha256: str
 
     def as_dict(self) -> dict[str, Any]:
         return {
-            "analysis_version": 1,
+            "analysis_version": 2,
             "classification": self.classification,
             "argv": list(self.argv),
             "executable_token": self.executable_token,
             "interpreter": self.interpreter,
             "has_embedded_script": self.has_embedded_script,
-            "shell_features": list(self.shell_features),
-            "command_sha256": self.command_sha256,
+            "action_sha256": self.action_sha256,
         }
 
 
-def _shell_features(command: str) -> set[str]:
-    features: set[str] = set()
-    quote = ""
-    escaped = False
-    word_start = True
-    index = 0
-    while index < len(command):
-        character = command[index]
-        if escaped:
-            escaped = False
-            word_start = False
-            index += 1
-            continue
-        if character == "\\" and quote != "'":
-            escaped = True
-            index += 1
-            continue
-        if quote:
-            if character == quote:
-                quote = ""
-            elif quote == '"' and character in "$`":
-                features.add("expansion")
-            index += 1
-            continue
-        if character in "'\"":
-            quote = character
-            word_start = False
-        elif character in "\r\n":
-            features.add("newline")
-            word_start = True
-        elif character.isspace():
-            word_start = True
-        elif character in ";&|()":
-            features.add("control_operator")
-            word_start = True
-        elif character in "<>":
-            features.add("redirection")
-            if command[index : index + 2] == "<<":
-                features.add("heredoc")
-            word_start = True
-        elif character in "$`":
-            features.add("expansion")
-            word_start = False
-        elif character in "*?[":
-            features.add("glob")
-            word_start = False
-        elif character in "{}":
-            features.add("brace_expansion")
-            word_start = False
-        elif character == "~" and word_start:
-            features.add("tilde_expansion")
-            word_start = False
-        elif character == "#" and word_start:
-            features.add("comment")
-            word_start = False
-        else:
-            word_start = False
-        index += 1
-    return features
+def _action_sha256(action: Any) -> str:
+    serialized = json.dumps(
+        action,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=repr,
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
-def _lex_tokens(command: str) -> list[str] | None:
-    lexer = shlex.shlex(command, posix=True, punctuation_chars="();&|<>")
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    try:
-        return list(lexer)
-    except ValueError:
-        return None
-
-
-def lex_single_command(command: str) -> list[str] | None:
-    """Lex one command, including dynamic words, without evaluating it."""
-
-    if not command or "\x00" in command or any(char in command for char in "\r\n"):
-        return None
-    tokens = _lex_tokens(command)
-    if (
-        not tokens
-        or tokens[0] in SHELL_RESERVED_WORDS
-        or any(token and set(token) <= SHELL_PUNCTUATION for token in tokens)
-    ):
-        return None
-    return tokens
-
-
-def _is_assignment(token: str) -> bool:
-    if "=" not in token or token.startswith("="):
-        return False
-    name = token.split("=", 1)[0]
-    return bool(name) and name.replace("_", "a").isalnum()
-
-
-def _interpreter_details(argv: list[str]) -> tuple[str, bool]:
-    if not argv:
-        return "", False
+def _interpreter_details(argv: tuple[str, ...]) -> tuple[str, bool]:
     executable = Path(argv[0]).name
+    arguments = argv[1:]
     if executable.startswith(("python", "pypy")):
-        return "python", "-c" in argv[1:]
+        return "python", "-c" in arguments
     if executable in {"bash", "dash", "ksh", "sh", "zsh"}:
         return "shell", any(
-            "c" in option[1:] for option in argv[1:] if option.startswith("-")
+            "c" in option[1:] for option in arguments if option.startswith("-")
         )
     if executable == "node":
-        return "javascript", any(option in argv[1:] for option in ("-e", "--eval"))
+        return "javascript", any(option in arguments for option in ("-e", "--eval"))
     if executable in {"perl", "ruby"}:
-        return executable, "-e" in argv[1:]
+        return executable, "-e" in arguments
     return "", False
 
 
-def analyze_command(command: str) -> CommandAnalysis:
-    """Classify a raw command as static argv, shell script, or invalid."""
+def analyze_command(action: dict[str, Any]) -> CommandAnalysis:
+    """Copy an exact argv from a command action and identify interpreter payloads."""
 
-    digest = hashlib.sha256(command.encode("utf-8")).hexdigest()
-    features = _shell_features(command)
-    if not command.strip() or "\x00" in command or _lex_tokens(command) is None:
+    digest = _action_sha256(action)
+    executable = action.get("executable")
+    arguments = action.get("arguments")
+    valid = (
+        action.get("action_type") == "command"
+        and isinstance(executable, str)
+        and bool(executable)
+        and "\x00" not in executable
+        and not any(character.isspace() for character in executable)
+        and isinstance(arguments, list)
+        and all(isinstance(argument, str) and "\x00" not in argument for argument in arguments)
+    )
+    if not valid:
         return CommandAnalysis(
             classification="invalid",
             argv=(),
             executable_token="",
             interpreter="",
             has_embedded_script=False,
-            shell_features=tuple(sorted(features)),
-            command_sha256=digest,
+            action_sha256=digest,
         )
-    lexical_argv = lex_single_command(command)
-    if lexical_argv is None:
-        return CommandAnalysis(
-            classification="shell_script",
-            argv=(),
-            executable_token="",
-            interpreter="",
-            has_embedded_script=False,
-            shell_features=tuple(sorted(features)),
-            command_sha256=digest,
-        )
-
-    if _is_assignment(lexical_argv[0]):
-        features.add("environment_assignment")
-    is_static = not features and lexical_argv[0] not in SHELL_RESERVED_WORDS
-    interpreter, embedded_script = _interpreter_details(lexical_argv)
+    argv = (executable, *arguments)
+    interpreter, embedded_script = _interpreter_details(argv)
     return CommandAnalysis(
-        classification="static_argv" if is_static else "shell_script",
-        argv=tuple(lexical_argv) if is_static else (),
-        executable_token=lexical_argv[0],
+        classification="static_argv",
+        argv=argv,
+        executable_token=executable,
         interpreter=interpreter,
         has_embedded_script=embedded_script,
-        shell_features=tuple(sorted(features)),
-        command_sha256=digest,
+        action_sha256=digest,
     )

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/plan_generation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/plan_generation.py
@@ -19,6 +19,7 @@ from .prompts import (
     build_validation_retry_prompt,
 )
 from .validation import (
+    FIX_PLAN_SCHEMA_VERSION,
     ValidationError,
     parse_strict_json_object,
     validate_fix_plan_set,
@@ -209,7 +210,7 @@ def _empty_fix_plan(
     generation_errors: list[dict[str, Any]],
 ) -> dict[str, Any]:
     return {
-        "schema_version": 1,
+        "schema_version": FIX_PLAN_SCHEMA_VERSION,
         "kind": "harbor_fixer_fix_plan_set",
         "source": source,
         "plans": [],

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/rules.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/rules.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from ..artifact_io import read_json
-from ..command_analysis import CommandAnalysis, analyze_command, lex_single_command
+from ..command_analysis import CommandAnalysis, analyze_command
 from ..validation import (
     ValidationError,
     require_dict,
@@ -54,10 +53,10 @@ def _is_assignment(token: str) -> bool:
     return bool(name) and name.replace("_", "a").isalnum()
 
 
-def parse_simple_argv(command: str) -> list[str] | None:
-    """Return a static, expansion-free argv eligible for T1 allow."""
+def parse_simple_argv(action: dict[str, Any]) -> list[str] | None:
+    """Return the exact argv from a valid command action."""
 
-    analysis = analyze_command(command)
+    analysis = analyze_command(action)
     return list(analysis.argv) if analysis.classification == "static_argv" else None
 
 
@@ -94,13 +93,10 @@ def normalize_argv(argv: list[str]) -> list[str]:
     return result
 
 
-def _rule_argv(
-    command: str,
-    analysis: CommandAnalysis,
-) -> tuple[list[list[str]], list[str]] | None:
-    argv = lex_single_command(command)
-    if argv is None:
+def _rule_argv(analysis: CommandAnalysis) -> tuple[list[list[str]], list[str]] | None:
+    if analysis.classification != "static_argv":
         return None
+    argv = list(analysis.argv)
     normalized = normalize_argv(argv)
     if not normalized:
         return None
@@ -110,8 +106,7 @@ def _rule_argv(
     static_argv = list(analysis.argv)
     allow_argv = (
         []
-        if static_argv is None
-        or _is_assignment(argv[0])
+        if not static_argv
         or analysis.has_embedded_script
         or Path(argv[0]).name in AGENT_ONLY_EXECUTABLES
         else static_argv
@@ -169,7 +164,7 @@ def _matches(rule: PrefixRule, argv: list[str]) -> bool:
 
 
 def evaluate_t1(
-    command: str,
+    action: dict[str, Any],
     user_rules: list[PrefixRule],
     *,
     analysis: CommandAnalysis | None = None,
@@ -177,13 +172,13 @@ def evaluate_t1(
 ) -> dict[str, Any] | None:
     """Return a deterministic T1 decision for a simple command, if available."""
 
-    command_sha256 = hashlib.sha256(command.encode("utf-8")).hexdigest()
+    action_sha256 = analyze_command(action).action_sha256
     command_analysis = (
         analysis
-        if analysis is not None and analysis.command_sha256 == command_sha256
-        else analyze_command(command)
+        if analysis is not None and analysis.action_sha256 == action_sha256
+        else analyze_command(action)
     )
-    parsed = _rule_argv(command, command_analysis)
+    parsed = _rule_argv(command_analysis)
     if parsed is None:
         return None
     candidates, allow_argv = parsed

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/prompts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/prompts.py
@@ -87,18 +87,18 @@ You must:
 - Use input.target_context as deterministic current project context collected by the
   read-only Python harness. An unavailable evidence excerpt is an unknown, not evidence
   that a dependency or file is absent.
-- Before proposing a mutating command, compare Analyzer evidence with target_environment
+- Before proposing a mutating action, compare Analyzer evidence with target_environment
   and target_context. Do not rely on stale Analyzer-host paths when current local paths
   are available.
-- Use commands as the only executable field.
-- Include fix_scope, task_list, commands, fix_reason, and verification_hint.
+- Use actions as the only executable field and preserve their execution order.
+- Include fix_scope, task_list, actions, fix_reason, and verification_hint.
 - Include every input task summary exactly once in either a plan task_list or
   unplanned_tasks.
 - Compare fix_scope with Analyzer scopes.
-- Put tasks without justified commands into unplanned_tasks.
-- Make commands idempotent: check the precondition, perform only the necessary change,
+- Put tasks without justified actions into unplanned_tasks.
+- Make actions idempotent: check the precondition, perform only the necessary change,
   and fail when the expected postcondition is not met.
-- Every mutating command must create durable target state that the verification run will
+- Every mutating action must create durable target state that the verification run will
   consume. A temporary clone, download, or probe that is deleted afterward is diagnostic,
   not a fix, and must not be presented as one.
 - When target_environment reports a required binary or dependency as available, do not
@@ -124,7 +124,7 @@ Return exactly one JSON object with no Markdown or explanatory text.
 
 Required fields and constraints:
 - Include every top-level field shown in the template below.
-- schema_version must be 1.
+- schema_version must be 2.
 - kind must be "harbor_fixer_fix_plan_set".
 - source must be copied exactly from input.source and must remain an object.
 - input.target_environment, input.target_environment_artifact, and input.target_context
@@ -135,14 +135,27 @@ Required fields and constraints:
 - plan.fix_scope: "task" | "benchmark" | "host".
 - analyzer_scope_comparison.analyzer_scopes contains only "task", "benchmark", or "host".
 - analyzer_scope_comparison.relation: "same" | "narrower" | "broader" | "mixed".
-- Every plan must have at least one task_list item and at least one command.
+- Every plan must have at least one task_list item and at least one action.
 - Each task_list item must preserve the task identity and Analyzer classification.
-- commands is the only executable field. cwd and command must be non-empty strings.
+- actions is the only executable field. Every action must use one of these contracts:
+  - command: provide a single executable and its literal arguments as separate strings.
+    Do not quote arguments for a shell or combine executable and arguments in one field.
+  - file_edit: replace known text in one existing UTF-8 file. old_text must be non-empty,
+    new_text must differ from old_text, expected_replacements must be a positive integer,
+    and path is literal relative to cwd unless absolute.
+- The template illustrates both action variants; include only the actions justified by
+  the evidence.
+- Use file_edit for file content changes that it can express. Do not use sed, tee, shell
+  redirection, or a Python script as a substitute.
+- If an operation truly requires shell evaluation, represent it explicitly as a command
+  with executable "bash" and arguments such as ["-c", "<script>"]. Python or shell
+  commands that modify files are outside the file_edit contract and require T3 policy
+  evaluation.
 - generation_errors must be []; the harness appends input.generation_errors after validation.
 
 Output template:
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "kind": "harbor_fixer_fix_plan_set",
   "source": {},
   "plans": [
@@ -163,19 +176,35 @@ Output template:
           "final_class": "env_fail | infra_fail"
         }
       ],
-      "commands": [
+      "actions": [
         {
-          "command_id": "cmd-001",
+          "action_id": "action-001",
+          "action_type": "command",
           "cwd": "<working directory>",
-          "command": "<shell command>",
+          "executable": "<single executable name or path>",
+          "arguments": ["<literal argument>"],
           "purpose": "<why the command is needed>",
+          "expected_effect": "<observable expected effect>"
+        },
+        {
+          "action_id": "action-002",
+          "action_type": "file_edit",
+          "cwd": "<working directory>",
+          "path": "<literal target path>",
+          "edit": {
+            "kind": "replace_text",
+            "old_text": "<exact non-empty existing text>",
+            "new_text": "<replacement text, possibly empty>",
+            "expected_replacements": 1
+          },
+          "purpose": "<why the edit is needed>",
           "expected_effect": "<observable expected effect>"
         }
       ],
       "fix_reason": {
         "summary": "<shared fix summary>",
         "evidence": [],
-        "reasoning": "<why these commands address the grouped failures>"
+        "reasoning": "<why these actions address the grouped failures>"
       },
       "verification_hint": {
         "expected_original_failure_absent": "<failure signal that should disappear>",

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -19,6 +19,8 @@ SCOPE_AGREEMENTS = {"agree", "unclear", "disagree"}
 CONFIDENCE_LABELS = {"high", "medium", "low"}
 PLAN_SCOPE_RELATIONS = {"same", "narrower", "broader", "mixed"}
 SCOPE_RANK = {"task": 0, "benchmark": 1, "host": 2}
+FIX_PLAN_SCHEMA_VERSION = 2
+ACTION_TYPES = {"command", "file_edit"}
 
 
 def require_dict(value: Any, name: str) -> dict[str, Any]:
@@ -46,6 +48,81 @@ def require_enum(value: Any, name: str, allowed: set[str]) -> str:
     if text not in allowed:
         raise ValidationError(f"{name} must be one of: {', '.join(sorted(allowed))}")
     return text
+
+
+def _require_exact_fields(value: dict[str, Any], name: str, fields: set[str]) -> None:
+    actual = set(value)
+    if actual != fields:
+        missing = sorted(fields - actual)
+        extra = sorted(actual - fields)
+        details = []
+        if missing:
+            details.append(f"missing {', '.join(missing)}")
+        if extra:
+            details.append(f"unexpected {', '.join(extra)}")
+        raise ValidationError(f"{name} fields are invalid: {'; '.join(details)}")
+
+
+def _require_text(value: Any, name: str, *, allow_empty: bool = False) -> str:
+    text = require_string(value, name, allow_empty=allow_empty)
+    if "\x00" in text:
+        raise ValidationError(f"{name} must not contain NUL")
+    return text
+
+
+def _validate_fix_action(value: Any, name: str) -> str:
+    action = require_dict(value, name)
+    action_type = require_enum(
+        action.get("action_type"), f"{name}.action_type", ACTION_TYPES
+    )
+    common_fields = {
+        "action_id",
+        "action_type",
+        "cwd",
+        "purpose",
+        "expected_effect",
+    }
+    action_fields = (
+        common_fields | {"executable", "arguments"}
+        if action_type == "command"
+        else common_fields | {"path", "edit"}
+    )
+    _require_exact_fields(action, name, action_fields)
+    action_id = _require_text(action.get("action_id"), f"{name}.action_id")
+    _require_text(action.get("cwd"), f"{name}.cwd")
+    _require_text(action.get("purpose"), f"{name}.purpose")
+    _require_text(action.get("expected_effect"), f"{name}.expected_effect")
+    if action_type == "command":
+        executable = _require_text(action.get("executable"), f"{name}.executable")
+        if any(character.isspace() for character in executable):
+            raise ValidationError(f"{name}.executable must be one token")
+        for index, argument in enumerate(
+            require_list(action.get("arguments"), f"{name}.arguments")
+        ):
+            _require_text(argument, f"{name}.arguments[{index}]", allow_empty=True)
+        return action_id
+
+    _require_text(action.get("path"), f"{name}.path")
+    edit = require_dict(action.get("edit"), f"{name}.edit")
+    _require_exact_fields(
+        edit,
+        f"{name}.edit",
+        {"kind", "old_text", "new_text", "expected_replacements"},
+    )
+    if edit.get("kind") != "replace_text":
+        raise ValidationError(f"{name}.edit.kind must be replace_text")
+    old_text = _require_text(edit.get("old_text"), f"{name}.edit.old_text")
+    new_text = _require_text(
+        edit.get("new_text"), f"{name}.edit.new_text", allow_empty=True
+    )
+    if old_text == new_text:
+        raise ValidationError(f"{name}.edit must change the matched text")
+    replacements = edit.get("expected_replacements")
+    if isinstance(replacements, bool) or not isinstance(replacements, int):
+        raise ValidationError(f"{name}.edit.expected_replacements must be an integer")
+    if replacements < 1:
+        raise ValidationError(f"{name}.edit.expected_replacements must be positive")
+    return action_id
 
 
 def task_key(task: dict[str, Any]) -> tuple[str, str, str]:
@@ -289,7 +366,12 @@ def validate_fix_plan_set(
     expected_source: dict[str, Any] | None = None,
     expected_task_summaries: list[dict[str, Any]] | None = None,
 ) -> None:
-    _check_kind(payload, version=1, kind="harbor_fixer_fix_plan_set", name="fix plan set")
+    _check_kind(
+        payload,
+        version=FIX_PLAN_SCHEMA_VERSION,
+        kind="harbor_fixer_fix_plan_set",
+        name="fix plan set",
+    )
     source = require_dict(payload.get("source"), "source")
     if expected_source is not None and source != expected_source:
         raise ValidationError("fix plan source does not match main agent input")
@@ -302,6 +384,19 @@ def validate_fix_plan_set(
     seen_plan_ids: set[str] = set()
     for index, plan in enumerate(require_list(payload.get("plans"), "plans")):
         plan_obj = require_dict(plan, f"plans[{index}]")
+        _require_exact_fields(
+            plan_obj,
+            f"plans[{index}]",
+            {
+                "plan_id",
+                "fix_scope",
+                "analyzer_scope_comparison",
+                "task_list",
+                "actions",
+                "fix_reason",
+                "verification_hint",
+            },
+        )
         plan_id = require_string(plan_obj.get("plan_id"), f"plans[{index}].plan_id")
         if plan_id in seen_plan_ids:
             raise ValidationError(f"duplicate plan_id: {plan_id}")
@@ -383,29 +478,16 @@ def validate_fix_plan_set(
                 raise ValidationError("fix plan analyzer scopes do not match task summaries")
             if relation != _scope_relation(fix_scope, expected_analyzer_scopes):
                 raise ValidationError("fix plan scope relation does not match task summaries")
-        commands = require_list(plan_obj.get("commands"), f"plans[{index}].commands")
-        if not commands:
-            raise ValidationError(f"plans[{index}].commands must be non-empty")
-        command_ids: set[str] = set()
-        for command_index, command in enumerate(commands):
-            command_obj = require_dict(command, f"plans[{index}].commands[{command_index}]")
-            command_id = require_string(
-                command_obj.get("command_id"),
-                f"plans[{index}].commands[{command_index}].command_id",
-            )
-            if command_id in command_ids:
-                raise ValidationError(f"duplicate command_id in plan {plan_id}: {command_id}")
-            command_ids.add(command_id)
-            require_string(command_obj.get("cwd"), f"plans[{index}].commands[{command_index}].cwd")
-            require_string(command_obj.get("command"), f"plans[{index}].commands[{command_index}].command")
-            require_string(
-                command_obj.get("purpose"),
-                f"plans[{index}].commands[{command_index}].purpose",
-            )
-            require_string(
-                command_obj.get("expected_effect"),
-                f"plans[{index}].commands[{command_index}].expected_effect",
-            )
+        actions = require_list(plan_obj.get("actions"), f"plans[{index}].actions")
+        if not actions:
+            raise ValidationError(f"plans[{index}].actions must be non-empty")
+        action_ids: set[str] = set()
+        for action_index, action in enumerate(actions):
+            name = f"plans[{index}].actions[{action_index}]"
+            action_id = _validate_fix_action(action, name)
+            if action_id in action_ids:
+                raise ValidationError(f"duplicate action_id in plan {plan_id}: {action_id}")
+            action_ids.add(action_id)
         fix_reason = require_dict(plan_obj.get("fix_reason"), f"plans[{index}].fix_reason")
         require_string(fix_reason.get("summary"), f"plans[{index}].fix_reason.summary")
         require_list(fix_reason.get("evidence"), f"plans[{index}].fix_reason.evidence")

--- a/Agents/utils/common/Harbor/tests/fixer_test_support.py
+++ b/Agents/utils/common/Harbor/tests/fixer_test_support.py
@@ -214,7 +214,7 @@ class MainInvoker:
 
 def make_fix_plan() -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "kind": "harbor_fixer_fix_plan_set",
         "source": {"fixture": True},
         "plans": [
@@ -235,11 +235,13 @@ def make_fix_plan() -> dict:
                         "final_class": "env_fail",
                     }
                 ],
-                "commands": [
+                "actions": [
                     {
-                        "command_id": "cmd-001",
+                        "action_id": "action-001",
+                        "action_type": "command",
                         "cwd": ".",
-                        "command": "printf '%s\\n' hello",
+                        "executable": "printf",
+                        "arguments": ["%s\\n", "hello"],
                         "purpose": "Emit a harmless test line.",
                         "expected_effect": "stdout contains hello.",
                     }
@@ -277,10 +279,10 @@ def write_fixture_pi(path: Path) -> Path:
                 "else:",
                 "    summaries = payload['task_summaries']",
                 "    result = {",
-                "      'schema_version': 1, 'kind': 'harbor_fixer_fix_plan_set', 'source': payload['source'],",
+                "      'schema_version': 2, 'kind': 'harbor_fixer_fix_plan_set', 'source': payload['source'],",
                 "      'plans': [{'plan_id': 'fix-001', 'fix_scope': 'benchmark', 'analyzer_scope_comparison': {'analyzer_scopes': ['benchmark'], 'relation': 'same', 'reason': 'fixture'},",
                 "        'task_list': [{'task_index': s['task']['task_index'], 'task_name': s['task']['task_name'], 'attempt_id': s['task']['attempt_id'], 'root_cause_code': s['analyzer_alignment']['root_cause_code'], 'final_class': s['analyzer_alignment']['final_class']} for s in summaries],",
-                "        'commands': [{'command_id': 'cmd-001', 'cwd': '.', 'command': \"printf '%s\\\\n' fixture-fix\", 'purpose': 'fixture command', 'expected_effect': 'fixture command runs'}],",
+                "        'actions': [{'action_id': 'action-001', 'action_type': 'command', 'cwd': '.', 'executable': 'printf', 'arguments': ['%s\\\\n', 'fixture-fix'], 'purpose': 'fixture command', 'expected_effect': 'fixture command runs'}],",
                 "        'fix_reason': {'summary': 'fixture shared fix', 'evidence': [], 'reasoning': 'fixture'},",
                 "        'verification_hint': {'expected_original_failure_absent': 'fixture failure', 'target_task_indexes': [s['task']['task_index'] for s in summaries]}}],",
                 "      'unplanned_tasks': [], 'generation_errors': []}",

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_plan.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_plan.py
@@ -81,13 +81,55 @@ class HarborFixerPlanTest(FixerTestCase):
         self.assertEqual(plan["generation_errors"], main_input["generation_errors"])
 
         incomplete = json.loads(valid_output)
-        del incomplete["plans"][0]["commands"][0]["expected_effect"]
+        del incomplete["plans"][0]["actions"][0]["expected_effect"]
         with self.assertRaisesRegex(ValidationError, "expected_effect"):
             validate_fix_plan_set(
                 incomplete,
                 expected_source=main_input["source"],
                 expected_task_summaries=[summary],
             )
+
+        with_file_edit = json.loads(valid_output)
+        with_file_edit["plans"][0]["actions"].append(
+            {
+                "action_id": "action-002",
+                "action_type": "file_edit",
+                "cwd": ".",
+                "path": "config.json",
+                "edit": {
+                    "kind": "replace_text",
+                    "old_text": '"enabled": false',
+                    "new_text": '"enabled": true',
+                    "expected_replacements": 1,
+                },
+                "purpose": "Enable the fixture.",
+                "expected_effect": "The fixture is enabled.",
+            }
+        )
+        validate_fix_plan_set(with_file_edit, expected_task_summaries=[summary])
+
+        raw_command = json.loads(valid_output)
+        raw_command["plans"][0]["actions"][0]["command"] = "printf hello"
+        with self.assertRaisesRegex(ValidationError, "unexpected command"):
+            validate_fix_plan_set(raw_command, expected_task_summaries=[summary])
+
+        legacy_commands = json.loads(valid_output)
+        legacy_commands["plans"][0]["commands"] = legacy_commands["plans"][0].pop(
+            "actions"
+        )
+        with self.assertRaisesRegex(ValidationError, "missing actions"):
+            validate_fix_plan_set(legacy_commands, expected_task_summaries=[summary])
+
+        invalid_edit = json.loads(json.dumps(with_file_edit))
+        invalid_edit["plans"][0]["actions"][1]["edit"]["expected_replacements"] = 0
+        with self.assertRaisesRegex(ValidationError, "must be positive"):
+            validate_fix_plan_set(invalid_edit, expected_task_summaries=[summary])
+
+        no_op_edit = json.loads(json.dumps(with_file_edit))
+        edit = no_op_edit["plans"][0]["actions"][1]["edit"]
+        edit["new_text"] = edit["old_text"]
+        with self.assertRaisesRegex(ValidationError, "must change"):
+            validate_fix_plan_set(no_op_edit, expected_task_summaries=[summary])
 
         agent_owned_errors = json.loads(valid_output)
         agent_owned_errors["generation_errors"] = [{"stage": "invented"}]

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy_rules.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy_rules.py
@@ -21,44 +21,53 @@ def _prefix_rule(rule_id: str, *pattern: str) -> dict:
     return {"rule_id": rule_id, "pattern": list(pattern), "match": "prefix"}
 
 
+def _command(executable: str, *arguments: str) -> dict:
+    return {
+        "action_id": "action-001",
+        "action_type": "command",
+        "cwd": ".",
+        "executable": executable,
+        "arguments": list(arguments),
+        "purpose": "test",
+        "expected_effect": "test",
+    }
+
+
 class HarborFixerPolicyRulesTest(FixerTestCase):
-    def test_command_analysis_separates_argv_from_shell_scripts(self) -> None:
-        cases = {
-            "python3 -c 'print(\"x\" * 1000)'": ("static_argv", True),
-            "python3 - <<'EOF'\nprint('x')\nEOF": ("shell_script", False),
-            "docker ps | grep fixture": ("shell_script", False),
-            "echo '$HOME'": ("static_argv", False),
-            "echo 'unterminated": ("invalid", False),
-        }
-        for command, expected in cases.items():
-            with self.subTest(command=command):
-                analysis = analyze_command(command)
+    def test_command_analysis_copies_structured_argv(self) -> None:
+        cases = [
+            (_command("python3", "-c", 'print("x" * 1000)'), ("static_argv", True)),
+            (_command("bash", "-lc", "docker ps | grep fixture"), ("static_argv", True)),
+            (_command("echo", "$HOME"), ("static_argv", False)),
+            ({"action_type": "file_edit"}, ("invalid", False)),
+        ]
+        for action, expected in cases:
+            with self.subTest(action=action):
+                analysis = analyze_command(action)
                 self.assertEqual(
                     (analysis.classification, analysis.has_embedded_script),
                     expected,
                 )
-                self.assertEqual(len(analysis.command_sha256), 64)
+                self.assertEqual(len(analysis.action_sha256), 64)
 
     def test_builtin_rules(self) -> None:
-        cases = {
-            "docker ps --all": None,
-            "git status --short": None,
-            "find . -delete": None,
-            "ls workspace": "allow",
-            "rm -rf build": "deny",
-            "sudo -u root rm -f /tmp/item": "deny",
-            "FOO=bar rm -rf build": "deny",
-            "bash -lc 'rm -rf build'": None,
-            "echo $(rm -f marker)": None,
-            "printf '%s\\n' marker | xargs rm -f": None,
-            "PATH=$PWD:$PATH ls": None,
-            "rm -rf *": "deny",
-            "ls *": None,
-            "echo '$HOME'": "allow",
-        }
-        for command, expected in cases.items():
-            with self.subTest(command=command):
-                decision = evaluate_t1(command, [], executable_verified=True)
+        cases = [
+            (_command("docker", "ps", "--all"), None),
+            (_command("git", "status", "--short"), None),
+            (_command("find", ".", "-delete"), None),
+            (_command("ls", "workspace"), "allow"),
+            (_command("rm", "-rf", "build"), "deny"),
+            (_command("sudo", "-u", "root", "rm", "-f", "/tmp/item"), "deny"),
+            (_command("env", "FOO=bar", "rm", "-rf", "build"), "deny"),
+            (_command("bash", "-lc", "rm -rf build"), None),
+            (_command("xargs", "rm", "-f"), None),
+            (_command("rm", "-rf", "*"), "deny"),
+            (_command("ls", "*"), "allow"),
+            (_command("echo", "$HOME"), "allow"),
+        ]
+        for action, expected in cases:
+            with self.subTest(action=action):
+                decision = evaluate_t1(action, [], executable_verified=True)
                 self.assertEqual(
                     None if decision is None else decision["decision"], expected
                 )
@@ -84,28 +93,37 @@ class HarborFixerPolicyRulesTest(FixerTestCase):
         rules, _ = load_user_rules(rules_path)
 
         self.assertEqual(
-            evaluate_t1("docker ps -a", rules)["rule_id"], "deny-docker-ps"
-        )
-        self.assertEqual(evaluate_t1("rm -rf build", rules)["source"], "builtin_rule")
-        self.assertIsNone(evaluate_t1("pytest -q $TESTS", rules))
-        self.assertIsNone(
-            evaluate_t1("python3 -c 'print(1)'", rules, executable_verified=True)
+            evaluate_t1(_command("docker", "ps", "-a"), rules)["rule_id"],
+            "deny-docker-ps",
         )
         self.assertEqual(
-            evaluate_t1("pytest -q tests/unit", rules, executable_verified=True)[
-                "decision"
-            ],
+            evaluate_t1(_command("rm", "-rf", "build"), rules)["source"],
+            "builtin_rule",
+        )
+        self.assertIsNone(
+            evaluate_t1(
+                _command("python3", "-c", "print(1)"),
+                rules,
+                executable_verified=True,
+            )
+        )
+        self.assertEqual(
+            evaluate_t1(
+                _command("pytest", "-q", "$TESTS"),
+                rules,
+                executable_verified=True,
+            )["decision"],
             "allow",
         )
         self.assertIsNone(
             evaluate_t1(
-                "curl https://example.test",
+                _command("curl", "https://example.test"),
                 [],
-                analysis=analyze_command("ls"),
+                analysis=analyze_command(_command("ls")),
                 executable_verified=True,
             )
         )
-        self.assertIsNone(evaluate_t1("ls", []))
+        self.assertIsNone(evaluate_t1(_command("ls"), []))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer plans currently encode each operation as a free-form shell command. Policy must then reconstruct argv and infer file-write semantics from shell text, while Execution cannot safely distinguish a bounded file edit from arbitrary interpreter code.

This change introduces an explicit action contract so Plan Generation describes commands and file edits without relying on implicit shell parsing. It is part of the Fixer work tracked in sii-system/tasks#115.

## 2. Summary of the change 

- Upgrade Fix Plan output to schema version 2 and replace `commands` with an ordered `actions` array.
- Represent command actions as `executable`, literal `arguments`, and `cwd`.
- Add a narrow `file_edit` action for exact text replacement in an existing UTF-8 file.
- Reject ambiguous or ineffective actions, including mixed legacy fields, invalid argv, non-positive replacement counts, and replacements where `old_text == new_text`.
- Simplify command analysis to consume structured argv directly while retaining explicit interpreter-payload detection and action digest binding.
- Adapt deterministic T1 policy rules to consume command actions instead of shell strings.
- Update the Main Agent prompt, fixtures, tests, and Harbor README.

## 3. Other details

`file_edit` execution is intentionally not implemented in this PR. The later Execution change must re-resolve containment, reject symlinks, verify the exact replacement count, and publish through an atomic replace. Explicit shell or Python file mutations remain command actions for T3 review.

Validation:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_harbor_fixer*.py'` — 20 tests passed
- Ruff check — passed
- Python `compileall` — passed
- `git diff --check` — passed
