### PR TITLE
feat(harbor): add qz sandbox provider (E2B-compatible)

### DIFF
--- a/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
+++ b/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
@@ -1,0 +1,90 @@
+# qz Sandbox Quick Start
+
+This guide runs Harbor tasks in qz (SII Inspire, qz.sii.edu.cn) sandboxes:
+each task executes in an isolated, disposable sandbox instance managed by the
+platform.
+
+## Prerequisites
+
+- A qz platform account that belongs to a project.
+- A machine on the SII internal network (it must reach
+  `qz-sbx-api.sii.edu.cn`), for example a platform CPU Notebook.
+- `./scripts/setup.sh` has been run from the repository root, and the model
+  gateway is configured (`BASE_URL` / `API_KEY` / `MODEL` in
+  `config.local.env`).
+
+## Platform-side setup (web console)
+
+Entry point: 作业中心 (Job Center) → Sandbox.
+
+1. **Create a Sandbox Key** on the「Sandbox Key」tab and copy the key
+   (starts with `sbx_`).
+2. **Create a Template** (the sandbox boot image) on the「Template 列表」tab:
+   - Name: letters, digits, and underscores only;
+   - Compute spec: fixed on the Template (e.g. g.c2 = 2 vCPU / 8 GB); create
+     another Template for a different spec;
+   - Sandbox Key: must be the key from step 1 — Templates are bound to a key;
+   - Image: an official image (e.g. `sandbox-base`, Ubuntu 24.04 +
+     Python 3.12), or a custom image pushed to the platform image registry
+     (镜像管理) first.
+3. Wait until the Template status is ready.
+
+## Repository-side configuration
+
+Add to `config.local.env` (never commit the key):
+
+```bash
+RL_ENVIRONMENT_TYPE=qz
+SBX_API_KEY=sbx_xxx                # from step 1
+QZ_SANDBOX_TEMPLATE=your_template  # Template name (or ID) from step 2
+# QZ_SANDBOX_TIMEOUT_SEC=14400     # max sandbox lifetime; 4h is the platform cap
+```
+
+If a Harbor runner environment was installed before this provider existed,
+rebuild it once:
+
+```bash
+rm -rf ~/.local/share/agent-fleet/harbor-runner
+bash Agents/utils/common/Harbor/setup_runner_env.sh
+```
+
+## Run one task
+
+```bash
+cd Agents/utils/common/Harbor
+
+AGENT=claude-code \
+DATASET_NAME=auto \
+DATASET_PATH=/absolute/path/to/Harbor-Dataset \
+INCLUDE_TASKS=0 \
+TOTAL_WORKERS=1 \
+TB_N_CONCURRENT=1 \
+bash start.sh
+```
+
+Scale up the worker count after a single task passes.
+
+## Limitations
+
+- Tasks must be **single-container with a prebuilt image**
+  (`environment.docker_image` in `task.toml`); docker-compose tasks and
+  on-the-fly Dockerfile builds are not supported — the environment image must
+  be registered as a Template beforehand.
+- All tasks share the Template named by `QZ_SANDBOX_TEMPLATE`; datasets with
+  one environment per task need a Template per task, and a batch registration
+  flow is not available yet.
+- Task network policies (no-network / allowlist) are not verified on qz yet;
+  do not rely on network isolation for now.
+
+## Troubleshooting
+
+| Error | Cause and fix |
+| --- | --- |
+| `template 'xxx' not found` | Name misspelled, or the Template is bound to a different key |
+| `Timeout cannot be greater than 4 hours` | Lower `QZ_SANDBOX_TIMEOUT_SEC` to 14400 or below |
+| `No available resources` | Platform pool is full; retry later, contact the platform if it persists |
+| Connection timeout / DNS failure | The machine is not on the SII internal network |
+| 401 | The key is invalid or deleted; check the「Sandbox Key」page |
+
+Protocol details and the adapter implementation live in the module docstring
+of `qz_e2b_sandbox.py`.

--- a/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
+++ b/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
@@ -74,9 +74,12 @@ pipeline.
   (`environment.docker_image` in `task.toml`); docker-compose tasks and
   on-the-fly Dockerfile builds are not supported — the environment image must
   be registered as a Template beforehand.
-- All tasks share the Template named by `QZ_SANDBOX_TEMPLATE`; datasets with
-  one environment per task need a Template per task, and a batch registration
-  flow is not available yet.
+- Fixed-template mode is intentional in this first provider version: all tasks
+  share the Template named by `QZ_SANDBOX_TEMPLATE`. A run may contain one task
+  or multiple tasks that use the same environment image; the operator is
+  responsible for selecting a compatible Template. Datasets with a different
+  environment per task require the follow-up content-addressed Template
+  registration and mapping pipeline.
 - Task network policies (no-network / allowlist) are not verified on qz yet;
   do not rely on network isolation for now.
 

--- a/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
+++ b/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
@@ -53,7 +53,7 @@ bash Agents/utils/common/Harbor/setup_runner_env.sh
 ```bash
 cd Agents/utils/common/Harbor
 
-AGENT=claude-code \
+AGENT=oracle \
 DATASET_NAME=auto \
 DATASET_PATH=/absolute/path/to/Harbor-Dataset \
 INCLUDE_TASKS=0 \
@@ -62,7 +62,11 @@ TB_N_CONCURRENT=1 \
 bash start.sh
 ```
 
-Scale up the worker count after a single task passes.
+Scale up the worker count after a single task passes. The launcher currently
+accepts `AGENT=oracle` only on qz: the claude-code/opencode delivery
+mechanisms (runner-local wheel server, hook bind mounts) cannot reach a qz
+sandbox, and agent runtime delivery lands together with the per-task template
+pipeline.
 
 ## Limitations
 

--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -3,7 +3,8 @@
 This directory contains the shared Harbor runner for Claude Code and OpenCode.
 
 For YiCloud OpenSandbox, start with the
-[OpenSandbox quick start](OPENSANDBOX_README.md).
+[OpenSandbox quick start](OPENSANDBOX_README.md). For qz (SII Inspire)
+sandboxes, start with the [qz Sandbox quick start](QZ_SANDBOX_README.md).
 
 The normal workflow is:
 

--- a/Agents/utils/common/Harbor/e2b_runtime.py
+++ b/Agents/utils/common/Harbor/e2b_runtime.py
@@ -308,7 +308,8 @@ def patch_e2b_verifier_tools_from_env() -> bool:
     and E2B template construction unchanged.
     """
 
-    if os.environ.get("TB_ENVIRONMENT_TYPE", "docker").strip().lower() != "e2b":
+    environment_type = os.environ.get("TB_ENVIRONMENT_TYPE", "docker").strip().lower()
+    if environment_type not in {"e2b", "qz"}:
         return False
 
     raw_source = os.environ.get("TB_E2B_VERIFIER_UV_SOURCE", "").strip()

--- a/Agents/utils/common/Harbor/e2b_runtime.py
+++ b/Agents/utils/common/Harbor/e2b_runtime.py
@@ -149,6 +149,9 @@ def patch_e2b_sandbox_timeout_from_env() -> bool:
     its public environment or trial configuration.
     """
 
+    # The cap is E2B-specific: on a mixed rollout host, qz workers inherit
+    # TB_E2B_SANDBOX_TIMEOUT_SEC too, and the qz adapter manages its own
+    # QZ_SANDBOX_TIMEOUT_SEC against the platform's 4-hour maximum.
     if os.environ.get("TB_ENVIRONMENT_TYPE", "docker").strip().lower() != "e2b":
         return False
 

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -372,7 +372,8 @@ export YICLOUD_SANDBOX_LIFECYCLE_MINUTES
 # qz (SII Inspire) E2B-compatible sandbox connection. Values usually come from
 # config.local.env; re-export here so shell-provided values survive into
 # worker panes. The qz adapter maps SBX_*/QZ_SANDBOX_* onto the official e2b
-# SDK and fills E2B_* only where unset.
+# SDK. Those qz values override ambient cloud-E2B connection and transport
+# settings inside a qz process; E2B_API_KEY remains a key-only fallback.
 QZ_SANDBOX_API_KEY="${QZ_SANDBOX_API_KEY:-}"
 QZ_SANDBOX_API_URL="${QZ_SANDBOX_API_URL:-}"
 QZ_SANDBOX_TEMPLATE="${QZ_SANDBOX_TEMPLATE:-}"

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -368,6 +368,20 @@ export YICLOUD_SANDBOX_S3_DIRECTORY_COMPRESSION
 export YICLOUD_SANDBOX_S3CMD
 export YICLOUD_SANDBOX_CPU YICLOUD_SANDBOX_MEMORY
 export YICLOUD_SANDBOX_LIFECYCLE_MINUTES
+
+# qz (SII Inspire) E2B-compatible sandbox connection. Values usually come from
+# config.local.env; re-export here so shell-provided values survive into
+# worker panes. The qz adapter maps SBX_*/QZ_SANDBOX_* onto the official e2b
+# SDK and fills E2B_* only where unset.
+QZ_SANDBOX_API_KEY="${QZ_SANDBOX_API_KEY:-}"
+QZ_SANDBOX_API_URL="${QZ_SANDBOX_API_URL:-}"
+QZ_SANDBOX_TEMPLATE="${QZ_SANDBOX_TEMPLATE:-}"
+QZ_SANDBOX_TIMEOUT_SEC="${QZ_SANDBOX_TIMEOUT_SEC:-}"
+SBX_API_KEY="${SBX_API_KEY:-}"
+SBX_API_URL="${SBX_API_URL:-}"
+export QZ_SANDBOX_API_KEY QZ_SANDBOX_API_URL QZ_SANDBOX_TEMPLATE
+export QZ_SANDBOX_TIMEOUT_SEC SBX_API_KEY SBX_API_URL
+
 UV_INDEX_URL="${UV_INDEX_URL:-$PIP_INDEX_URL}"
 UV_DEFAULT_INDEX="${UV_DEFAULT_INDEX:-$UV_INDEX_URL}"
 
@@ -482,13 +496,17 @@ RL_ENABLE_SUMMARIZE="${RL_ENABLE_SUMMARIZE:-false}"
 
 # Harbor accepts either a built-in environment name or a module:Class import
 # path. YiCloud uses its own OpenAPI SDK and OGW signing, so it is loaded as a
-# provider adapter without patching the PyPI Harbor package.
+# provider adapter without patching the PyPI Harbor package. qz (SII Inspire)
+# exposes an E2B-compatible control plane, so its adapter reuses Harbor's E2B
+# environment with qz connection settings mapped onto the official e2b SDK.
 TB_ENVIRONMENT_TYPE="${TB_ENVIRONMENT_TYPE:-$RL_ENVIRONMENT_TYPE}"
 if [[ -z "${TB_ENVIRONMENT_SPEC:-}" ]]; then
   if [[ "$TB_ENVIRONMENT_TYPE" == "opensandbox" ]]; then
     TB_ENVIRONMENT_SPEC="yicloud_opensandbox:YiCloudOpenSandboxEnvironment"
   elif [[ "$TB_ENVIRONMENT_TYPE" == "e2b" && -n "$TB_E2B_PREBUILT_TEMPLATE" ]]; then
     TB_ENVIRONMENT_SPEC="$HARBOR_E2B_PREBUILT_ENVIRONMENT_SPEC"
+  elif [[ "$TB_ENVIRONMENT_TYPE" == "qz" ]]; then
+    TB_ENVIRONMENT_SPEC="qz_e2b_sandbox:QzSandboxEnvironment"
   else
     TB_ENVIRONMENT_SPEC="$TB_ENVIRONMENT_TYPE"
   fi

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -1246,9 +1246,10 @@ harbor_write_effective_wheel_source() {
 }
 
 harbor_apply_effective_wheel_source() {
-  if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" ]]; then
-    # Public E2B Sandboxes cannot consume a runner-local HTTP server. Leave
-    # these unset so agent installation uses a Sandbox-reachable registry.
+  if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" || "$TB_ENVIRONMENT_TYPE" == "qz" ]]; then
+    # Public E2B Sandboxes cannot consume a runner-local HTTP server, and qz
+    # sandboxes have no route back to the runner host either. Leave these
+    # unset so agent installation uses a Sandbox-reachable registry.
     unset TB_LOCAL_WHEEL_SERVER_URL TB_LOCAL_CLAUDE_TGZ_URL
     return 0
   fi

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -373,7 +373,8 @@ export YICLOUD_SANDBOX_LIFECYCLE_MINUTES
 # config.local.env; re-export here so shell-provided values survive into
 # worker panes. The qz adapter maps SBX_*/QZ_SANDBOX_* onto the official e2b
 # SDK. Those qz values override ambient cloud-E2B connection and transport
-# settings inside a qz process; E2B_API_KEY remains a key-only fallback.
+# settings inside a qz process; E2B_API_KEY remains a fallback only when it
+# contains an sbx_-prefixed qz key.
 QZ_SANDBOX_API_KEY="${QZ_SANDBOX_API_KEY:-}"
 QZ_SANDBOX_API_URL="${QZ_SANDBOX_API_URL:-}"
 QZ_SANDBOX_TEMPLATE="${QZ_SANDBOX_TEMPLATE:-}"

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -274,6 +274,13 @@ validate_environment_backend() {
         echo '[ERROR] agent runtime delivery for qz lands with the per-task template pipeline' >&2
         exit 1
       fi
+      case "${TB_FORCE_BUILD:-0}" in
+        0|false|no|"") ;;
+        *)
+          echo '[ERROR] TB_FORCE_BUILD is not supported on qz: templates are registered on the platform, not built by Harbor' >&2
+          exit 1
+          ;;
+      esac
       echo "[INFO] qz sandbox template: $QZ_SANDBOX_TEMPLATE"
       ;;
     *)

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -476,7 +476,11 @@ configure_e2b_verifier_uv_upload() {
   if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" || "$TB_ENVIRONMENT_TYPE" == "qz" ]] \
     && verifier_uv_bin_ready; then
     TB_E2B_VERIFIER_UV_SOURCE="$VERIFIER_UV_BIN_DIR_SOURCE"
-    echo "[INFO] ${TB_ENVIRONMENT_TYPE} verifier uv tools will be uploaded after sandbox start"
+    if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" ]]; then
+      echo "[INFO] E2B verifier uv tools will be uploaded after sandbox start"
+    else
+      echo "[INFO] qz verifier uv tools will be uploaded after sandbox start"
+    fi
   fi
   export TB_E2B_VERIFIER_UV_SOURCE
 }

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -251,8 +251,28 @@ validate_environment_backend() {
         fi
       fi
       ;;
+    qz)
+      if [[ -z "${SBX_API_KEY:-}" && -z "${QZ_SANDBOX_API_KEY:-}" \
+        && -z "${E2B_API_KEY:-}" ]]; then
+        echo '[ERROR] qz sandbox requires SBX_API_KEY (or QZ_SANDBOX_API_KEY / E2B_API_KEY)' >&2
+        exit 1
+      fi
+      if [[ -z "${QZ_SANDBOX_TEMPLATE:-}" ]]; then
+        echo '[ERROR] qz sandbox requires QZ_SANDBOX_TEMPLATE: a platform-registered template name or ID' >&2
+        echo '[ERROR] per-task template registration is not available yet' >&2
+        exit 1
+      fi
+      if [[ -n "${QZ_SANDBOX_TIMEOUT_SEC:-}" ]]; then
+        if [[ ! "$QZ_SANDBOX_TIMEOUT_SEC" =~ ^[0-9]+$ ]] \
+          || (( QZ_SANDBOX_TIMEOUT_SEC < 1 || QZ_SANDBOX_TIMEOUT_SEC > 14400 )); then
+          echo "[ERROR] QZ_SANDBOX_TIMEOUT_SEC must be an integer between 1 and 14400 (the platform's 4-hour cap), got: $QZ_SANDBOX_TIMEOUT_SEC" >&2
+          exit 1
+        fi
+      fi
+      echo "[INFO] qz sandbox template: $QZ_SANDBOX_TEMPLATE"
+      ;;
     *)
-      echo "[ERROR] TB_ENVIRONMENT_TYPE must be docker, e2b, or opensandbox, got: $TB_ENVIRONMENT_TYPE" >&2
+      echo "[ERROR] TB_ENVIRONMENT_TYPE must be docker, e2b, opensandbox, or qz, got: $TB_ENVIRONMENT_TYPE" >&2
       exit 1
       ;;
   esac
@@ -349,6 +369,9 @@ append_environment_backend_args() {
       --ek "lifecycle_minutes=$YICLOUD_SANDBOX_LIFECYCLE_MINUTES"
     )
   else
+    # qz needs no extra args: the adapter reads its connection and template
+    # settings from the exported qz environment variables, and the compose
+    # overlay helper self-guards on the Docker backend.
     append_harbor_unprivileged_docker_compose
   fi
 }

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -253,8 +253,8 @@ validate_environment_backend() {
       ;;
     qz)
       if [[ -z "${SBX_API_KEY:-}" && -z "${QZ_SANDBOX_API_KEY:-}" \
-        && -z "${E2B_API_KEY:-}" ]]; then
-        echo '[ERROR] qz sandbox requires SBX_API_KEY (or QZ_SANDBOX_API_KEY / E2B_API_KEY)' >&2
+        && "${E2B_API_KEY:-}" != sbx_* ]]; then
+        echo '[ERROR] qz sandbox requires SBX_API_KEY (or QZ_SANDBOX_API_KEY / an sbx_-prefixed E2B_API_KEY)' >&2
         exit 1
       fi
       if [[ -z "${QZ_SANDBOX_TEMPLATE:-}" ]]; then

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -269,6 +269,11 @@ validate_environment_backend() {
           exit 1
         fi
       fi
+      if ! harbor_agent_is_oracle; then
+        echo "[ERROR] qz currently supports AGENT=oracle only: the claude-code/opencode delivery mechanisms (wheel server, hook bind mounts) cannot reach a qz sandbox" >&2
+        echo '[ERROR] agent runtime delivery for qz lands with the per-task template pipeline' >&2
+        exit 1
+      fi
       echo "[INFO] qz sandbox template: $QZ_SANDBOX_TEMPLATE"
       ;;
     *)
@@ -461,9 +466,10 @@ verifier_uv_bin_ready() {
 
 configure_e2b_verifier_uv_upload() {
   TB_E2B_VERIFIER_UV_SOURCE=""
-  if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" ]] && verifier_uv_bin_ready; then
+  if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" || "$TB_ENVIRONMENT_TYPE" == "qz" ]] \
+    && verifier_uv_bin_ready; then
     TB_E2B_VERIFIER_UV_SOURCE="$VERIFIER_UV_BIN_DIR_SOURCE"
-    echo "[INFO] E2B verifier uv tools will be uploaded after sandbox start"
+    echo "[INFO] ${TB_ENVIRONMENT_TYPE} verifier uv tools will be uploaded after sandbox start"
   fi
   export TB_E2B_VERIFIER_UV_SOURCE
 }
@@ -760,7 +766,8 @@ run_oracle_task() {
     cmd+=( --path "$TB_PATH" )
   fi
   append_environment_backend_args
-  if [[ "$TB_ENVIRONMENT_TYPE" != "e2b" ]] && verifier_uv_bin_ready; then
+  if [[ "$TB_ENVIRONMENT_TYPE" != "e2b" && "$TB_ENVIRONMENT_TYPE" != "qz" ]] \
+    && verifier_uv_bin_ready; then
     local verifier_mounts_json verifier_uv_path_prefix
     verifier_mounts_json="$(
       python3 - "$VERIFIER_UV_BIN_DIR_SOURCE" "$TB_VERIFIER_UV_BIN_DIR_MOUNT_PATH" <<'PY'
@@ -785,7 +792,8 @@ PY
       --ve "TB_VERIFIER_UV_BIN_DIR=$TB_VERIFIER_UV_BIN_DIR_MOUNT_PATH"
     )
   fi
-  if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" ]] && verifier_uv_bin_ready; then
+  if [[ "$TB_ENVIRONMENT_TYPE" == "e2b" || "$TB_ENVIRONMENT_TYPE" == "qz" ]] \
+    && verifier_uv_bin_ready; then
     local verifier_uv_path_prefix
     verifier_uv_path_prefix="/root/.local/bin:/home/oai/.local/bin:/home/agent/.local/bin:/home/ubuntu/.local/bin"
     if [[ -n "${TB_VERIFIER_UV_HOME:-}" ]]; then
@@ -908,7 +916,8 @@ run_tb() {
     echo "[ERROR] current TB_LLM_KWARGS: $TB_LLM_KWARGS" >&2
     exit 1
   fi
-  if [[ "$TB_ENVIRONMENT_TYPE" == "docker" || "$TB_ENVIRONMENT_TYPE" == "e2b" || "$TB_ENVIRONMENT_TYPE" == "opensandbox" ]]; then
+  if [[ "$TB_ENVIRONMENT_TYPE" == "docker" || "$TB_ENVIRONMENT_TYPE" == "e2b" \
+    || "$TB_ENVIRONMENT_TYPE" == "opensandbox" || "$TB_ENVIRONMENT_TYPE" == "qz" ]]; then
     VERIFIER_UV_BIN_DIR_SOURCE="$(mktemp -d "${RUNTIME_DIR%/}/verifier-uv.${job_name}.XXXXXX" 2>/dev/null || true)"
     if [[ -n "$VERIFIER_UV_BIN_DIR_SOURCE" ]]; then
       prepare_verifier_uv_bin "$VERIFIER_UV_BIN_DIR_SOURCE" || true

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 
 from harbor.environments.capabilities import (
     EnvironmentCapabilities,
@@ -290,7 +291,7 @@ class QzSandboxEnvironment(E2BEnvironment):
         )
 
     @_retry_create
-    async def _create_sandbox(self) -> None:
+    async def _allocate_sandbox(self):
         # Mirrors E2BEnvironment._create_sandbox with the sandbox timeout made
         # configurable: the platform caps it at 4 hours while the base class
         # hardcodes 24h.
@@ -300,7 +301,7 @@ class QzSandboxEnvironment(E2BEnvironment):
         timeout_sec = qz_sandbox_timeout_sec()
         # Pass the qz connection explicitly so sandbox creation is immune to
         # ambient E2B_* values on a mixed-provider host.
-        self._sandbox = await AsyncSandbox.create(
+        return await AsyncSandbox.create(
             template=self._template_name,
             api_key=os.environ.get("E2B_API_KEY") or None,
             api_url=os.environ.get("E2B_API_URL") or None,
@@ -314,6 +315,26 @@ class QzSandboxEnvironment(E2BEnvironment):
             ),
             network=self._sandbox_create_network_options(),
         )
+
+    async def _create_sandbox(self) -> None:
+        self._sandbox = await self._allocate_sandbox()
+
+        # Platform templates may be generic images that do not contain
+        # Harbor's task workdir. Prepare it after allocation, outside the
+        # allocation retry boundary: a transport failure here must not create
+        # a second sandbox and orphan the first one.
+        workdir = shlex.quote(str(self._workdir))
+        result = await self._sandbox.commands.run(
+            f"mkdir -p -- {workdir} && chmod 0777 -- {workdir}",
+            user="root",
+            cwd="/",
+            timeout=30,
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to prepare task workdir {self._workdir}: "
+                f"exit {result.exit_code}: {result.stderr or result.stdout}"
+            )
 
     @classmethod
     def preflight(cls) -> None:

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -38,9 +38,35 @@ import re
 from harbor.environments.e2b import E2BEnvironment
 
 try:
-    from tenacity import retry, stop_after_attempt, wait_exponential
+    import httpcore
+    import httpx
+    from e2b.exceptions import RateLimitException
+    from tenacity import (
+        retry,
+        retry_if_exception_type,
+        stop_after_attempt,
+        wait_exponential,
+    )
 
+    # Sandbox creation is not idempotent: once the request reaches the
+    # control plane, a lost response under a blanket retry would allocate a
+    # second sandbox and orphan the first for its full lifetime (up to the
+    # 4-hour cap). Retry only failures that prove the request never got
+    # there -- connection establishment and 429s -- mirroring the
+    # dispatch-retry rationale in Harbor's E2B backend. Post-dispatch
+    # failures defer to Harbor's trial-level retry, with the platform
+    # lifetime as the orphan backstop.
+    _CREATE_RETRYABLE: tuple[type[BaseException], ...] = (
+        httpcore.ConnectError,
+        httpcore.ConnectTimeout,
+        httpcore.PoolTimeout,
+        httpx.ConnectError,
+        httpx.ConnectTimeout,
+        httpx.PoolTimeout,
+        RateLimitException,
+    )
     _retry_create = retry(
+        retry=retry_if_exception_type(_CREATE_RETRYABLE),
         stop=stop_after_attempt(2),
         wait=wait_exponential(multiplier=1, min=1, max=10),
         reraise=True,

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -1,0 +1,248 @@
+"""qz (SII Inspire) sandbox provider adapter for Harbor's E2B environment.
+
+The qz sandbox service (``https://qz-sbx-api.sii.edu.cn``) is a self-hosted
+E2B-compatible control plane: the REST surface is E2B's (``NewSandbox`` with
+``templateID``, ``X-API-Key`` auth, template aliases) mounted under a ``/v1``
+prefix, and the platform's own ``inspire_sandbox`` SDK is a rebranded E2B
+Python SDK driven by ``SBX_API_KEY`` / ``SBX_API_URL``. Harbor 0.18 already
+ships an E2B environment backed by the official ``e2b`` SDK, which supports
+self-hosted deployments through ``E2B_API_URL`` / ``E2B_SANDBOX_URL``
+overrides, so this adapter only maps qz configuration onto the official SDK
+and reuses the complete E2B environment implementation.
+
+Verified end to end against the live service (2026-08-13, template
+``agent_fleet_probe``): create, get_info, exec with cwd/env/user overrides,
+file write/read round-trip, and kill all pass through the official SDK with
+the mappings below. The qz-specific deltas:
+
+- ``POST /v1/sandboxes`` accepts E2B ``NewSandbox`` bodies; ``templateID`` is
+  required. Templates are registered on the platform (image + spec + key
+  binding); the e2b ``/v2/templates`` build flow is not mounted.
+- The auth header is ``X-API-Key``. Keys use an ``sbx_`` prefix, so the SDK's
+  default ``e2b_`` prefix validation must stay disabled.
+- The official ``e2b`` SDK reaches the control plane once ``E2B_API_URL``
+  includes the ``/v1`` prefix; ``SBX_API_URL`` follows the platform docs and
+  stays prefix-free, so the mapping below appends it.
+- The envd data plane host is ``sbx-{port}-{sandbox_id}.{sandbox_domain}``
+  (the create response's ``hostTemplate``). The SDK builds the host without
+  the ``sbx-`` prefix and does not consume ``hostTemplate``; the unprefixed
+  host lands on the platform gateway's own auth (401), so ``get_host`` is
+  patched here.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from harbor.environments.e2b import E2BEnvironment
+
+try:
+    from tenacity import retry, stop_after_attempt, wait_exponential
+
+    _retry_create = retry(
+        stop=stop_after_attempt(2),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    )
+except ImportError:  # unit tests run without the harbor/e2b dependency set
+
+    def _retry_create(fn):
+        return fn
+
+
+QZ_DEFAULT_API_URL = "https://qz-sbx-api.sii.edu.cn"
+QZ_DEFAULT_HOST_PREFIX = "sbx-"
+# The platform rejects sandbox timeouts above 4 hours ("Timeout cannot be
+# greater than 4 hours"), while Harbor's E2B backend hardcodes 24h.
+QZ_MAX_SANDBOX_TIMEOUT_SEC = 4 * 60 * 60
+QZ_DEFAULT_SANDBOX_TIMEOUT_SEC = QZ_MAX_SANDBOX_TIMEOUT_SEC
+_API_VERSION_SUFFIX = "/v1"
+
+
+def qz_sandbox_timeout_sec() -> int:
+    """Resolve and validate QZ_SANDBOX_TIMEOUT_SEC.
+
+    Rejects bad values up front: a non-numeric or out-of-range setting would
+    otherwise surface deep inside trial startup (ValueError) or as retried
+    platform 400s.
+    """
+    raw = os.environ.get("QZ_SANDBOX_TIMEOUT_SEC", "").strip()
+    if not raw:
+        return QZ_DEFAULT_SANDBOX_TIMEOUT_SEC
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"QZ_SANDBOX_TIMEOUT_SEC must be an integer, got {raw!r}"
+        ) from None
+    if not 1 <= value <= QZ_MAX_SANDBOX_TIMEOUT_SEC:
+        raise ValueError(
+            "QZ_SANDBOX_TIMEOUT_SEC must be between 1 and "
+            f"{QZ_MAX_SANDBOX_TIMEOUT_SEC} (the platform's 4-hour cap), "
+            f"got {value}"
+        )
+    return value
+_TEMPLATE_NAME_ALLOWED = re.compile(r"[^A-Za-z0-9_]")
+
+
+def sanitize_template_name(name: str) -> str:
+    """Fold a Harbor template alias onto qz's allowed alphabet.
+
+    qz template names accept only letters, digits, and underscores, while
+    Harbor's auto-generated aliases ({task}__{hash}) routinely contain
+    hyphens.
+    """
+    return _TEMPLATE_NAME_ALLOWED.sub("_", name)
+
+
+def _qz_api_key() -> str:
+    return (
+        os.environ.get("QZ_SANDBOX_API_KEY", "").strip()
+        or os.environ.get("SBX_API_KEY", "").strip()
+    )
+
+
+def _qz_api_url() -> str:
+    return (
+        os.environ.get("QZ_SANDBOX_API_URL", "").strip()
+        or os.environ.get("SBX_API_URL", "").strip()
+        or QZ_DEFAULT_API_URL
+    )
+
+
+def _e2b_api_url(qz_url: str) -> str:
+    base = qz_url.rstrip("/")
+    if base.endswith(_API_VERSION_SUFFIX):
+        return base
+    return base + _API_VERSION_SUFFIX
+
+
+def apply_qz_environment() -> None:
+    """Map qz sandbox settings onto the official e2b SDK's environment.
+
+    Explicitly set ``E2B_*`` values always win so a mixed configuration keeps
+    working; only the gaps are filled from the qz-flavored variables.
+    """
+    # Empty strings count as unset: env.sh exports empty placeholders so the
+    # variables survive into worker panes even when unconfigured.
+    key = _qz_api_key()
+    if key and not os.environ.get("E2B_API_KEY"):
+        os.environ["E2B_API_KEY"] = key
+    if not os.environ.get("E2B_API_URL"):
+        os.environ["E2B_API_URL"] = _e2b_api_url(_qz_api_url())
+    # qz keys use the sbx_ prefix, which the SDK's default e2b_ prefix
+    # validation would reject before any request is sent.
+    if not os.environ.get("E2B_VALIDATE_API_KEY"):
+        os.environ["E2B_VALIDATE_API_KEY"] = "false"
+
+
+def patch_envd_host() -> None:
+    """Point the SDK's envd host at qz's ``sbx-``-prefixed route.
+
+    An E2B_SANDBOX_URL override still wins: the SDK consults it before
+    calling ``get_host``. Idempotent; a no-op when the e2b extra is missing
+    (E2BEnvironment's own import guard reports that case).
+    """
+    try:
+        from e2b.connection_config import ConnectionConfig
+    except ImportError:
+        return
+    if getattr(ConnectionConfig, "_qz_host_patched", False):
+        return
+
+    def get_host(self, sandbox_id: str, sandbox_domain: str, port: int) -> str:
+        prefix = (
+            os.environ.get("QZ_SANDBOX_HOST_PREFIX") or QZ_DEFAULT_HOST_PREFIX
+        )
+        return f"{prefix}{port}-{sandbox_id}.{sandbox_domain or self.domain}"
+
+    ConnectionConfig.get_host = get_host
+    ConnectionConfig._qz_host_patched = True
+
+
+class QzSandboxEnvironment(E2BEnvironment):
+    """Run one Harbor task in a qz (SII Inspire) managed E2B sandbox.
+
+    Templates must be pre-registered on the platform (image + spec + key
+    binding); qz does not mount the e2b remote build API. The template is
+    resolved as: explicit ``template`` kwarg or ``QZ_SANDBOX_TEMPLATE`` when
+    set, else Harbor's auto-generated per-task alias folded onto qz's allowed
+    name alphabet.
+    """
+
+    def __init__(self, *args, template: str | None = None, **kwargs) -> None:
+        apply_qz_environment()
+        patch_envd_host()
+        self._template_override = (
+            template
+            if template is not None
+            else os.environ.get("QZ_SANDBOX_TEMPLATE", "")
+        ).strip()
+        super().__init__(*args, **kwargs)
+        if self._template_override:
+            self._template_name = self._template_override
+        else:
+            self._template_name = sanitize_template_name(self._template_name)
+
+    async def start(self, force_build: bool) -> None:
+        if force_build:
+            self.logger.warning(
+                "qz sandbox ignores force_build; templates are registered on "
+                "the platform, not built by Harbor."
+            )
+        await super().start(False)
+
+    async def _does_template_exist(self) -> bool:
+        # An explicit override may be a template alias or a template ID. The
+        # alias lookup can't see IDs, so trust the override and let sandbox
+        # creation be the authority -- the platform returns a clear
+        # "template 'xxx' not found" for a bad value, which beats failing the
+        # pre-check and misreporting "register the template first".
+        if self._template_override:
+            return True
+        return await super()._does_template_exist()
+
+    async def _create_template(self) -> None:
+        raise RuntimeError(
+            "qz sandbox does not expose the e2b template build API. Register "
+            f"template {self._template_name!r} on the platform first (image + "
+            "spec + sandbox key binding), or point QZ_SANDBOX_TEMPLATE at an "
+            "existing template."
+        )
+
+    @_retry_create
+    async def _create_sandbox(self) -> None:
+        # Mirrors E2BEnvironment._create_sandbox with the sandbox timeout made
+        # configurable: the platform caps it at 4 hours while the base class
+        # hardcodes 24h.
+        from e2b import AsyncSandbox
+        from harbor.models.task.config import NetworkMode
+
+        timeout_sec = qz_sandbox_timeout_sec()
+        self._sandbox = await AsyncSandbox.create(
+            template=self._template_name,
+            metadata={
+                "environment_name": self.environment_name,
+                "session_id": self.session_id,
+            },
+            timeout=timeout_sec,
+            allow_internet_access=(
+                self.network_policy.network_mode != NetworkMode.NO_NETWORK
+            ),
+            network=self._sandbox_create_network_options(),
+        )
+
+    @classmethod
+    def preflight(cls) -> None:
+        apply_qz_environment()
+        patch_envd_host()
+        if not os.environ.get("E2B_API_KEY"):
+            raise SystemExit(
+                "qz sandbox requires an API key: set SBX_API_KEY (or "
+                "QZ_SANDBOX_API_KEY / E2B_API_KEY) before starting the runner."
+            )
+        try:
+            qz_sandbox_timeout_sec()
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -88,6 +88,15 @@ QZ_DEFAULT_HOST_PREFIX = "sbx-"
 QZ_MAX_SANDBOX_TIMEOUT_SEC = 4 * 60 * 60
 QZ_DEFAULT_SANDBOX_TIMEOUT_SEC = QZ_MAX_SANDBOX_TIMEOUT_SEC
 _API_VERSION_SUFFIX = "/v1"
+# These settings describe a particular cloud-E2B data plane rather than the
+# shared SDK API surface. Letting them leak into a qz process can create the
+# sandbox through qz and then send commands or files to the other provider.
+_AMBIENT_E2B_TRANSPORT_VARS = (
+    "E2B_SANDBOX_URL",
+    "E2B_DOMAIN",
+    "E2B_DEBUG",
+    "E2B_ACCESS_TOKEN",
+)
 
 
 def qz_sandbox_timeout_sec() -> int:
@@ -158,6 +167,9 @@ def apply_qz_environment() -> None:
     configured. Empty strings count as unset: env.sh exports empty
     placeholders so the variables survive into worker panes.
     """
+    for name in _AMBIENT_E2B_TRANSPORT_VARS:
+        os.environ.pop(name, None)
+
     key = _qz_api_key()
     if key:
         os.environ["E2B_API_KEY"] = key
@@ -171,9 +183,10 @@ def apply_qz_environment() -> None:
 def patch_envd_host() -> None:
     """Point the SDK's envd host at qz's ``sbx-``-prefixed route.
 
-    An E2B_SANDBOX_URL override still wins: the SDK consults it before
-    calling ``get_host``. Idempotent; a no-op when the e2b extra is missing
-    (E2BEnvironment's own import guard reports that case).
+    ``apply_qz_environment`` removes cloud-E2B transport overrides before a
+    config is constructed, so the SDK reaches this host resolver. Idempotent;
+    a no-op when the e2b extra is missing (E2BEnvironment's own import guard
+    reports that case).
     """
     try:
         from e2b.connection_config import ConnectionConfig
@@ -196,10 +209,11 @@ class QzSandboxEnvironment(E2BEnvironment):
     """Run one Harbor task in a qz (SII Inspire) managed E2B sandbox.
 
     Templates must be pre-registered on the platform (image + spec + key
-    binding); qz does not mount the e2b remote build API. The template is
-    resolved as: explicit ``template`` kwarg or ``QZ_SANDBOX_TEMPLATE`` when
-    set, else Harbor's auto-generated per-task alias folded onto qz's allowed
-    name alphabet.
+    binding); qz does not mount the e2b remote build API. An explicit
+    ``template`` kwarg or ``QZ_SANDBOX_TEMPLATE`` intentionally selects one
+    fixed template for every trial in the run, so the operator must choose
+    tasks compatible with that image. Without an override, Harbor's
+    auto-generated per-task alias is folded onto qz's allowed name alphabet.
     """
 
     def __init__(self, *args, template: str | None = None, **kwargs) -> None:

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -149,22 +149,23 @@ def _e2b_api_url(qz_url: str) -> str:
 
 
 def apply_qz_environment() -> None:
-    """Map qz sandbox settings onto the official e2b SDK's environment.
+    """Point the official e2b SDK's environment at the qz service.
 
-    Explicitly set ``E2B_*`` values always win so a mixed configuration keeps
-    working; only the gaps are filled from the qz-flavored variables.
+    qz-flavored values take precedence: on a mixed rollout host the ambient
+    ``E2B_*`` variables belong to the cloud-E2B backend, and a qz process
+    must not defer to them or its requests would go to the wrong control
+    plane. ``E2B_API_KEY`` only serves as a fallback when no qz key is
+    configured. Empty strings count as unset: env.sh exports empty
+    placeholders so the variables survive into worker panes.
     """
-    # Empty strings count as unset: env.sh exports empty placeholders so the
-    # variables survive into worker panes even when unconfigured.
     key = _qz_api_key()
-    if key and not os.environ.get("E2B_API_KEY"):
+    if key:
         os.environ["E2B_API_KEY"] = key
-    if not os.environ.get("E2B_API_URL"):
-        os.environ["E2B_API_URL"] = _e2b_api_url(_qz_api_url())
-    # qz keys use the sbx_ prefix, which the SDK's default e2b_ prefix
-    # validation would reject before any request is sent.
-    if not os.environ.get("E2B_VALIDATE_API_KEY"):
-        os.environ["E2B_VALIDATE_API_KEY"] = "false"
+    os.environ["E2B_API_URL"] = _e2b_api_url(_qz_api_url())
+    # qz keys use the sbx_ prefix, which the SDK's e2b_ prefix validation
+    # would reject client-side before any request is sent; an inherited
+    # E2B_VALIDATE_API_KEY=true from the cloud backend must not apply here.
+    os.environ["E2B_VALIDATE_API_KEY"] = "false"
 
 
 def patch_envd_host() -> None:
@@ -271,8 +272,12 @@ class QzSandboxEnvironment(E2BEnvironment):
         from harbor.models.task.config import NetworkMode
 
         timeout_sec = qz_sandbox_timeout_sec()
+        # Pass the qz connection explicitly so sandbox creation is immune to
+        # ambient E2B_* values on a mixed-provider host.
         self._sandbox = await AsyncSandbox.create(
             template=self._template_name,
+            api_key=os.environ.get("E2B_API_KEY") or None,
+            api_url=os.environ.get("E2B_API_URL") or None,
             metadata={
                 "environment_name": self.environment_name,
                 "session_id": self.session_id,

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -35,6 +35,10 @@ from __future__ import annotations
 import os
 import re
 
+from harbor.environments.capabilities import (
+    EnvironmentCapabilities,
+    EnvironmentResourceCapabilities,
+)
 from harbor.environments.e2b import E2BEnvironment
 
 try:
@@ -211,11 +215,32 @@ class QzSandboxEnvironment(E2BEnvironment):
         else:
             self._template_name = sanitize_template_name(self._template_name)
 
+    @property
+    def capabilities(self) -> EnvironmentCapabilities:
+        # Advertise only verified behavior. Network isolation (no-network /
+        # allowlist) is inherited from the E2B backend but has not been
+        # verified on qz, so declaring it unsupported rejects such tasks up
+        # front instead of running them unenforced. GPUs and host bind
+        # mounts are unavailable.
+        return EnvironmentCapabilities(
+            gpus=False, disable_internet=False, mounted=False
+        )
+
+    @classmethod
+    def resource_capabilities(cls) -> EnvironmentResourceCapabilities:
+        # The compute spec is fixed on the platform template and cannot be
+        # applied per task at create time. Declaring no support turns an
+        # explicit cpu/memory enforcement policy into a fail-fast reject,
+        # while the default AUTO policy keeps running with the template's
+        # spec.
+        return EnvironmentResourceCapabilities()
+
     async def start(self, force_build: bool) -> None:
         if force_build:
-            self.logger.warning(
-                "qz sandbox ignores force_build; templates are registered on "
-                "the platform, not built by Harbor."
+            raise RuntimeError(
+                "qz sandbox cannot rebuild templates: they are registered on "
+                "the platform, not built by Harbor. Re-register the template "
+                "and retry without force_build."
             )
         await super().start(False)
 

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -122,6 +122,8 @@ def qz_sandbox_timeout_sec() -> int:
             f"got {value}"
         )
     return value
+
+
 _TEMPLATE_NAME_ALLOWED = re.compile(r"[^A-Za-z0-9_]")
 
 
@@ -136,10 +138,19 @@ def sanitize_template_name(name: str) -> str:
 
 
 def _qz_api_key() -> str:
-    return (
+    explicit_key = (
         os.environ.get("QZ_SANDBOX_API_KEY", "").strip()
         or os.environ.get("SBX_API_KEY", "").strip()
     )
+    if explicit_key:
+        return explicit_key
+
+    # Preserve the legacy SDK-shaped configuration only when the value is
+    # unambiguously a qz key. On a mixed-provider host an e2b_-prefixed key
+    # belongs to cloud E2B; carrying it across while rewriting E2B_API_URL to
+    # qz would disclose the credential to the wrong control plane.
+    legacy_key = os.environ.get("E2B_API_KEY", "").strip()
+    return legacy_key if legacy_key.startswith("sbx_") else ""
 
 
 def _qz_api_url() -> str:
@@ -164,8 +175,9 @@ def apply_qz_environment() -> None:
     ``E2B_*`` variables belong to the cloud-E2B backend, and a qz process
     must not defer to them or its requests would go to the wrong control
     plane. ``E2B_API_KEY`` only serves as a fallback when no qz key is
-    configured. Empty strings count as unset: env.sh exports empty
-    placeholders so the variables survive into worker panes.
+    configured and it contains an unambiguous ``sbx_`` platform key. Empty
+    strings count as unset: env.sh exports empty placeholders so the variables
+    survive into worker panes.
     """
     for name in _AMBIENT_E2B_TRANSPORT_VARS:
         os.environ.pop(name, None)
@@ -173,6 +185,8 @@ def apply_qz_environment() -> None:
     key = _qz_api_key()
     if key:
         os.environ["E2B_API_KEY"] = key
+    else:
+        os.environ.pop("E2B_API_KEY", None)
     os.environ["E2B_API_URL"] = _e2b_api_url(_qz_api_url())
     # qz keys use the sbx_ prefix, which the SDK's e2b_ prefix validation
     # would reject client-side before any request is sent; an inherited
@@ -196,9 +210,7 @@ def patch_envd_host() -> None:
         return
 
     def get_host(self, sandbox_id: str, sandbox_domain: str, port: int) -> str:
-        prefix = (
-            os.environ.get("QZ_SANDBOX_HOST_PREFIX") or QZ_DEFAULT_HOST_PREFIX
-        )
+        prefix = os.environ.get("QZ_SANDBOX_HOST_PREFIX") or QZ_DEFAULT_HOST_PREFIX
         return f"{prefix}{port}-{sandbox_id}.{sandbox_domain or self.domain}"
 
     ConnectionConfig.get_host = get_host
@@ -310,7 +322,8 @@ class QzSandboxEnvironment(E2BEnvironment):
         if not os.environ.get("E2B_API_KEY"):
             raise SystemExit(
                 "qz sandbox requires an API key: set SBX_API_KEY (or "
-                "QZ_SANDBOX_API_KEY / E2B_API_KEY) before starting the runner."
+                "QZ_SANDBOX_API_KEY / an sbx_-prefixed E2B_API_KEY) before "
+                "starting the runner."
             )
         try:
             qz_sandbox_timeout_sec()

--- a/Agents/utils/common/Harbor/runner-requirements.txt
+++ b/Agents/utils/common/Harbor/runner-requirements.txt
@@ -6,3 +6,6 @@ opik==2.1.32
 pip==25.2
 s3cmd==2.4.0
 yicloud-sdk-python==0.3.1
+# qz (SII Inspire) E2B-compatible sandbox provider (harbor[e2b] extra, pinned).
+e2b==2.38.0
+dockerfile-parse==2.0.1

--- a/Agents/utils/common/Harbor/runner-requirements.txt
+++ b/Agents/utils/common/Harbor/runner-requirements.txt
@@ -1,11 +1,11 @@
 # Direct dependencies of the Harbor runner control environment.
 # Keep this list small; task-container dependencies are prepared separately.
 harbor==0.18.0
+# e2b serves both the cloud E2B backend and the qz provider; dockerfile-parse
+# completes the harbor[e2b] extra.
 e2b==2.32.1
+dockerfile-parse==2.0.1
 opik==2.1.32
 pip==25.2
 s3cmd==2.4.0
 yicloud-sdk-python==0.3.1
-# qz (SII Inspire) E2B-compatible sandbox provider (harbor[e2b] extra, pinned).
-e2b==2.38.0
-dockerfile-parse==2.0.1

--- a/Agents/utils/common/Harbor/tests/test_e2b_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_e2b_runtime.py
@@ -116,10 +116,14 @@ class E2BRuntimeTest(unittest.TestCase):
         fake_e2b = types.SimpleNamespace(AsyncSandbox=FakeAsyncSandbox)
         with patch.dict(sys.modules, {"e2b": fake_e2b}), patch.dict(
             os.environ,
-            {
-                "TB_ENVIRONMENT_TYPE": "e2b",
-                "TB_E2B_SANDBOX_TIMEOUT_SEC": "3600",
-            },
+            {"TB_ENVIRONMENT_TYPE": "qz", "TB_E2B_SANDBOX_TIMEOUT_SEC": "3600"},
+        ):
+            # The cap is E2B-specific; a qz worker inheriting the variable on
+            # a mixed host must keep its own timeout handling.
+            self.assertFalse(MODULE.patch_e2b_sandbox_timeout_from_env())
+        with patch.dict(sys.modules, {"e2b": fake_e2b}), patch.dict(
+            os.environ,
+            {"TB_ENVIRONMENT_TYPE": "e2b", "TB_E2B_SANDBOX_TIMEOUT_SEC": "3600"},
         ):
             self.assertTrue(MODULE.patch_e2b_sandbox_timeout_from_env())
             result = asyncio.run(FakeAsyncSandbox.create(timeout=86_400))

--- a/Agents/utils/common/Harbor/tests/test_e2b_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_e2b_runtime.py
@@ -322,5 +322,35 @@ class E2BRuntimeTest(unittest.TestCase):
             ),
         )
 
+    def test_verifier_tools_patch_arms_for_qz_but_not_docker(self) -> None:
+        class FakeE2BEnvironment:
+            async def start(self, force_build: bool):
+                return "started"
+
+            async def exec(self, command, user=None):
+                return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+            async def upload_dir(self, source: Path, target: str):
+                return None
+
+        modules = fake_runtime_modules(FakeE2BEnvironment, type("FakeTemplate", (), {}))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            for name in ("uv", "uvx", "curl"):
+                (source / name).write_text(name)
+
+            common_env = {
+                "TB_E2B_VERIFIER_UV_SOURCE": str(source),
+                "TB_VERIFIER_UV_BIN_DIR_MOUNT_PATH": "/opt/test-uv/bin",
+            }
+            with patch.dict(sys.modules, modules), patch.dict(
+                os.environ, {**common_env, "TB_ENVIRONMENT_TYPE": "qz"}
+            ):
+                self.assertTrue(MODULE.patch_e2b_verifier_tools_from_env())
+            with patch.dict(
+                os.environ, {**common_env, "TB_ENVIRONMENT_TYPE": "docker"}
+            ):
+                self.assertFalse(MODULE.patch_e2b_verifier_tools_from_env())
+
 if __name__ == "__main__":
     unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_harbor_prepare_runner_cli.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_prepare_runner_cli.py
@@ -63,6 +63,7 @@ class RunnerValidationTest(unittest.TestCase):
             f"[ \"$#\" = 2 ] && echo {python_version} && exit 0\n"
             f"[ \"$3\" = harbor ] && echo {harbor_version} && exit 0\n"
             "[ \"$3\" = e2b ] && echo 2.32.1 && exit 0\n"
+            "[ \"$3\" = dockerfile-parse ] && echo 2.0.1 && exit 0\n"
             "[ \"$3\" = opik ] && echo 2.1.32 && exit 0\n"
             "[ \"$3\" = pip ] && echo 25.2 && exit 0\n"
             "[ \"$3\" = s3cmd ] && echo 2.4.0 && exit 0\n"
@@ -76,6 +77,7 @@ class RunnerValidationTest(unittest.TestCase):
             [
                 ("harbor", "0.18.0"),
                 ("e2b", "2.32.1"),
+                ("dockerfile-parse", "2.0.1"),
                 ("opik", "2.1.32"),
                 ("pip", "25.2"),
                 ("s3cmd", "2.4.0"),

--- a/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
@@ -19,11 +19,12 @@ run_dry() {
   local sbx_api_key="$1"
   local qz_template="$2"
   local qz_timeout="${3:-}"
+  local agent="${4:-oracle}"
   env -i \
+    AGENT="$agent" \
     QZ_SANDBOX_TIMEOUT_SEC="$qz_timeout" \
     PATH="$tmp/bin:/usr/bin:/bin" \
     HOME="$tmp/home" \
-    AGENT=oracle \
     DATASET_NAME=auto \
     DATASET_PATH="$tmp/dataset" \
     INCLUDE_TASKS=0 \
@@ -52,6 +53,10 @@ if grep -F -- '--extra-docker-compose' <<< "$qz_run" >/dev/null; then
 fi
 if grep -F -- '--ek image_ref=' <<< "$qz_run" >/dev/null; then
   echo 'qz command unexpectedly contains OpenSandbox image arguments' >&2
+  exit 1
+fi
+if grep -F -- '--mounts-json' <<< "$qz_run" >/dev/null; then
+  echo 'qz command unexpectedly contains host bind mounts' >&2
   exit 1
 fi
 
@@ -85,5 +90,16 @@ done
 # A valid timeout passes through.
 valid_run="$(run_dry sbx_fake_key fake_template 600)"
 grep -F -- '--env qz_e2b_sandbox:QzSandboxEnvironment' <<< "$valid_run" >/dev/null
+
+# Non-oracle agents must fail launch validation: their delivery mechanisms
+# cannot reach a qz sandbox yet.
+for agent in claude-code opencode; do
+  if agent_run="$(run_dry sbx_fake_key fake_template '' "$agent")"; then
+    echo "qz launch unexpectedly succeeded with AGENT=$agent" >&2
+    exit 1
+  else
+    grep -F -- 'qz currently supports AGENT=oracle only' <<< "$agent_run" >/dev/null
+  fi
+done
 
 echo 'test_harboropik_qz.sh passed'

--- a/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HARBOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+
+mkdir -p "$tmp/bin" "$tmp/dataset/0/environment" "$tmp/home"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$tmp/bin/uv"
+chmod +x "$tmp/bin/uv"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$tmp/bin/uvx"
+chmod +x "$tmp/bin/uvx"
+printf '#!/usr/bin/env bash\necho "ELF 64-bit executable"\n' > "$tmp/bin/file"
+chmod +x "$tmp/bin/file"
+printf '[environment]\nbuild_timeout_sec = 60\n' > "$tmp/dataset/0/task.toml"
+printf 'FROM ubuntu:24.04\n' > "$tmp/dataset/0/environment/Dockerfile"
+
+run_dry() {
+  local sbx_api_key="$1"
+  local qz_template="$2"
+  local qz_timeout="${3:-}"
+  env -i \
+    QZ_SANDBOX_TIMEOUT_SEC="$qz_timeout" \
+    PATH="$tmp/bin:/usr/bin:/bin" \
+    HOME="$tmp/home" \
+    AGENT=oracle \
+    DATASET_NAME=auto \
+    DATASET_PATH="$tmp/dataset" \
+    INCLUDE_TASKS=0 \
+    OUTPUT_PATH="$tmp/output" \
+    TB_DRY_RUN=1 \
+    TB_N_CONCURRENT=1 \
+    TB_MAX_RETRIES=0 \
+    TB_ENVIRONMENT_TYPE=qz \
+    SBX_API_KEY="$sbx_api_key" \
+    QZ_SANDBOX_TEMPLATE="$qz_template" \
+    bash "$HARBOR_DIR/harboropik.sh" 2>&1
+}
+
+# A configured qz run passes the adapter import path and nothing docker- or
+# opensandbox-specific.
+qz_run="$(run_dry sbx_fake_key fake_template)"
+grep -F -- '--env qz_e2b_sandbox:QzSandboxEnvironment' <<< "$qz_run" >/dev/null
+if [[ "$(grep -oF -- '--env qz_e2b_sandbox:QzSandboxEnvironment' \
+  <<< "$qz_run" | wc -l | tr -d ' ')" != "1" ]]; then
+  echo 'qz command must contain exactly one qz environment argument' >&2
+  exit 1
+fi
+if grep -F -- '--extra-docker-compose' <<< "$qz_run" >/dev/null; then
+  echo 'qz command unexpectedly contains a Docker compose overlay' >&2
+  exit 1
+fi
+if grep -F -- '--ek image_ref=' <<< "$qz_run" >/dev/null; then
+  echo 'qz command unexpectedly contains OpenSandbox image arguments' >&2
+  exit 1
+fi
+
+# A missing key must fail launch validation before Harbor runs.
+if missing_key="$(run_dry '' fake_template)"; then
+  echo 'qz launch unexpectedly succeeded without an API key' >&2
+  exit 1
+else
+  grep -F -- 'qz sandbox requires SBX_API_KEY' <<< "$missing_key" >/dev/null
+fi
+
+# A missing template must fail launch validation before Harbor runs.
+if missing_template="$(run_dry sbx_fake_key '')"; then
+  echo 'qz launch unexpectedly succeeded without a template' >&2
+  exit 1
+else
+  grep -F -- 'qz sandbox requires QZ_SANDBOX_TEMPLATE' <<< "$missing_template" >/dev/null
+fi
+
+# An invalid timeout must fail launch validation before Harbor runs.
+for bad_timeout in abc 0 14401; do
+  if bad_run="$(run_dry sbx_fake_key fake_template "$bad_timeout")"; then
+    echo "qz launch unexpectedly succeeded with QZ_SANDBOX_TIMEOUT_SEC=$bad_timeout" >&2
+    exit 1
+  else
+    grep -F -- 'QZ_SANDBOX_TIMEOUT_SEC must be an integer between 1 and 14400' \
+      <<< "$bad_run" >/dev/null
+  fi
+done
+
+# A valid timeout passes through.
+valid_run="$(run_dry sbx_fake_key fake_template 600)"
+grep -F -- '--env qz_e2b_sandbox:QzSandboxEnvironment' <<< "$valid_run" >/dev/null
+
+echo 'test_harboropik_qz.sh passed'

--- a/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
@@ -20,8 +20,10 @@ run_dry() {
   local qz_template="$2"
   local qz_timeout="${3:-}"
   local agent="${4:-oracle}"
+  local force_build="${5:-0}"
   env -i \
     AGENT="$agent" \
+    TB_FORCE_BUILD="$force_build" \
     QZ_SANDBOX_TIMEOUT_SEC="$qz_timeout" \
     PATH="$tmp/bin:/usr/bin:/bin" \
     HOME="$tmp/home" \
@@ -99,6 +101,16 @@ for agent in claude-code opencode; do
     exit 1
   else
     grep -F -- 'qz currently supports AGENT=oracle only' <<< "$agent_run" >/dev/null
+  fi
+done
+
+# force_build has no meaning for platform-registered templates.
+for force_build in 1 true; do
+  if fb_run="$(run_dry sbx_fake_key fake_template '' oracle "$force_build")"; then
+    echo "qz launch unexpectedly succeeded with TB_FORCE_BUILD=$force_build" >&2
+    exit 1
+  else
+    grep -F -- 'TB_FORCE_BUILD is not supported on qz' <<< "$fb_run" >/dev/null
   fi
 done
 

--- a/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_qz.sh
@@ -21,6 +21,7 @@ run_dry() {
   local qz_timeout="${3:-}"
   local agent="${4:-oracle}"
   local force_build="${5:-0}"
+  local e2b_api_key="${6:-}"
   env -i \
     AGENT="$agent" \
     TB_FORCE_BUILD="$force_build" \
@@ -36,6 +37,7 @@ run_dry() {
     TB_MAX_RETRIES=0 \
     TB_ENVIRONMENT_TYPE=qz \
     SBX_API_KEY="$sbx_api_key" \
+    E2B_API_KEY="$e2b_api_key" \
     QZ_SANDBOX_TEMPLATE="$qz_template" \
     bash "$HARBOR_DIR/harboropik.sh" 2>&1
 }
@@ -68,6 +70,18 @@ if missing_key="$(run_dry '' fake_template)"; then
   exit 1
 else
   grep -F -- 'qz sandbox requires SBX_API_KEY' <<< "$missing_key" >/dev/null
+fi
+
+# A legacy E2B_API_KEY is accepted only when it is visibly a qz sbx_ key. An
+# ambient cloud-E2B key must fail before Harbor can send it to the qz endpoint.
+legacy_key_run="$(run_dry '' fake_template '' oracle 0 sbx_legacy_key)"
+grep -F -- '--env qz_e2b_sandbox:QzSandboxEnvironment' \
+  <<< "$legacy_key_run" >/dev/null
+if cloud_key_run="$(run_dry '' fake_template '' oracle 0 e2b_cloud_key)"; then
+  echo 'qz launch unexpectedly accepted an ambient cloud-E2B API key' >&2
+  exit 1
+else
+  grep -F -- 'qz sandbox requires SBX_API_KEY' <<< "$cloud_key_run" >/dev/null
 fi
 
 # A missing template must fail launch validation before Harbor runs.

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -390,13 +390,33 @@ class PreflightTest(unittest.TestCase):
 
 class CreateRetryTest(unittest.TestCase):
     def run_create(
-        self, failure_name: str, *, succeeds_after_failure: bool
-    ) -> tuple[int, Exception | None]:
+        self,
+        failure_name: str | None,
+        *,
+        succeeds_after_failure: bool,
+        prepare_failure_name: str | None = None,
+        prepare_exit_code: int = 0,
+    ) -> tuple[int, Exception | None, list[tuple[str, dict]]]:
         dependency_modules, error_types = retry_dependency_stubs()
-        expected_error_types = tuple(error_types.values())
-        outcomes: list[object] = [error_types[failure_name]("boom")]
+        command_calls: list[tuple[str, dict]] = []
+
+        class FakeCommands:
+            async def run(self, command, **kwargs):
+                command_calls.append((command, kwargs))
+                if prepare_failure_name is not None:
+                    raise error_types[prepare_failure_name]("prepare failed")
+                return types.SimpleNamespace(
+                    exit_code=prepare_exit_code,
+                    stderr="prepare stderr" if prepare_exit_code else "",
+                    stdout="",
+                )
+
+        sandbox = types.SimpleNamespace(commands=FakeCommands())
+        outcomes: list[object] = []
+        if failure_name is not None:
+            outcomes.append(error_types[failure_name]("boom"))
         if succeeds_after_failure:
-            outcomes.append(object())
+            outcomes.append(sandbox)
         calls: list[dict] = []
 
         class FakeAsyncSandbox:
@@ -421,32 +441,75 @@ class CreateRetryTest(unittest.TestCase):
                     os.environ.pop(name, None)
             module = load_module()
             environment = module.QzSandboxEnvironment(template="test_template")
+            environment._workdir = Path("/app")
             try:
                 asyncio.run(environment._create_sandbox())
-            except expected_error_types as exc:
+            except Exception as exc:
                 error = exc
-        return len(calls), error
+        return len(calls), error, command_calls
 
     def test_connection_failure_is_retried_once(self):
-        calls, error = self.run_create("connect", succeeds_after_failure=True)
+        calls, error, _ = self.run_create("connect", succeeds_after_failure=True)
         self.assertEqual(calls, 2)
         self.assertIsNone(error)
 
     def test_rate_limit_is_retried_once(self):
-        calls, error = self.run_create("rate_limit", succeeds_after_failure=True)
+        calls, error, _ = self.run_create("rate_limit", succeeds_after_failure=True)
         self.assertEqual(calls, 2)
         self.assertIsNone(error)
 
     def test_post_dispatch_read_timeout_is_not_retried(self):
-        calls, error = self.run_create("read_timeout", succeeds_after_failure=False)
+        calls, error, _ = self.run_create(
+            "read_timeout", succeeds_after_failure=False
+        )
         self.assertEqual(calls, 1)
         self.assertIsNotNone(error)
         self.assertEqual(type(error).__name__, "HttpxReadTimeout")
 
     def test_generic_failure_is_not_retried(self):
-        calls, error = self.run_create("generic", succeeds_after_failure=False)
+        calls, error, _ = self.run_create("generic", succeeds_after_failure=False)
         self.assertEqual(calls, 1)
         self.assertIsInstance(error, ValueError)
+
+    def test_prepares_workdir_after_allocation(self):
+        calls, error, command_calls = self.run_create(
+            None, succeeds_after_failure=True
+        )
+
+        self.assertEqual(calls, 1)
+        self.assertIsNone(error)
+        self.assertEqual(
+            command_calls,
+            [
+                (
+                    "mkdir -p -- /app && chmod 0777 -- /app",
+                    {"user": "root", "cwd": "/", "timeout": 30},
+                )
+            ],
+        )
+
+    def test_workdir_transport_failure_does_not_retry_allocation(self):
+        calls, error, command_calls = self.run_create(
+            None,
+            succeeds_after_failure=True,
+            prepare_failure_name="connect",
+        )
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(len(command_calls), 1)
+        self.assertEqual(type(error).__name__, "HttpcoreConnectError")
+
+    def test_workdir_command_failure_is_actionable(self):
+        calls, error, _ = self.run_create(
+            None,
+            succeeds_after_failure=True,
+            prepare_exit_code=23,
+        )
+
+        self.assertEqual(calls, 1)
+        self.assertIsInstance(error, RuntimeError)
+        self.assertIn("failed to prepare task workdir /app", str(error))
+        self.assertIn("exit 23: prepare stderr", str(error))
 
 
 class TemplateResolutionTest(unittest.TestCase):

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -398,6 +398,7 @@ class CreateRetryTest(unittest.TestCase):
         prepare_exit_code: int = 0,
     ) -> tuple[int, Exception | None, list[tuple[str, dict]]]:
         dependency_modules, error_types = retry_dependency_stubs()
+        expected_error_types = (*error_types.values(), RuntimeError)
         command_calls: list[tuple[str, dict]] = []
 
         class FakeCommands:
@@ -444,7 +445,7 @@ class CreateRetryTest(unittest.TestCase):
             environment._workdir = Path("/app")
             try:
                 asyncio.run(environment._create_sandbox())
-            except Exception as exc:
+            except expected_error_types as exc:
                 error = exc
         return len(calls), error, command_calls
 

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -1,0 +1,304 @@
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import patch
+
+HARBOR_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = HARBOR_DIR / "qz_e2b_sandbox.py"
+sys.path.insert(0, str(HARBOR_DIR))
+
+
+def install_harbor_stubs() -> None:
+    harbor = types.ModuleType("harbor")
+    environments = types.ModuleType("harbor.environments")
+    e2b = types.ModuleType("harbor.environments.e2b")
+
+    class E2BEnvironment:
+        init_calls: ClassVar[list[tuple[tuple, dict]]] = []
+        start_calls: ClassVar[list[bool]] = []
+        exist_calls: ClassVar[list[str]] = []
+
+        def __init__(self, *args, **kwargs):
+            type(self).init_calls.append((args, kwargs))
+            self._template_name = "hello-world__abc.123"
+
+        async def start(self, force_build: bool) -> None:
+            type(self).start_calls.append(force_build)
+
+        async def _does_template_exist(self) -> bool:
+            type(self).exist_calls.append(self._template_name)
+            return False
+
+    e2b.E2BEnvironment = E2BEnvironment
+    sys.modules.update(
+        {
+            "harbor": harbor,
+            "harbor.environments": environments,
+            "harbor.environments.e2b": e2b,
+        }
+    )
+
+
+def load_module():
+    install_harbor_stubs()
+    spec = importlib.util.spec_from_file_location("qz_e2b_sandbox", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+QZ_VARS = (
+    "QZ_SANDBOX_API_KEY",
+    "QZ_SANDBOX_API_URL",
+    "SBX_API_KEY",
+    "SBX_API_URL",
+    "E2B_API_KEY",
+    "E2B_API_URL",
+    "E2B_VALIDATE_API_KEY",
+)
+
+
+class ApplyQzEnvironmentTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+
+    def run_mapping(self, env: dict[str, str]) -> dict[str, str]:
+        cleaned = {name: "" for name in QZ_VARS}
+        cleaned.update(env)
+        with patch.dict(os.environ, cleaned, clear=False):
+            for name in QZ_VARS:
+                if not cleaned.get(name):
+                    os.environ.pop(name, None)
+            self.module.apply_qz_environment()
+            return {name: os.environ.get(name, "") for name in QZ_VARS}
+
+    def test_sbx_values_map_to_e2b_with_v1_suffix(self):
+        result = self.run_mapping(
+            {
+                "SBX_API_KEY": "sbx_secret",
+                "SBX_API_URL": "https://qz-sbx-api.sii.edu.cn",
+            }
+        )
+        self.assertEqual(result["E2B_API_KEY"], "sbx_secret")
+        self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
+        self.assertEqual(result["E2B_VALIDATE_API_KEY"], "false")
+
+    def test_defaults_apply_without_any_url(self):
+        result = self.run_mapping({"SBX_API_KEY": "sbx_secret"})
+        self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
+
+    def test_url_with_existing_v1_suffix_is_not_doubled(self):
+        result = self.run_mapping(
+            {
+                "SBX_API_KEY": "sbx_secret",
+                "SBX_API_URL": "https://qz-sbx-api.sii.edu.cn/v1/",
+            }
+        )
+        self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
+
+    def test_qz_specific_variables_win_over_sbx(self):
+        result = self.run_mapping(
+            {
+                "QZ_SANDBOX_API_KEY": "sbx_qz",
+                "SBX_API_KEY": "sbx_other",
+                "QZ_SANDBOX_API_URL": "https://alt.example.com",
+                "SBX_API_URL": "https://qz-sbx-api.sii.edu.cn",
+            }
+        )
+        self.assertEqual(result["E2B_API_KEY"], "sbx_qz")
+        self.assertEqual(result["E2B_API_URL"], "https://alt.example.com/v1")
+
+    def test_explicit_e2b_values_are_preserved(self):
+        result = self.run_mapping(
+            {
+                "SBX_API_KEY": "sbx_secret",
+                "SBX_API_URL": "https://qz-sbx-api.sii.edu.cn",
+                "E2B_API_KEY": "e2b_direct",
+                "E2B_API_URL": "https://direct.example.com/v1",
+                "E2B_VALIDATE_API_KEY": "true",
+            }
+        )
+        self.assertEqual(result["E2B_API_KEY"], "e2b_direct")
+        self.assertEqual(result["E2B_API_URL"], "https://direct.example.com/v1")
+        self.assertEqual(result["E2B_VALIDATE_API_KEY"], "true")
+
+    def test_empty_exported_placeholders_count_as_unset(self):
+        # env.sh exports empty placeholders so worker panes inherit the names.
+        cleaned = {name: "" for name in QZ_VARS}
+        cleaned["SBX_API_KEY"] = "sbx_secret"
+        with patch.dict(os.environ, cleaned, clear=False):
+            self.module.apply_qz_environment()
+            self.assertEqual(os.environ["E2B_API_KEY"], "sbx_secret")
+            self.assertEqual(
+                os.environ["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1"
+            )
+            self.assertEqual(os.environ["E2B_VALIDATE_API_KEY"], "false")
+
+
+def install_e2b_stub():
+    e2b_pkg = types.ModuleType("e2b")
+    cc_mod = types.ModuleType("e2b.connection_config")
+
+    class ConnectionConfig:
+        domain = "fallback.example.com"
+
+        def get_host(self, sandbox_id, sandbox_domain, port):
+            return f"{port}-{sandbox_id}.{sandbox_domain}"
+
+    cc_mod.ConnectionConfig = ConnectionConfig
+    sys.modules["e2b"] = e2b_pkg
+    sys.modules["e2b.connection_config"] = cc_mod
+    return ConnectionConfig
+
+
+class PatchEnvdHostTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+        self.cc_cls = install_e2b_stub()
+
+    def host(self):
+        return self.cc_cls().get_host("sbx123", "openapi-qb-nat.sii.edu.cn", 49983)
+
+    def test_patch_adds_sbx_prefix(self):
+        self.module.patch_envd_host()
+        self.assertEqual(self.host(), "sbx-49983-sbx123.openapi-qb-nat.sii.edu.cn")
+
+    def test_prefix_override_via_environment(self):
+        self.module.patch_envd_host()
+        with patch.dict(os.environ, {"QZ_SANDBOX_HOST_PREFIX": "alt-"}, clear=False):
+            self.assertEqual(self.host(), "alt-49983-sbx123.openapi-qb-nat.sii.edu.cn")
+
+    def test_patch_is_idempotent(self):
+        self.module.patch_envd_host()
+        first = self.cc_cls.get_host
+        self.module.patch_envd_host()
+        self.assertIs(self.cc_cls.get_host, first)
+
+    def test_empty_sandbox_domain_falls_back_to_config_domain(self):
+        self.module.patch_envd_host()
+        result = self.cc_cls().get_host("sbx123", "", 49983)
+        self.assertEqual(result, "sbx-49983-sbx123.fallback.example.com")
+
+    def test_missing_e2b_extra_is_a_noop(self):
+        sys.modules.pop("e2b.connection_config", None)
+        sys.modules.pop("e2b", None)
+        self.module.patch_envd_host()  # must not raise
+
+
+class PreflightTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+
+    def test_preflight_without_key_exits(self):
+        cleaned = {name: "" for name in QZ_VARS}
+        with patch.dict(os.environ, cleaned, clear=False):
+            for name in QZ_VARS:
+                os.environ.pop(name, None)
+            with self.assertRaises(SystemExit):
+                self.module.QzSandboxEnvironment.preflight()
+
+    def test_preflight_with_sbx_key_passes(self):
+        cleaned = {name: "" for name in QZ_VARS}
+        cleaned["SBX_API_KEY"] = "sbx_secret"
+        with patch.dict(os.environ, cleaned, clear=False):
+            self.module.QzSandboxEnvironment.preflight()
+            self.assertEqual(os.environ["E2B_API_KEY"], "sbx_secret")
+
+    def test_init_applies_mapping_before_super(self):
+        cleaned = {name: "" for name in QZ_VARS}
+        cleaned["SBX_API_KEY"] = "sbx_secret"
+        with patch.dict(os.environ, cleaned, clear=False):
+            for name in QZ_VARS:
+                if not cleaned.get(name):
+                    os.environ.pop(name, None)
+            self.module.QzSandboxEnvironment()
+            self.assertEqual(os.environ["E2B_API_KEY"], "sbx_secret")
+
+
+class TemplateResolutionTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+        self.env_vars = dict.fromkeys((*QZ_VARS, "QZ_SANDBOX_TEMPLATE"), "")
+        self.env_vars["SBX_API_KEY"] = "sbx_secret"
+
+    def make_env(self, **kwargs):
+        with patch.dict(os.environ, self.env_vars, clear=False):
+            for name, value in self.env_vars.items():
+                if not value:
+                    os.environ.pop(name, None)
+            return self.module.QzSandboxEnvironment(**kwargs)
+
+    def test_sanitize_template_name(self):
+        self.assertEqual(
+            self.module.sanitize_template_name("hello-world__abc.123/x"),
+            "hello_world__abc_123_x",
+        )
+
+    def test_auto_template_name_is_sanitized(self):
+        env = self.make_env()
+        self.assertEqual(env._template_name, "hello_world__abc_123")
+
+    def test_template_kwarg_wins(self):
+        env = self.make_env(template="agent_fleet_probe")
+        self.assertEqual(env._template_name, "agent_fleet_probe")
+
+    def test_template_env_override(self):
+        self.env_vars["QZ_SANDBOX_TEMPLATE"] = "agent_fleet_probe"
+        env = self.make_env()
+        self.assertEqual(env._template_name, "agent_fleet_probe")
+
+    def test_start_drops_force_build(self):
+        env = self.make_env()
+        env.logger = types.SimpleNamespace(warning=lambda *a, **k: None)
+        asyncio.run(env.start(True))
+        self.assertEqual(env.start_calls[-1], False)
+
+    def test_create_template_raises(self):
+        env = self.make_env()
+        with self.assertRaises(RuntimeError):
+            asyncio.run(env._create_template())
+
+    def test_timeout_default_and_valid_values(self):
+        with patch.dict(os.environ, {"QZ_SANDBOX_TIMEOUT_SEC": ""}, clear=False):
+            self.assertEqual(self.module.qz_sandbox_timeout_sec(), 14400)
+        with patch.dict(os.environ, {"QZ_SANDBOX_TIMEOUT_SEC": "600"}, clear=False):
+            self.assertEqual(self.module.qz_sandbox_timeout_sec(), 600)
+
+    def test_timeout_rejects_bad_values(self):
+        for bad in ("abc", "0", "-5", "14401"):
+            with (
+                patch.dict(os.environ, {"QZ_SANDBOX_TIMEOUT_SEC": bad}, clear=False),
+                self.assertRaises(ValueError),
+            ):
+                self.module.qz_sandbox_timeout_sec()
+
+    def test_preflight_rejects_bad_timeout(self):
+        self.env_vars["QZ_SANDBOX_TIMEOUT_SEC"] = "not-a-number"
+        with (
+            patch.dict(os.environ, self.env_vars, clear=False),
+            self.assertRaises(SystemExit),
+        ):
+            self.module.QzSandboxEnvironment.preflight()
+
+    def test_override_skips_alias_precheck(self):
+        # An override may be a template ID, invisible to the alias lookup;
+        # creation is the authority, so the pre-check must pass it through.
+        env = self.make_env(template="erbkewn6i1y4zf41mpz8")
+        env.exist_calls.clear()
+        self.assertTrue(asyncio.run(env._does_template_exist()))
+        self.assertEqual(env.exist_calls, [])
+
+    def test_auto_alias_still_prechecked(self):
+        env = self.make_env()
+        env.exist_calls.clear()
+        self.assertFalse(asyncio.run(env._does_template_exist()))
+        self.assertEqual(env.exist_calls, ["hello_world__abc_123"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -16,7 +16,15 @@ sys.path.insert(0, str(HARBOR_DIR))
 def install_harbor_stubs() -> None:
     harbor = types.ModuleType("harbor")
     environments = types.ModuleType("harbor.environments")
+    capabilities = types.ModuleType("harbor.environments.capabilities")
     e2b = types.ModuleType("harbor.environments.e2b")
+
+    class Capability:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    capabilities.EnvironmentCapabilities = Capability
+    capabilities.EnvironmentResourceCapabilities = Capability
 
     class E2BEnvironment:
         init_calls: ClassVar[list[tuple[tuple, dict]]] = []
@@ -39,6 +47,7 @@ def install_harbor_stubs() -> None:
         {
             "harbor": harbor,
             "harbor.environments": environments,
+            "harbor.environments.capabilities": capabilities,
             "harbor.environments.e2b": e2b,
         }
     )
@@ -252,11 +261,24 @@ class TemplateResolutionTest(unittest.TestCase):
         env = self.make_env()
         self.assertEqual(env._template_name, "agent_fleet_probe")
 
-    def test_start_drops_force_build(self):
+    def test_start_rejects_force_build(self):
         env = self.make_env()
-        env.logger = types.SimpleNamespace(warning=lambda *a, **k: None)
-        asyncio.run(env.start(True))
-        self.assertEqual(env.start_calls[-1], False)
+        with self.assertRaises(RuntimeError):
+            asyncio.run(env.start(True))
+
+    def test_start_passes_through_without_force_build(self):
+        env = self.make_env()
+        env.start_calls.clear()
+        asyncio.run(env.start(False))
+        self.assertEqual(env.start_calls, [False])
+
+    def test_capabilities_advertise_only_verified_behavior(self):
+        env = self.make_env()
+        caps = env.capabilities
+        self.assertFalse(caps.__dict__.get("disable_internet"))
+        self.assertFalse(caps.__dict__.get("gpus"))
+        resource = self.module.QzSandboxEnvironment.resource_capabilities()
+        self.assertEqual(resource.__dict__, {})
 
     def test_create_template_raises(self):
         env = self.make_env()

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -69,6 +69,10 @@ QZ_VARS = (
     "E2B_API_KEY",
     "E2B_API_URL",
     "E2B_VALIDATE_API_KEY",
+    "E2B_SANDBOX_URL",
+    "E2B_DOMAIN",
+    "E2B_DEBUG",
+    "E2B_ACCESS_TOKEN",
 )
 
 
@@ -122,7 +126,7 @@ class ApplyQzEnvironmentTest(unittest.TestCase):
         self.assertEqual(result["E2B_API_KEY"], "sbx_qz")
         self.assertEqual(result["E2B_API_URL"], "https://alt.example.com/v1")
 
-    def test_qz_values_override_ambient_cloud_e2b_settings(self):
+    def test_qz_values_override_and_clear_ambient_cloud_e2b_settings(self):
         # On a mixed rollout host the ambient E2B_* variables belong to the
         # cloud-E2B backend; a qz process must not send its requests there.
         result = self.run_mapping(
@@ -132,11 +136,19 @@ class ApplyQzEnvironmentTest(unittest.TestCase):
                 "E2B_API_KEY": "e2b_cloud_key",
                 "E2B_API_URL": "https://api.e2b.app",
                 "E2B_VALIDATE_API_KEY": "true",
+                "E2B_SANDBOX_URL": "https://sandbox.e2b.app",
+                "E2B_DOMAIN": "e2b.app",
+                "E2B_DEBUG": "true",
+                "E2B_ACCESS_TOKEN": "cloud_access_token",
             }
         )
         self.assertEqual(result["E2B_API_KEY"], "sbx_secret")
         self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
         self.assertEqual(result["E2B_VALIDATE_API_KEY"], "false")
+        self.assertEqual(result["E2B_SANDBOX_URL"], "")
+        self.assertEqual(result["E2B_DOMAIN"], "")
+        self.assertEqual(result["E2B_DEBUG"], "")
+        self.assertEqual(result["E2B_ACCESS_TOKEN"], "")
 
     def test_e2b_key_serves_as_fallback_without_qz_key(self):
         result = self.run_mapping({"E2B_API_KEY": "e2b_direct"})

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import importlib.util
 import os
@@ -18,6 +20,9 @@ def install_harbor_stubs() -> None:
     environments = types.ModuleType("harbor.environments")
     capabilities = types.ModuleType("harbor.environments.capabilities")
     e2b = types.ModuleType("harbor.environments.e2b")
+    models = types.ModuleType("harbor.models")
+    task = types.ModuleType("harbor.models.task")
+    task_config = types.ModuleType("harbor.models.task.config")
 
     class Capability:
         def __init__(self, **kwargs):
@@ -34,6 +39,9 @@ def install_harbor_stubs() -> None:
         def __init__(self, *args, **kwargs):
             type(self).init_calls.append((args, kwargs))
             self._template_name = "hello-world__abc.123"
+            self.environment_name = "test-environment"
+            self.session_id = "test-session"
+            self.network_policy = types.SimpleNamespace(network_mode="allow")
 
         async def start(self, force_build: bool) -> None:
             type(self).start_calls.append(force_build)
@@ -42,13 +50,24 @@ def install_harbor_stubs() -> None:
             type(self).exist_calls.append(self._template_name)
             return False
 
+        def _sandbox_create_network_options(self):
+            return None
+
     e2b.E2BEnvironment = E2BEnvironment
+
+    class NetworkMode:
+        NO_NETWORK = "none"
+
+    task_config.NetworkMode = NetworkMode
     sys.modules.update(
         {
             "harbor": harbor,
             "harbor.environments": environments,
             "harbor.environments.capabilities": capabilities,
             "harbor.environments.e2b": e2b,
+            "harbor.models": models,
+            "harbor.models.task": task,
+            "harbor.models.task.config": task_config,
         }
     )
 
@@ -59,6 +78,101 @@ def load_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def retry_dependency_stubs():
+    """Provide enough of e2b/httpx/httpcore/tenacity to exercise retries."""
+
+    httpcore = types.ModuleType("httpcore")
+    httpx = types.ModuleType("httpx")
+    e2b_pkg = types.ModuleType("e2b")
+    e2b_pkg.__path__ = []
+    e2b_exceptions = types.ModuleType("e2b.exceptions")
+    tenacity = types.ModuleType("tenacity")
+
+    class HttpcoreConnectError(Exception):
+        pass
+
+    class HttpcoreConnectTimeout(Exception):
+        pass
+
+    class HttpcorePoolTimeout(Exception):
+        pass
+
+    class HttpcoreReadTimeout(Exception):
+        pass
+
+    class HttpxConnectError(Exception):
+        pass
+
+    class HttpxConnectTimeout(Exception):
+        pass
+
+    class HttpxPoolTimeout(Exception):
+        pass
+
+    class HttpxReadTimeout(Exception):
+        pass
+
+    class RateLimitException(Exception):
+        pass
+
+    httpcore.ConnectError = HttpcoreConnectError
+    httpcore.ConnectTimeout = HttpcoreConnectTimeout
+    httpcore.PoolTimeout = HttpcorePoolTimeout
+    httpcore.ReadTimeout = HttpcoreReadTimeout
+    httpx.ConnectError = HttpxConnectError
+    httpx.ConnectTimeout = HttpxConnectTimeout
+    httpx.PoolTimeout = HttpxPoolTimeout
+    httpx.ReadTimeout = HttpxReadTimeout
+    e2b_exceptions.RateLimitException = RateLimitException
+
+    def retry_if_exception_type(exception_types):
+        return exception_types
+
+    def stop_after_attempt(attempts):
+        return attempts
+
+    def wait_exponential(**_kwargs):
+        return None
+
+    def retry(*, retry, stop, wait, reraise):
+        del wait, reraise
+
+        def decorate(fn):
+            async def wrapped(*args, **kwargs):
+                for attempt in range(stop):
+                    try:
+                        return await fn(*args, **kwargs)
+                    except retry:
+                        if attempt + 1 >= stop:
+                            raise
+                raise AssertionError("retry loop exhausted without returning")
+
+            return wrapped
+
+        return decorate
+
+    tenacity.retry = retry
+    tenacity.retry_if_exception_type = retry_if_exception_type
+    tenacity.stop_after_attempt = stop_after_attempt
+    tenacity.wait_exponential = wait_exponential
+
+    return (
+        {
+            "httpcore": httpcore,
+            "httpx": httpx,
+            "e2b": e2b_pkg,
+            "e2b.exceptions": e2b_exceptions,
+            "tenacity": tenacity,
+        },
+        {
+            "connect": HttpcoreConnectError,
+            "rate_limit": RateLimitException,
+            "read_timeout": HttpxReadTimeout,
+            "generic": ValueError,
+        },
+    )
 
 
 QZ_VARS = (
@@ -150,9 +264,19 @@ class ApplyQzEnvironmentTest(unittest.TestCase):
         self.assertEqual(result["E2B_DEBUG"], "")
         self.assertEqual(result["E2B_ACCESS_TOKEN"], "")
 
-    def test_e2b_key_serves_as_fallback_without_qz_key(self):
-        result = self.run_mapping({"E2B_API_KEY": "e2b_direct"})
-        self.assertEqual(result["E2B_API_KEY"], "e2b_direct")
+    def test_sbx_prefixed_e2b_key_serves_as_legacy_fallback(self):
+        result = self.run_mapping({"E2B_API_KEY": "sbx_legacy"})
+        self.assertEqual(result["E2B_API_KEY"], "sbx_legacy")
+        self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
+
+    def test_ambient_cloud_e2b_key_is_cleared_without_qz_key(self):
+        result = self.run_mapping(
+            {
+                "E2B_API_KEY": "e2b_cloud_key",
+                "E2B_API_URL": "https://api.e2b.app",
+            }
+        )
+        self.assertEqual(result["E2B_API_KEY"], "")
         self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
 
     def test_empty_exported_placeholders_count_as_unset(self):
@@ -237,6 +361,22 @@ class PreflightTest(unittest.TestCase):
             self.module.QzSandboxEnvironment.preflight()
             self.assertEqual(os.environ["E2B_API_KEY"], "sbx_secret")
 
+    def test_preflight_rejects_ambient_cloud_e2b_key(self):
+        cleaned = {name: "" for name in QZ_VARS}
+        cleaned.update(
+            {
+                "E2B_API_KEY": "e2b_cloud_key",
+                "E2B_API_URL": "https://api.e2b.app",
+            }
+        )
+        with patch.dict(os.environ, cleaned, clear=False):
+            for name in QZ_VARS:
+                if not cleaned.get(name):
+                    os.environ.pop(name, None)
+            with self.assertRaises(SystemExit):
+                self.module.QzSandboxEnvironment.preflight()
+            self.assertNotIn("E2B_API_KEY", os.environ)
+
     def test_init_applies_mapping_before_super(self):
         cleaned = {name: "" for name in QZ_VARS}
         cleaned["SBX_API_KEY"] = "sbx_secret"
@@ -246,6 +386,67 @@ class PreflightTest(unittest.TestCase):
                     os.environ.pop(name, None)
             self.module.QzSandboxEnvironment()
             self.assertEqual(os.environ["E2B_API_KEY"], "sbx_secret")
+
+
+class CreateRetryTest(unittest.TestCase):
+    def run_create(
+        self, failure_name: str, *, succeeds_after_failure: bool
+    ) -> tuple[int, Exception | None]:
+        dependency_modules, error_types = retry_dependency_stubs()
+        expected_error_types = tuple(error_types.values())
+        outcomes: list[object] = [error_types[failure_name]("boom")]
+        if succeeds_after_failure:
+            outcomes.append(object())
+        calls: list[dict] = []
+
+        class FakeAsyncSandbox:
+            @classmethod
+            async def create(cls, **kwargs):
+                calls.append(kwargs)
+                outcome = outcomes.pop(0)
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return outcome
+
+        dependency_modules["e2b"].AsyncSandbox = FakeAsyncSandbox
+        cleaned = {name: "" for name in QZ_VARS}
+        cleaned["SBX_API_KEY"] = "sbx_secret"
+        error = None
+        with (
+            patch.dict(sys.modules, dependency_modules),
+            patch.dict(os.environ, cleaned, clear=False),
+        ):
+            for name in QZ_VARS:
+                if not cleaned.get(name):
+                    os.environ.pop(name, None)
+            module = load_module()
+            environment = module.QzSandboxEnvironment(template="test_template")
+            try:
+                asyncio.run(environment._create_sandbox())
+            except expected_error_types as exc:
+                error = exc
+        return len(calls), error
+
+    def test_connection_failure_is_retried_once(self):
+        calls, error = self.run_create("connect", succeeds_after_failure=True)
+        self.assertEqual(calls, 2)
+        self.assertIsNone(error)
+
+    def test_rate_limit_is_retried_once(self):
+        calls, error = self.run_create("rate_limit", succeeds_after_failure=True)
+        self.assertEqual(calls, 2)
+        self.assertIsNone(error)
+
+    def test_post_dispatch_read_timeout_is_not_retried(self):
+        calls, error = self.run_create("read_timeout", succeeds_after_failure=False)
+        self.assertEqual(calls, 1)
+        self.assertIsNotNone(error)
+        self.assertEqual(type(error).__name__, "HttpxReadTimeout")
+
+    def test_generic_failure_is_not_retried(self):
+        calls, error = self.run_create("generic", succeeds_after_failure=False)
+        self.assertEqual(calls, 1)
+        self.assertIsInstance(error, ValueError)
 
 
 class TemplateResolutionTest(unittest.TestCase):

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -122,19 +122,26 @@ class ApplyQzEnvironmentTest(unittest.TestCase):
         self.assertEqual(result["E2B_API_KEY"], "sbx_qz")
         self.assertEqual(result["E2B_API_URL"], "https://alt.example.com/v1")
 
-    def test_explicit_e2b_values_are_preserved(self):
+    def test_qz_values_override_ambient_cloud_e2b_settings(self):
+        # On a mixed rollout host the ambient E2B_* variables belong to the
+        # cloud-E2B backend; a qz process must not send its requests there.
         result = self.run_mapping(
             {
                 "SBX_API_KEY": "sbx_secret",
                 "SBX_API_URL": "https://qz-sbx-api.sii.edu.cn",
-                "E2B_API_KEY": "e2b_direct",
-                "E2B_API_URL": "https://direct.example.com/v1",
+                "E2B_API_KEY": "e2b_cloud_key",
+                "E2B_API_URL": "https://api.e2b.app",
                 "E2B_VALIDATE_API_KEY": "true",
             }
         )
+        self.assertEqual(result["E2B_API_KEY"], "sbx_secret")
+        self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
+        self.assertEqual(result["E2B_VALIDATE_API_KEY"], "false")
+
+    def test_e2b_key_serves_as_fallback_without_qz_key(self):
+        result = self.run_mapping({"E2B_API_KEY": "e2b_direct"})
         self.assertEqual(result["E2B_API_KEY"], "e2b_direct")
-        self.assertEqual(result["E2B_API_URL"], "https://direct.example.com/v1")
-        self.assertEqual(result["E2B_VALIDATE_API_KEY"], "true")
+        self.assertEqual(result["E2B_API_URL"], "https://qz-sbx-api.sii.edu.cn/v1")
 
     def test_empty_exported_placeholders_count_as_unset(self):
         # env.sh exports empty placeholders so worker panes inherit the names.

--- a/Agents/utils/common/Harbor/tests/test_setup_runner_env.sh
+++ b/Agents/utils/common/Harbor/tests/test_setup_runner_env.sh
@@ -20,6 +20,10 @@ elif [[ "\${3:-}" == "pip" ]]; then
   printf '%s\n' '25.2'
 elif [[ "\${3:-}" == "s3cmd" ]]; then
   printf '%s\n' '2.4.0'
+elif [[ "\${3:-}" == "e2b" ]]; then
+  printf '%s\n' '2.38.0'
+elif [[ "\${3:-}" == "dockerfile-parse" ]]; then
+  printf '%s\n' '2.0.1'
 elif [[ "\$#" == 2 ]]; then
   printf '%s\n' '3.12.13'
 else

--- a/Agents/utils/common/Harbor/tests/test_setup_runner_env.sh
+++ b/Agents/utils/common/Harbor/tests/test_setup_runner_env.sh
@@ -21,7 +21,7 @@ elif [[ "\${3:-}" == "pip" ]]; then
 elif [[ "\${3:-}" == "s3cmd" ]]; then
   printf '%s\n' '2.4.0'
 elif [[ "\${3:-}" == "e2b" ]]; then
-  printf '%s\n' '2.38.0'
+  printf '%s\n' '2.32.1'
 elif [[ "\${3:-}" == "dockerfile-parse" ]]; then
   printf '%s\n' '2.0.1'
 elif [[ "\$#" == 2 ]]; then

--- a/Agents/utils/rl/rollout_remote_harbor.py
+++ b/Agents/utils/rl/rollout_remote_harbor.py
@@ -635,7 +635,7 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, fmt: str, *args: Any) -> None:
         print(f"{self.address_string()} - {fmt % args}", flush=True)
 
-    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler protocol
+    def do_GET(self) -> None:
         parsed = urlparse(self.path)
         query = parse_qs(parsed.query)
         try:
@@ -682,7 +682,7 @@ class Handler(BaseHTTPRequestHandler):
         except Exception as exc:  # noqa: BLE001 - HTTP boundary returns structured failures
             self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"detail": {"exception_type": type(exc).__name__, "exception_message": str(exc)}})
 
-    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler protocol
+    def do_POST(self) -> None:
         if urlparse(self.path).path != "/run_trial":
             self._send_json(HTTPStatus.NOT_FOUND, {"detail": "not found"})
             return

--- a/Agents/utils/rl/rollout_remote_harbor.py
+++ b/Agents/utils/rl/rollout_remote_harbor.py
@@ -82,27 +82,30 @@ def _environment_type(request: dict[str, Any]) -> str:
         DEFAULT_ENVIRONMENT_TYPE,
         "docker",
     ).lower()
-    if value not in {"docker", "e2b", "opensandbox"}:
+    if value not in {"docker", "e2b", "opensandbox", "qz"}:
         raise ValueError(
-            "environment_type must be docker, e2b, or opensandbox, "
+            "environment_type must be docker, e2b, opensandbox, or qz, "
             f"got: {value}"
         )
     return value
 
 
 def _reject_e2b_credentials(request: dict[str, Any]) -> None:
-    if _contains_key(request, "e2b_api_key"):
-        raise ValueError(
-            "E2B_API_KEY must be supplied by the agent-fleet host environment, not the request"
-        )
+    for key in ("e2b_api_key", "sbx_api_key", "qz_sandbox_api_key"):
+        if _contains_key(request, key):
+            raise ValueError(
+                "sandbox API keys must be supplied by the agent-fleet host "
+                "environment, not the request"
+            )
     for key in (
         "e2b_template",
         "tb_e2b_prebuilt_template",
         "rl_e2b_prebuilt_template",
+        "qz_sandbox_template",
     ):
         if _contains_key(request, key):
             raise ValueError(
-                "the E2B prebuilt template must be supplied by the agent-fleet "
+                "the sandbox template must be supplied by the agent-fleet "
                 "host environment, not the request"
             )
 

--- a/Agents/utils/rl/run_rl_rollout_worker.sh
+++ b/Agents/utils/rl/run_rl_rollout_worker.sh
@@ -355,6 +355,8 @@ while true; do
       export TB_ENVIRONMENT_SPEC="$HARBOR_E2B_PREBUILT_ENVIRONMENT_SPEC"
     elif [[ "$environment_type" == "opensandbox" ]]; then
       export TB_ENVIRONMENT_SPEC="yicloud_opensandbox:YiCloudOpenSandboxEnvironment"
+    elif [[ "$environment_type" == "qz" ]]; then
+      export TB_ENVIRONMENT_SPEC="qz_e2b_sandbox:QzSandboxEnvironment"
     elif [[ "$environment_type" != "${RL_ENVIRONMENT_TYPE:-docker}" ]]; then
       # A per-request backend override must not inherit the listener's default
       # environment import path.

--- a/config.env
+++ b/config.env
@@ -50,7 +50,8 @@
 # adapter (Agents/utils/common/Harbor/qz_e2b_sandbox.py) maps these onto the
 # official e2b SDK. In a qz process, QZ_SANDBOX_*/SBX_* connection values
 # override ambient cloud-E2B settings; E2B_API_KEY is only a fallback when no
-# qz key is configured. Keep the real key in config.local.env.
+# qz key is configured and its value is an sbx_-prefixed qz key. Keep the real
+# key in config.local.env.
 # RL_ENVIRONMENT_TYPE=qz
 # SBX_API_KEY=sbx-your-key
 # SBX_API_URL=https://qz-sbx-api.sii.edu.cn

--- a/config.env
+++ b/config.env
@@ -48,8 +48,9 @@
 # Set RL_ENVIRONMENT_TYPE=qz to run Harbor trials in qz sandboxes
 # (https://qz-sbx-api.sii.edu.cn, an E2B-compatible control plane). The
 # adapter (Agents/utils/common/Harbor/qz_e2b_sandbox.py) maps these onto the
-# official e2b SDK; explicitly set E2B_* values always win. Keep the real key
-# in config.local.env.
+# official e2b SDK. In a qz process, QZ_SANDBOX_*/SBX_* connection values
+# override ambient cloud-E2B settings; E2B_API_KEY is only a fallback when no
+# qz key is configured. Keep the real key in config.local.env.
 # RL_ENVIRONMENT_TYPE=qz
 # SBX_API_KEY=sbx-your-key
 # SBX_API_URL=https://qz-sbx-api.sii.edu.cn

--- a/config.env
+++ b/config.env
@@ -44,6 +44,21 @@
 # HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS=24000
 # HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS=400000
 
+# ── qz (SII Inspire) E2B-compatible sandbox ──────────────────────────────────
+# Set RL_ENVIRONMENT_TYPE=qz to run Harbor trials in qz sandboxes
+# (https://qz-sbx-api.sii.edu.cn, an E2B-compatible control plane). The
+# adapter (Agents/utils/common/Harbor/qz_e2b_sandbox.py) maps these onto the
+# official e2b SDK; explicitly set E2B_* values always win. Keep the real key
+# in config.local.env.
+# RL_ENVIRONMENT_TYPE=qz
+# SBX_API_KEY=sbx-your-key
+# SBX_API_URL=https://qz-sbx-api.sii.edu.cn
+# Platform-registered template every trial runs in (name or template ID).
+# Required until per-task template registration lands.
+# QZ_SANDBOX_TEMPLATE=your_registered_template
+# Per-sandbox lifetime; the platform caps it at 4 hours (14400).
+# QZ_SANDBOX_TIMEOUT_SEC=14400
+
 # ── YiCloud OpenSandbox task images ──────────────────────────────────────────
 # Set RL_ENVIRONMENT_TYPE=opensandbox to enable the YiCloud provider. When an
 # explicit HARBOR_OPENSANDBOX_IMAGE_REF is absent, the Harbor runner builds the one


### PR DESCRIPTION
> **Stacked on #90** (`feat/harbor-e2b-rollout`): per review, this branch is rebased onto #90 and routes qz through its shared cloud-E2B machinery instead of running a parallel implementation. The diff below includes #90's commit until it merges; the remaining commits are qz-specific. Merge #90 first.

## Summary

Add a **qz (SII Inspire) sandbox provider** that runs Harbor trials in the platform's sandbox service (`qz-sbx-api.sii.edu.cn`). The service exposes an E2B-compatible control plane, so the provider reuses Harbor's native E2B environment and maps only the platform deltas onto the official `e2b` SDK:

- `QZ_SANDBOX_*` / `SBX_*` connection values map onto the SDK (including the `/v1` mount prefix) and override ambient cloud-E2B state inside qz processes; `E2B_API_KEY` is accepted only as an unambiguous `sbx_`-prefixed legacy fallback, while cloud credentials and transport overrides are cleared
- key prefix validation disabled (qz keys use `sbx_`)
- envd data-plane host patched to the platform's `sbx-{port}-{sandbox_id}.{domain}` route
- sandbox timeout validated against the platform's 4-hour cap, in both the launcher and the adapter
- templates resolve from platform-registered names **or IDs** via `QZ_SANDBOX_TEMPLATE`; the unsupported remote build path and `force_build` fail fast
- create retries restricted to pre-allocation failures (connection establishment + 429) so a lost response cannot orphan a sandbox
- capabilities advertise only verified behavior: fixed template spec (no per-task cpu/memory) and unverified network isolation are declared unsupported, turning explicit enforcement into a fail-fast reject

Integration with #90's machinery:

- rollout listener accepts `environment_type=qz` and rejects request-supplied sandbox keys/templates, matching the e2b handling
- the runner-local wheel server is disabled for qz (no route from a qz sandbox back to the runner host); verifier uv tools ride the shared post-start upload path
- the launcher accepts `AGENT=oracle` only on qz for now — the claude-code/opencode delivery mechanisms cannot reach a qz sandbox; agent runtime delivery lands with the per-task template pipeline
- runner requirements converge on this branch's `e2b==2.32.1` pin (verified to carry every SDK feature the qz adapter uses) plus `dockerfile-parse`, with both runner-validation test fixtures updated

## Verification

- 34 stub-based unit tests plus a launcher dry-run test covering the emitted command and every preflight failure mode (missing key/template, timeout bounds, non-oracle agents, force_build)
- Live SDK probe against the real service: create / get_info / exec with cwd/env/uid / file round-trip (60 MB upload) / kill — all pass
- Live Harbor smoke trials (`harbor run`, oracle agent): reward **1.0** with a template alias and with a raw template ID; a live pi-agent trial through the SII model gateway also passes (reward 1.0), verifying gateway egress from inside a sandbox
- Pre-existing on `#90` and unchanged here (macOS-only): `test_harboropik_e2b_smoke` (Linux-only uv staging) and three `test_rollout_request_context` cases (`/var` vs `/private/var` resolve), plus the `test_harboropik_opensandbox` fixture missing the new curl requirement

## Scope and follow-up

Fixed-template mode is intentional in this provider version: all trials share the single pre-registered template named by `QZ_SANDBOX_TEMPLATE`, and a run may contain one task or multiple tasks that deliberately use the same environment image. The operator is responsible for selecting a compatible Template; qz does not expose the e2b remote build API. The follow-up (per-task template pipeline) covers content-addressed image build/push, platform template registration, task→template mapping, and agent runtime delivery for claude-code/opencode.
