### PR TITLE
Fix OpenCode registry concurrency

### DIFF
--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -966,7 +966,13 @@ PY
     no_proxy_value="$no_proxy_value,$opik_host"
   fi
 
-  local cmd
+  local cmd opencode_n_concurrent
+  opencode_n_concurrent="1"
+  if harbor_is_native_registry_main; then
+    # Registry runs use one Harbor process, so it must own the requested
+    # concurrency. Local task lists already shard work across queue workers.
+    opencode_n_concurrent="$TB_N_CONCURRENT"
+  fi
   build_opencode_cmd() {
     local trial_id="$1"
     local opencode_tgz_url=""
@@ -978,7 +984,7 @@ PY
     cmd=(
       "$HARBOR_OPIK_PYTHON" "$HARBOR_OPENCODE_DIR/enable_track_harbor.py" run
       -y
-      --n-concurrent 1
+      --n-concurrent "$opencode_n_concurrent"
       --max-retries "$TB_MAX_RETRIES"
       -o "$out_dir"
       -k 1

--- a/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
@@ -237,6 +237,7 @@ run_harboropik() {
   local queue_worker="${8:-1}"
   local min_test="${9:-0}"
   local runs="${10:-1}"
+  local n_concurrent="${11:-1}"
   local opik_base="http://opik.example"
   local opik_url_override="http://opik.example/api"
   local hook_flag="1"
@@ -250,9 +251,13 @@ run_harboropik() {
   local fake_bin
   local trace_dir
   local wheel_dir
+  local dataset_path
   fake_bin="$(dirname "$capture_bin")"
   mkdir -p "$output_dir"
   mkdir -p "$output_dir/run/runtime/$agent"
+  mkdir -p "$output_dir/run/queue/$agent"
+  dataset_path="$output_dir/dataset"
+  mkdir -p "$dataset_path"
   wheel_dir="$output_dir/wheels"
   mkdir -p "$wheel_dir"
   trace_dir="$output_dir/trace"
@@ -272,6 +277,7 @@ run_harboropik() {
     HOME="$output_dir/home" \
     AGENT="$agent" \
     DATASET_NAME="$dataset_name" \
+    DATASET_PATH="$dataset_path" \
     INCLUDE_TASKS="$include_tasks" \
     OUTPUT_PATH="$output_dir/run" \
     HARBOR_QUEUE_WORKER="$queue_worker" \
@@ -291,7 +297,7 @@ run_harboropik() {
     TB_SKIP_DOCKERHUB_PREFLIGHT="1" \
     TB_RUNS="$runs" \
     N_ATTEMPTS="1" \
-    TB_N_CONCURRENT="1" \
+    TB_N_CONCURRENT="$n_concurrent" \
     TOTAL_WORKERS="1" \
     TB_MAX_RETRIES="0" \
     HARBOR_CAPTURE_FILE="$capture_file" \
@@ -349,6 +355,7 @@ assert_registry_summary_requires_result() {
 main() {
   local tmp fake_bin default_overlay claude_capture opencode_capture capture_bin
   local seta_capture sweverify_capture registry_capture traceoff_capture traceoff_oc_capture
+  local opencode_registry_capture opencode_local_capture
   local min_test_capture
   tmp="$(mktemp -d)"
   TEST_TMP_DIR="$tmp"
@@ -387,6 +394,18 @@ main() {
     "$opencode_capture" \
     "$tmp/opencode-default/wheels" \
     "/opt/tb-opik/python-wheels"
+
+  opencode_registry_capture="$tmp/opencode-registry.args"
+  run_harboropik \
+    "opencode" "$capture_bin" "$opencode_registry_capture" "$tmp/opencode-registry" \
+    "terminalbench21" "" "true" "0" "0" "1" "20"
+  assert_arg_pair "$opencode_registry_capture" "--n-concurrent" "20"
+
+  opencode_local_capture="$tmp/opencode-local.args"
+  run_harboropik \
+    "opencode" "$capture_bin" "$opencode_local_capture" "$tmp/opencode-local" \
+    "auto" "" "true" "0" "0" "1" "20"
+  assert_arg_pair "$opencode_local_capture" "--n-concurrent" "1"
 
   seta_capture="$tmp/seta-default.args"
   run_harboropik \


### PR DESCRIPTION
## Why the change?

OpenCode runs against Harbor registry datasets ignored the requested worker count because the command builder always passed `--n-concurrent 1`. Registry runs launch one Harbor process, so Terminal-Bench 2.1 ran serially even when the fleet requested 20 workers.

## Summary of the change

- Use `TB_N_CONCURRENT` for the native Harbor registry main process.
- Keep OpenCode internal concurrency at 1 for local task-list runs, where work is already sharded across queue workers.
- Add regression coverage for both registry and local dataset modes.

## Other details

The root cause was specific to the OpenCode command builder. The Claude Code builder already forwards `TB_N_CONCURRENT`.

Validation:

- `bash Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh`
- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` (75 tests)
- All `Agents/utils/common/Harbor/tests/test_*.sh`
- `python3 scripts/tests/test_run_fleet.py` (56 tests)
- DinD prompt dry-run produced `TOTAL_WORKERS=20` and `TB_N_CONCURRENT=20`.
- DinD Harbor dry-run produced `--n-concurrent 20` for `terminal-bench/terminal-bench-2-1`.
