### PR TITLE
feat(harbor): add Fixer verification contracts

### DIFF
--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -50,6 +50,7 @@ Agents/utils/common/Harbor/
     │   ├── planning_context/   # Runtime inventory and workspace evidence
     │   ├── policy/             # T1 rules, path routing, and T2/T3 Agent policy
     │   ├── prompts.py          # Task and plan agent contracts
+    │   ├── verification/       # Verification contracts and Harbor-state readers
     │   └── validation.py       # Plan and execution artifact validation
     ├── online_rule_analyzer.py # Optional console-only online analysis
     └── write_harbor_registry_summary.py # Native registry summary writer

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/executor.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/executor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import signal
 import stat
@@ -16,7 +15,7 @@ from typing import Any
 from .agent_invocation import AgentInvoker
 from .artifact_io import read_json, write_json_atomic
 from .policy import run_policy_preflight
-from .validation import validate_exec_input, validate_exec_result
+from .validation import json_sha256, validate_exec_input, validate_exec_result
 
 SUMMARY_LIMIT = 4000
 MAX_SUMMARY_LIMIT = 100_000
@@ -46,16 +45,6 @@ COMMAND_ENV_ALLOWLIST = (
     "XDG_RUNTIME_DIR",
     "DBUS_SESSION_BUS_ADDRESS",
 )
-
-
-def _json_sha256(value: Any) -> str:
-    serialized = json.dumps(
-        value,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def _safe_label(value: str, prefix: str) -> str:
@@ -255,7 +244,7 @@ def _unexecuted_action_record(
 def _binding_error(
     action: dict[str, Any], cwd: Path, decision: dict[str, Any]
 ) -> str | None:
-    if _json_sha256(action) != decision["action_sha256"]:
+    if json_sha256(action) != decision["action_sha256"]:
         return "action no longer matches the policy decision"
     if str(cwd) != decision["resolved_cwd"]:
         return "action cwd no longer matches the policy decision"
@@ -675,6 +664,7 @@ def _publish_result(
             "fix_plan_path": exec_input["fix_plan_path"],
             "workspace_root": exec_input["workspace_root"],
             "policy_decision_path": str(output_dir / "execution-policy-decision.json"),
+            "fix_plan_sha256": json_sha256(exec_input["fix_plan"]),
         },
         "status": status,
         "policy_status": policy_status,
@@ -714,7 +704,7 @@ def run_fix_exec(
         user_rules_path=policy_rules_path,
         writable_roots=policy_write_roots,
     )
-    if policy_result["fix_plan_sha256"] != _json_sha256(fix_plan):
+    if policy_result["fix_plan_sha256"] != json_sha256(fix_plan):
         raise RuntimeError("policy decision does not match the execution fix plan")
     if policy_result["status"] == "denied":
         return _policy_blocked_result(

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 from typing import Any
@@ -24,6 +25,54 @@ ACTION_TYPES = {"command", "file_edit"}
 
 EXEC_STATUSES = {"success", "partial_failed", "failed"}
 EXEC_COMMAND_STATUSES = {"success", "failed", "skipped"}
+EXEC_POLICY_STATUSES = {"allowed", "denied"}
+HARBOR_AGENTS = {"claude-code", "opencode", "oracle"}
+MONITOR_POLICIES = {"auto", "on", "off"}
+VERIFICATION_STATUSES = {
+    "fixed",
+    "partially_fixed",
+    "not_fixed",
+    "inconclusive",
+    "exec_failed",
+}
+TASK_VERIFICATION_STATUSES = {
+    "fixed",
+    "not_fixed",
+    "unknown",
+    "not_complete",
+    "not_sampled",
+    "exec_failed",
+}
+TASK_COMPLETE_STATUSES = {
+    "complete_success",
+    "complete_failed",
+    "complete_unknown",
+    "not_complete",
+}
+EXEC_FAILURE_REASONS = {"execution_failed", "policy_denied"}
+VERIFICATION_REASON_CODES = EXEC_FAILURE_REASONS | {
+    "mapping_error",
+    "monitor_timed_out",
+    "monitor_unavailable",
+    "no_verifiable_tasks",
+    "rerun_failed",
+}
+INCONCLUSIVE_VERIFICATION_REASONS = {
+    "mapping_error",
+    "monitor_timed_out",
+    "monitor_unavailable",
+    "rerun_failed",
+}
+
+
+def json_sha256(value: Any) -> str:
+    serialized = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def require_dict(value: Any, name: str) -> dict[str, Any]:
@@ -197,16 +246,6 @@ def _check_kind(payload: dict[str, Any], *, version: int, kind: str, name: str) 
         raise ValidationError(f"{name} schema_version must be {version}")
     if payload.get("kind") != kind:
         raise ValidationError(f"{name} kind must be {kind}")
-
-
-def _check_kind_versions(payload: dict[str, Any], *, versions: set[int], kind: str, name: str) -> int:
-    require_dict(payload, name)
-    version = payload.get("schema_version")
-    if version not in versions:
-        raise ValidationError(f"{name} schema_version must be one of: {', '.join(str(item) for item in sorted(versions))}")
-    if payload.get("kind") != kind:
-        raise ValidationError(f"{name} kind must be {kind}")
-    return int(version)
 
 
 def validate_analyzer_manifest(payload: dict[str, Any]) -> None:
@@ -553,11 +592,23 @@ def validate_exec_input(payload: dict[str, Any]) -> None:
     validate_fix_plan_set(require_dict(payload.get("fix_plan"), "fix_plan"))
 
 
+def _aggregate_exec_status(statuses: list[str]) -> str:
+    failed_count = statuses.count("failed")
+    if failed_count == 0:
+        return "success"
+    if failed_count == len(statuses):
+        return "failed"
+    return "partial_failed"
+
+
 def validate_exec_result(payload: dict[str, Any]) -> None:
     _check_kind(payload, version=1, kind="harbor_fixer_exec_result", name="exec result")
     status = require_enum(payload.get("status"), "status", EXEC_STATUSES)
+    policy_status = require_enum(
+        payload.get("policy_status"), "policy_status", EXEC_POLICY_STATUSES
+    )
     plans = require_list(payload.get("plans"), "plans")
-    failed_plan_count = 0
+    plan_statuses: list[str] = []
     for plan_index, plan in enumerate(plans):
         plan_obj = require_dict(plan, f"plans[{plan_index}]")
         plan_status = require_enum(
@@ -565,8 +616,7 @@ def validate_exec_result(payload: dict[str, Any]) -> None:
             f"plans[{plan_index}].status",
             {"success", "failed"},
         )
-        if plan_status == "failed":
-            failed_plan_count += 1
+        plan_statuses.append(plan_status)
         actions = require_list(
             plan_obj.get("actions"),
             f"plans[{plan_index}].actions",
@@ -586,11 +636,264 @@ def validate_exec_result(payload: dict[str, Any]) -> None:
                 raise ValidationError("successful action exit_code must be 0")
             if action_status == "skipped" and exit_code is not None:
                 raise ValidationError("skipped action exit_code must be null")
-    if failed_plan_count == 0:
-        expected = "success"
-    elif failed_plan_count == len(plans):
-        expected = "failed"
-    else:
-        expected = "partial_failed"
+    expected = _aggregate_exec_status(plan_statuses)
     if status != expected:
         raise ValidationError(f"status must be {expected}")
+    if policy_status == "denied" and status != "failed":
+        raise ValidationError("policy_status denied requires failed status")
+
+
+def validate_verification_input(payload: dict[str, Any]) -> None:
+    _check_kind(
+        payload,
+        version=2,
+        kind="harbor_fixer_verification_input",
+        name="verification input",
+    )
+    for key in (
+        "fix_plan_path",
+        "exec_result_path",
+        "verification_run_dir",
+        "output_dir",
+    ):
+        require_string(payload.get(key), key)
+    require_enum(payload.get("monitor_policy"), "monitor_policy", MONITOR_POLICIES)
+    if payload.get("verification_mode") != "smoke_test":
+        raise ValidationError("verification_mode must be smoke_test")
+    limit = payload.get("verification_task_limit_per_plan")
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+        raise ValidationError(
+            "verification_task_limit_per_plan must be a positive integer"
+        )
+    fix_plan = require_dict(payload.get("fix_plan"), "fix_plan")
+    exec_result = require_dict(payload.get("exec_result"), "exec_result")
+    validate_fix_plan_set(fix_plan)
+    validate_exec_result(exec_result)
+    agent = require_enum(payload.get("agent"), "agent", HARBOR_AGENTS)
+    fix_plan_source = require_dict(fix_plan.get("source"), "fix_plan.source")
+    source_agent = require_string(
+        fix_plan_source.get("agent", ""), "fix_plan.source.agent", allow_empty=True
+    )
+    if source_agent and agent != source_agent:
+        raise ValidationError("agent does not match fix_plan source")
+    exec_source = require_dict(exec_result.get("source"), "exec_result.source")
+    fix_plan_digest = require_string(
+        exec_source.get("fix_plan_sha256"),
+        "exec_result.source.fix_plan_sha256",
+    )
+    if fix_plan_digest != json_sha256(fix_plan):
+        raise ValidationError("exec_result does not match fix_plan")
+    fix_plan_ids = {str(plan["plan_id"]) for plan in fix_plan["plans"]}
+    exec_plan_ids = [
+        require_string(plan.get("plan_id"), f"exec_result.plans[{index}].plan_id")
+        for index, plan in enumerate(exec_result["plans"])
+    ]
+    if len(exec_plan_ids) != len(set(exec_plan_ids)):
+        raise ValidationError("exec_result contains duplicate plan_id")
+    if set(exec_plan_ids) != fix_plan_ids:
+        raise ValidationError("exec_result plan_ids must match fix_plan")
+
+
+def _validate_run_record(
+    payload: dict[str, Any], name: str
+) -> tuple[str, str]:
+    task_index = require_string(payload.get("task_index"), f"{name}.task_index")
+    task_name = require_string(payload.get("task_name"), f"{name}.task_name")
+    require_enum(
+        payload.get("task_complete_status"),
+        f"{name}.task_complete_status",
+        TASK_COMPLETE_STATUSES,
+    )
+    return task_index, task_name
+
+
+def _validate_exec_failure_reason(
+    payload: dict[str, Any], name: str, policy_status: str
+) -> str:
+    exec_status = require_enum(
+        payload.get("exec_status"), f"{name}.exec_status", {"success", "failed"}
+    )
+    if policy_status == "denied" and exec_status != "failed":
+        raise ValidationError(f"{name}.exec_status must be failed after policy denial")
+    reason = payload.get("exec_failure_reason")
+    if exec_status == "success":
+        if reason is not None:
+            raise ValidationError(
+                f"{name}.exec_failure_reason must be null after successful execution"
+            )
+        return exec_status
+    expected = "policy_denied" if policy_status == "denied" else "execution_failed"
+    if reason != expected:
+        raise ValidationError(f"{name}.exec_failure_reason must be {expected}")
+    return exec_status
+
+
+def _expected_verification_status(
+    statuses: list[str], reason_codes: list[str]
+) -> str:
+    sampled = [status for status in statuses if status != "not_sampled"]
+    if (
+        not sampled
+        or INCONCLUSIVE_VERIFICATION_REASONS.intersection(reason_codes)
+    ):
+        return "inconclusive"
+    if "exec_failed" in sampled:
+        return "exec_failed"
+    if all(status == "fixed" for status in sampled):
+        return "fixed"
+    if "fixed" in sampled:
+        return "partially_fixed"
+    if any(status in {"unknown", "not_complete"} for status in sampled):
+        return "inconclusive"
+    return "not_fixed"
+
+
+def validate_verification_result(payload: dict[str, Any]) -> None:
+    _check_kind(
+        payload,
+        version=2,
+        kind="harbor_fixer_verification_result",
+        name="verification result",
+    )
+    require_enum(payload.get("agent"), "agent", HARBOR_AGENTS)
+    status = require_enum(payload.get("status"), "status", VERIFICATION_STATUSES)
+    require_dict(payload.get("source"), "source")
+    execution = require_dict(payload.get("execution"), "execution")
+    execution_status = require_enum(
+        execution.get("status"), "execution.status", EXEC_STATUSES
+    )
+    policy_status = require_enum(
+        execution.get("policy_status"),
+        "execution.policy_status",
+        EXEC_POLICY_STATUSES,
+    )
+    if policy_status == "denied" and execution_status != "failed":
+        raise ValidationError("policy_status denied requires failed execution status")
+    reason_codes = require_list(payload.get("reason_codes"), "reason_codes")
+    for index, reason in enumerate(reason_codes):
+        require_enum(
+            reason,
+            f"reason_codes[{index}]",
+            VERIFICATION_REASON_CODES,
+        )
+    if len(reason_codes) != len(set(reason_codes)):
+        raise ValidationError("reason_codes must not contain duplicates")
+    exec_reason = "policy_denied" if policy_status == "denied" else "execution_failed"
+    expected_exec_reasons = set() if execution_status == "success" else {exec_reason}
+    if set(reason_codes).intersection(EXEC_FAILURE_REASONS) != expected_exec_reasons:
+        raise ValidationError("reason_codes do not match execution status")
+    require_dict(payload.get("rerun"), "rerun")
+    require_dict(payload.get("new_run_summary"), "new_run_summary")
+    if payload.get("verification_mode") != "smoke_test":
+        raise ValidationError("verification_mode must be smoke_test")
+    sampling = require_dict(payload.get("sampling"), "sampling")
+    plan_task_count = sampling.get("plan_task_count")
+    if (
+        isinstance(plan_task_count, bool)
+        or not isinstance(plan_task_count, int)
+        or plan_task_count < 0
+    ):
+        raise ValidationError("sampling.plan_task_count must be a non-negative integer")
+    if (plan_task_count == 0) != ("no_verifiable_tasks" in reason_codes):
+        raise ValidationError(
+            "no_verifiable_tasks must match sampling.plan_task_count"
+        )
+    plan_exec_statuses: list[str] = []
+    for index, plan in enumerate(
+        require_list(payload.get("plan_results"), "plan_results")
+    ):
+        plan_obj = require_dict(plan, f"plan_results[{index}]")
+        require_string(plan_obj.get("plan_id"), f"plan_results[{index}].plan_id")
+        plan_status = require_enum(
+            plan_obj.get("status"),
+            f"plan_results[{index}].status",
+            VERIFICATION_STATUSES,
+        )
+        plan_exec_status = _validate_exec_failure_reason(
+            plan_obj,
+            f"plan_results[{index}]",
+            policy_status,
+        )
+        plan_exec_statuses.append(plan_exec_status)
+        if plan_exec_status == "failed" and plan_status != "exec_failed":
+            raise ValidationError(
+                f"plan_results[{index}].status must be exec_failed"
+            )
+        if plan_exec_status == "success" and plan_status == "exec_failed":
+            raise ValidationError(
+                f"plan_results[{index}].status cannot be exec_failed"
+            )
+    task_statuses: list[str] = []
+    for index, task in enumerate(
+        require_list(payload.get("task_results"), "task_results")
+    ):
+        task_obj = require_dict(task, f"task_results[{index}]")
+        task_identity = require_dict(
+            task_obj.get("task"),
+            f"task_results[{index}].task",
+        )
+        _validate_task_identity(
+            task_identity,
+            f"task_results[{index}].task",
+        )
+        verification_status = require_enum(
+            task_obj.get("verification_status"),
+            f"task_results[{index}].verification_status",
+            TASK_VERIFICATION_STATUSES,
+        )
+        task_statuses.append(verification_status)
+        exec_status = _validate_exec_failure_reason(
+            task_obj,
+            f"task_results[{index}]",
+            policy_status,
+        )
+        new_run = task_obj.get("new_run")
+        if exec_status == "failed":
+            expected_status = "exec_failed"
+        elif new_run is None:
+            expected_status = "not_sampled"
+        else:
+            run_record = require_dict(new_run, f"task_results[{index}].new_run")
+            run_identity = _validate_run_record(
+                run_record, f"task_results[{index}].new_run"
+            )
+            if run_identity != (
+                task_identity["task_index"],
+                task_identity["task_name"],
+            ):
+                raise ValidationError(
+                    f"task_results[{index}].new_run identity does not match task"
+                )
+            expected_status = {
+                "complete_success": "fixed",
+                "complete_failed": "not_fixed",
+                "complete_unknown": "unknown",
+                "not_complete": "not_complete",
+            }[run_record["task_complete_status"]]
+        if verification_status != expected_status:
+            raise ValidationError(
+                f"task_results[{index}].verification_status must be "
+                f"{expected_status}"
+            )
+        if exec_status == "failed" and new_run is not None:
+            raise ValidationError(
+                f"task_results[{index}].new_run must be null after failed execution"
+            )
+    if plan_exec_statuses:
+        expected_execution_status = _aggregate_exec_status(plan_exec_statuses)
+        if execution_status != expected_execution_status:
+            raise ValidationError(
+                f"execution.status must be {expected_execution_status}"
+            )
+    expected_status = _expected_verification_status(task_statuses, reason_codes)
+    if status != expected_status:
+        raise ValidationError(f"status must be {expected_status}")
+    unexpected = require_list(
+        payload.get("unexpected_run_task_results"),
+        "unexpected_run_task_results",
+    )
+    for index, record in enumerate(unexpected):
+        _validate_run_record(
+            require_dict(record, f"unexpected_run_task_results[{index}]"),
+            f"unexpected_run_task_results[{index}]",
+        )

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/__init__.py
@@ -1,0 +1,1 @@
+"""Implementation package for deterministic Fixer verification."""

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/run_state.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/run_state.py
@@ -1,0 +1,199 @@
+"""Read Harbor task results and monitor state for a verification run."""
+
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from harbor_monitor.artifacts import (
+    HarborJobSnapshot,
+    TaskInput,
+    load_harbor_job_snapshot,
+    load_manifest,
+    load_task_file_manifest,
+    load_task_records,
+)
+from harbor_monitor.classification import classify_task_status
+from harbor_monitor.runner import run_loop
+
+from ..artifact_io import read_json
+
+
+def locate_queue_files(run_dir: Path, agent: str) -> tuple[Path, Path]:
+    queue_dir = run_dir / "queue" / agent
+    return queue_dir / "done.txt", queue_dir / "failed.txt"
+
+
+def locate_native_runtime_files(run_dir: Path, agent: str) -> tuple[Path, Path, Path]:
+    runtime_dir = run_dir / "runtime" / agent
+    return (
+        runtime_dir / "harbor-job-dir",
+        runtime_dir / "harbor-benchmark.pid",
+        runtime_dir / "harbor-benchmark.exit",
+    )
+
+
+def load_task_manifest(run_dir: Path) -> dict[str, str]:
+    return load_manifest(run_dir / "task-manifest.tsv") or load_task_file_manifest(
+        run_dir / "tasks.txt"
+    )
+
+
+def _load_native_snapshot(job_dir_file: Path) -> HarborJobSnapshot | None:
+    try:
+        raw_job_dir = job_dir_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return load_harbor_job_snapshot(Path(raw_job_dir)) if raw_job_dir else None
+
+
+def _result_mtime(task: TaskInput) -> int:
+    try:
+        return Path(task.result_path).stat().st_mtime_ns if task.result_path else 0
+    except OSError:
+        return 0
+
+
+def load_native_task_records(
+    run_dir: Path, agent: str, manifest: dict[str, str]
+) -> dict[str, TaskInput] | None:
+    job_dir_file, _, _ = locate_native_runtime_files(run_dir, agent)
+    snapshot = _load_native_snapshot(job_dir_file)
+    if snapshot is None:
+        return None
+    if not manifest:
+        return snapshot.tasks
+
+    manifest_name_counts: dict[str, int] = {}
+    for name in manifest.values():
+        manifest_name_counts[name] = manifest_name_counts.get(name, 0) + 1
+
+    tasks: dict[str, TaskInput] = {}
+    consumed: set[str] = set()
+    for index, name in manifest.items():
+        matches = [
+            (trial_name, task)
+            for trial_name, task in snapshot.tasks.items()
+            if task.task_name == name or task.task_name == f"terminal-bench/{name}"
+        ]
+        if manifest_name_counts[name] == 1 and matches:
+            trial_name, task = max(
+                matches,
+                key=lambda match: (_result_mtime(match[1]), match[0]),
+            )
+            task.task_index = index
+            task.task_name = name
+            tasks[index] = task
+            consumed.update(match[0] for match in matches)
+        else:
+            tasks[index] = TaskInput(task_index=index, task_name=name)
+    for trial_name, task in snapshot.tasks.items():
+        if trial_name not in consumed:
+            tasks.setdefault(trial_name, task)
+    return tasks
+
+
+def collect_task_results(
+    run_dir: Path, agent: str
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    done_path, failed_path = locate_queue_files(run_dir, agent)
+    manifest = load_task_manifest(run_dir)
+    tasks = load_native_task_records(run_dir, agent, manifest)
+    if tasks is None:
+        tasks = load_task_records(done_path, failed_path)
+    for index, name in manifest.items():
+        tasks.setdefault(index, TaskInput(task_index=index, task_name=name))
+
+    records: dict[str, dict[str, Any]] = {}
+    counts = {
+        "total": len(tasks),
+        "complete_success": 0,
+        "complete_failed": 0,
+        "complete_unknown": 0,
+        "not_complete": 0,
+        "finished": 0,
+        "success_rate": 0.0,
+    }
+    for index, task in sorted(tasks.items()):
+        status, signals, evidence = classify_task_status(
+            task, [run_dir, done_path.parent]
+        )
+        counts[status] += 1
+        counts["finished"] += status != "not_complete"
+        records[index] = {
+            "task_index": index,
+            "task_name": task.task_name,
+            "task_complete_status": status,
+            "task_result_signals": sorted(set(signals)),
+            "evidence": evidence,
+            "result_path": task.result_path or "",
+        }
+    if counts["finished"]:
+        counts["success_rate"] = counts["complete_success"] / counts["finished"] * 100.0
+    return records, counts
+
+
+def read_monitor_snapshot(run_dir: Path) -> tuple[dict[str, Any] | None, str]:
+    path = run_dir / "monitor" / "monitor-latest.json"
+    try:
+        if path.is_file():
+            return read_json(path), str(path)
+    except (OSError, ValueError):
+        pass
+    return None, ""
+
+
+def generate_monitor_snapshot(
+    run_dir: Path,
+    output_dir: Path,
+    agent: str,
+    *,
+    startup_grace: int = 0,
+) -> tuple[dict[str, Any] | None, str]:
+    done_path, failed_path = locate_queue_files(run_dir, agent)
+    job_dir_file, pid_file, exit_file = locate_native_runtime_files(run_dir, agent)
+    native_runtime = job_dir_file.is_file()
+    monitor_dir = output_dir / "verification-monitor"
+    monitor_output = monitor_dir / "monitor-latest.json"
+    try:
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            run_loop(
+                run_dir=run_dir,
+                done_path=done_path,
+                failed_path=failed_path,
+                queue_dir=done_path.parent if done_path.parent.exists() else None,
+                task_manifest_path=run_dir / "task-manifest.tsv",
+                task_file_path=run_dir / "tasks.txt",
+                restart_cmd=None,
+                stop_cmd=None,
+                output_path=monitor_output,
+                poll_interval=1,
+                max_retries=0,
+                S_default=1800,
+                S_min=900,
+                S_max=3600,
+                startup_grace=startup_grace,
+                configured_timeout=None,
+                total_override=None,
+                running_override=None,
+                claimed_override=None,
+                remaining_override=None,
+                user_report_output=monitor_dir / "user-notify-latest.json",
+                analyzer_handover_output=monitor_dir / "analyzer-handover-latest.json",
+                runner_action_output=monitor_dir / "runner-action-latest.json",
+                loop_once=True,
+                include_unknown_not_complete=True,
+                state_path=monitor_dir / "monitor-state.json",
+                harbor_job_dir_file=job_dir_file if native_runtime else None,
+                harbor_pid_file=pid_file if native_runtime else None,
+                harbor_exit_file=exit_file if native_runtime else None,
+            )
+    except (OSError, ValueError):
+        return None, ""
+    return (
+        (read_json(monitor_output), str(monitor_output))
+        if monitor_output.is_file()
+        else (None, "")
+    )

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/evaluator.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/evaluator.py
@@ -45,8 +45,17 @@ def evaluate_once(
     )
     tasks = dict(task_records) if task_records is not None else load_task_records(done_path, failed_path)
     # Add manifest tasks for not_complete inference
+    represented_names: dict[str, int] = {}
+    if task_records is not None:
+        for task in tasks.values():
+            task_name = task.task_name.removeprefix("terminal-bench/")
+            if task_name:
+                represented_names[task_name] = represented_names.get(task_name, 0) + 1
     for task_index, task_name in tasks_manifest.items():
         if task_index in tasks:
+            continue
+        if represented_names.get(task_name, 0):
+            represented_names[task_name] -= 1
             continue
         tasks[task_index] = TaskInput(task_index=task_index, task_name=task_name)
     if not tasks_manifest and total is not None:

--- a/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_monitor/runner.py
@@ -149,8 +149,9 @@ def run_loop(
     harbor_job_dir_file: Path | None = None,
     harbor_pid_file: Path | None = None,
     harbor_exit_file: Path | None = None,
+    state_path: Path | None = None,
 ) -> None:
-    state_path = run_dir / ".monitor_state.json"
+    state_path = state_path or run_dir / ".monitor_state.json"
     state = load_state(state_path)
     state.setdefault("retry_count", 0)
     state.setdefault("history", [])
@@ -191,7 +192,7 @@ def run_loop(
             if native_snapshot is None:
                 # Give the native Harbor process its normal startup window. If it
                 # exits without creating a job result, this becomes abnormal_exit.
-                total = total if total is not None else 1
+                total = total if total is not None else len(tasks_manifest) or 1
                 claimed = claimed if claimed is not None else 0
                 remaining = remaining if remaining is not None else total
                 running = 1 if process_is_alive(harbor_pid_file) else 0

--- a/Agents/utils/common/Harbor/tests/fixer_test_support.py
+++ b/Agents/utils/common/Harbor/tests/fixer_test_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 import tempfile
@@ -290,6 +291,45 @@ def make_fix_plan() -> dict:
         ],
         "unplanned_tasks": [],
         "generation_errors": [],
+    }
+
+
+def make_exec_result(
+    plan_status: str = "success",
+    *,
+    policy_status: str = "allowed",
+    fix_plan: dict | None = None,
+) -> dict:
+    fix_plan = fix_plan or make_fix_plan()
+    serialized_plan = json.dumps(
+        fix_plan, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    action_status = "success" if plan_status == "success" else "failed"
+    return {
+        "schema_version": 1,
+        "kind": "harbor_fixer_exec_result",
+        "source": {
+            "fix_plan_path": "fix-plan-latest.json",
+            "workspace_root": "/workspace",
+            "fix_plan_sha256": hashlib.sha256(
+                serialized_plan.encode("utf-8")
+            ).hexdigest(),
+        },
+        "status": "success" if plan_status == "success" else "failed",
+        "policy_status": policy_status,
+        "plans": [
+            {
+                "plan_id": "fix-001",
+                "status": plan_status,
+                "actions": [
+                    {
+                        "action_id": "action-001",
+                        "status": action_status,
+                        "exit_code": 0 if action_status == "success" else 1,
+                    }
+                ],
+            }
+        ],
     }
 
 

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_contracts.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_contracts.py
@@ -1,0 +1,328 @@
+"""Contract and Harbor-state tests for Fixer verification."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for path in (TEST_DIR, SCRIPT_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from fixer_test_support import FixerTestCase, make_exec_result, make_fix_plan
+from harbor_fixer.validation import (
+    ValidationError,
+    validate_exec_result,
+    validate_verification_input,
+    validate_verification_result,
+)
+from harbor_fixer.verification.run_state import (
+    collect_task_results,
+    generate_monitor_snapshot,
+    read_monitor_snapshot,
+)
+
+
+def _empty_verification_result() -> dict:
+    return {
+        "schema_version": 2,
+        "kind": "harbor_fixer_verification_result",
+        "agent": "claude-code",
+        "verification_mode": "smoke_test",
+        "source": {},
+        "execution": {"status": "success", "policy_status": "allowed"},
+        "status": "inconclusive",
+        "reason_codes": ["no_verifiable_tasks"],
+        "rerun": {},
+        "sampling": {"plan_task_count": 0},
+        "new_run_summary": {},
+        "plan_results": [],
+        "task_results": [],
+        "unexpected_run_task_results": [],
+    }
+
+
+def _successful_task_result() -> dict:
+    payload = _empty_verification_result()
+    payload.update(
+        status="fixed",
+        reason_codes=[],
+        sampling={"plan_task_count": 1},
+        task_results=[
+            {
+                "task": {
+                    "task_index": "1",
+                    "task_name": "task-one",
+                    "attempt_id": None,
+                },
+                "verification_status": "fixed",
+                "exec_status": "success",
+                "exec_failure_reason": None,
+                "new_run": {
+                    "task_index": "1",
+                    "task_name": "task-one",
+                    "task_complete_status": "complete_success",
+                },
+            }
+        ],
+    )
+    return payload
+
+
+class HarborFixerVerificationContractsTest(FixerTestCase):
+    def test_exec_result_requires_consistent_policy_status(self) -> None:
+        validate_exec_result(make_exec_result())
+
+        missing = make_exec_result()
+        missing.pop("policy_status")
+        with self.assertRaisesRegex(ValidationError, "policy_status"):
+            validate_exec_result(missing)
+
+        denied_success = make_exec_result(policy_status="denied")
+        with self.assertRaisesRegex(ValidationError, "denied requires failed"):
+            validate_exec_result(denied_success)
+
+    def test_empty_verification_result_requires_reason(self) -> None:
+        payload = _empty_verification_result()
+        validate_verification_result(payload)
+
+        invalid = copy.deepcopy(payload)
+        invalid["reason_codes"] = []
+        with self.assertRaisesRegex(ValidationError, "no_verifiable_tasks"):
+            validate_verification_result(invalid)
+
+    def test_verification_input_is_bound_to_executed_fix_plan(self) -> None:
+        fix_plan = make_fix_plan()
+        fix_plan["source"]["agent"] = "claude-code"
+        payload = {
+            "schema_version": 2,
+            "kind": "harbor_fixer_verification_input",
+            "fix_plan_path": "fix-plan-latest.json",
+            "exec_result_path": "exec-result-latest.json",
+            "verification_run_dir": "run",
+            "output_dir": "output",
+            "agent": "claude-code",
+            "monitor_policy": "auto",
+            "verification_mode": "smoke_test",
+            "verification_task_limit_per_plan": 2,
+            "fix_plan": fix_plan,
+            "exec_result": make_exec_result(fix_plan=fix_plan),
+        }
+        validate_verification_input(payload)
+
+        wrong_agent = copy.deepcopy(payload)
+        wrong_agent["agent"] = "opencode"
+        with self.assertRaisesRegex(ValidationError, "does not match fix_plan source"):
+            validate_verification_input(wrong_agent)
+
+        selected_agent = copy.deepcopy(payload)
+        selected_agent["fix_plan"]["source"]["agent"] = ""
+        selected_agent["exec_result"] = make_exec_result(
+            fix_plan=selected_agent["fix_plan"]
+        )
+        validate_verification_input(selected_agent)
+
+        selected_agent["agent"] = "unsupported"
+        with self.assertRaisesRegex(ValidationError, "claude-code, opencode, oracle"):
+            validate_verification_input(selected_agent)
+
+        missing_digest = copy.deepcopy(payload)
+        missing_digest["exec_result"]["source"].pop("fix_plan_sha256")
+        with self.assertRaisesRegex(ValidationError, "fix_plan_sha256"):
+            validate_verification_input(missing_digest)
+
+        payload["fix_plan"]["plans"][0]["actions"][0]["purpose"] = "changed"
+        with self.assertRaisesRegex(ValidationError, "does not match fix_plan"):
+            validate_verification_input(payload)
+
+    def test_task_verification_status_matches_execution_and_run(self) -> None:
+        payload = _successful_task_result()
+        validate_verification_result(payload)
+
+        payload["task_results"][0]["new_run"]["task_complete_status"] = (
+            "complete_failed"
+        )
+        with self.assertRaisesRegex(ValidationError, "must be not_fixed"):
+            validate_verification_result(payload)
+
+        task = payload["task_results"][0]
+        task.update(
+            verification_status="fixed",
+            exec_status="failed",
+            exec_failure_reason="execution_failed",
+            new_run=None,
+        )
+        with self.assertRaisesRegex(ValidationError, "must be exec_failed"):
+            validate_verification_result(payload)
+
+    def test_verification_result_rejects_contradictory_summaries(self) -> None:
+        denied = _successful_task_result()
+        denied["execution"]["policy_status"] = "denied"
+        with self.assertRaisesRegex(ValidationError, "requires failed"):
+            validate_verification_result(denied)
+
+        wrong_status = _successful_task_result()
+        wrong_status["task_results"][0]["verification_status"] = "not_fixed"
+        wrong_status["task_results"][0]["new_run"]["task_complete_status"] = (
+            "complete_failed"
+        )
+        with self.assertRaisesRegex(ValidationError, "status must be not_fixed"):
+            validate_verification_result(wrong_status)
+
+        wrong_record = _successful_task_result()
+        wrong_record["task_results"][0]["new_run"]["task_index"] = "2"
+        with self.assertRaisesRegex(ValidationError, "identity does not match"):
+            validate_verification_result(wrong_record)
+
+    def test_collect_task_results_uses_harbor_classification(self) -> None:
+        run_dir = self.root / "run"
+        queue_dir = run_dir / "queue" / "claude-code"
+        queue_dir.mkdir(parents=True)
+        (run_dir / "task-manifest.tsv").write_text(
+            "1\ttask-one\n", encoding="utf-8"
+        )
+        (queue_dir / "done.txt").write_text(
+            "1\ttask-one\t1.0\t\t\n", encoding="utf-8"
+        )
+        (queue_dir / "failed.txt").write_text("", encoding="utf-8")
+        source_state = run_dir / ".monitor_state.json"
+        source_state.write_text('{"sentinel": true}\n', encoding="utf-8")
+
+        records, summary = collect_task_results(run_dir, "claude-code")
+        snapshot, _ = generate_monitor_snapshot(
+            run_dir, self.root / "output", "claude-code"
+        )
+
+        self.assertEqual(records["1"]["task_complete_status"], "complete_success")
+        self.assertEqual(summary["complete_success"], 1)
+        self.assertEqual(snapshot["benchmark_status"], "completed")
+        self.assertEqual(source_state.read_text(encoding="utf-8"), '{"sentinel": true}\n')
+
+        other_queue = run_dir / "queue" / "opencode"
+        other_queue.mkdir()
+        (other_queue / "done.txt").write_text("", encoding="utf-8")
+        explicit, _ = collect_task_results(run_dir, "claude-code")
+        self.assertEqual(explicit["1"]["task_complete_status"], "complete_success")
+
+    def test_native_harbor_results_use_smoke_indexes_and_monitor_metadata(self) -> None:
+        run_dir = self.root / "native-run"
+        runtime_dir = run_dir / "runtime" / "claude-code"
+        job_dir = run_dir / "native-job"
+        trial_dir = job_dir / "task-one__random"
+        retry_dir = job_dir / "task-one__retry"
+        prefixed_trial_dir = job_dir / "fix-git__random"
+        runtime_dir.mkdir(parents=True)
+        trial_dir.mkdir(parents=True)
+        retry_dir.mkdir()
+        prefixed_trial_dir.mkdir()
+        (run_dir / "tasks.txt").write_text("task-one\nfix-git\n", encoding="utf-8")
+        (runtime_dir / "harbor-job-dir").write_text(f"{job_dir}\n", encoding="utf-8")
+        (runtime_dir / "harbor-benchmark.exit").write_text("0\n", encoding="utf-8")
+        (job_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "n_total_trials": 3,
+                    "stats": {"n_running_trials": 0, "n_pending_trials": 0},
+                    "finished_at": "2026-08-18T00:00:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (trial_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "trial_name": "task-one__random",
+                    "task_name": "task-one",
+                    "verifier_result": {"rewards": {"reward": 1.0}},
+                    "exception_info": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (prefixed_trial_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "trial_name": "fix-git__random",
+                    "task_name": "terminal-bench/fix-git",
+                    "verifier_result": {"rewards": {"reward": 1.0}},
+                    "exception_info": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (retry_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "trial_name": "task-one__retry",
+                    "task_name": "task-one",
+                    "verifier_result": {"rewards": {"reward": 1.0}},
+                    "exception_info": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        records, summary = collect_task_results(run_dir, "claude-code")
+        snapshot, _ = generate_monitor_snapshot(
+            run_dir, self.root / "native-output", "claude-code"
+        )
+
+        self.assertEqual(set(records), {"1", "2"})
+        self.assertEqual(records["1"]["task_name"], "task-one")
+        self.assertEqual(records["1"]["task_complete_status"], "complete_success")
+        self.assertEqual(records["1"]["result_path"], str(retry_dir / "result.json"))
+        self.assertEqual(records["2"]["task_name"], "fix-git")
+        self.assertEqual(records["2"]["task_complete_status"], "complete_success")
+        self.assertEqual(summary["complete_success"], 2)
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot["benchmark_status"], "completed")
+        self.assertEqual(snapshot["task_summary"]["total_evaluated"], 3)
+        self.assertEqual(snapshot["task_summary"]["not_complete"], 0)
+        self.assertFalse(snapshot["analyzer_handover"]["should_run_analyzer"])
+
+        (prefixed_trial_dir / "result.json").unlink()
+        partial, _ = generate_monitor_snapshot(
+            run_dir, self.root / "partial-native-output", "claude-code"
+        )
+
+        self.assertIsNotNone(partial)
+        assert partial is not None
+        self.assertEqual(partial["task_summary"]["total_evaluated"], 3)
+        self.assertEqual(partial["task_summary"]["not_complete"], 1)
+        self.assertTrue(partial["analyzer_handover"]["should_run_analyzer"])
+        self.assertEqual(partial["analyzer_handover"]["tasks"][0]["task_name"], "fix-git")
+
+        waiting_run = self.root / "waiting-native-run"
+        waiting_runtime = waiting_run / "runtime" / "claude-code"
+        waiting_runtime.mkdir(parents=True)
+        (waiting_run / "tasks.txt").write_text("task-one\ntask-two\n", encoding="utf-8")
+        (waiting_runtime / "harbor-job-dir").write_text("", encoding="utf-8")
+
+        waiting, _ = generate_monitor_snapshot(
+            waiting_run, self.root / "waiting-native-output", "claude-code"
+        )
+
+        self.assertIsNotNone(waiting)
+        assert waiting is not None
+        self.assertEqual(waiting["task_summary"]["total_evaluated"], 2)
+        self.assertEqual(waiting["task_summary_action"]["total"], 2)
+        self.assertTrue(waiting["analyzer_handover"]["should_run_analyzer"])
+        self.assertEqual(len(waiting["analyzer_handover"]["tasks"]), 2)
+
+    def test_read_monitor_snapshot_tolerates_partial_json(self) -> None:
+        run_dir = self.root / "live-run"
+        monitor_path = run_dir / "monitor" / "monitor-latest.json"
+        monitor_path.parent.mkdir(parents=True)
+        monitor_path.write_text('{"benchmark_status":', encoding="utf-8")
+
+        self.assertEqual(read_monitor_snapshot(run_dir), (None, ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer can now generate, authorize, and execute structured Fix Plans, but the next verification stage does not yet have a stable input/result contract or a shared interpretation of Harbor rerun state. Without that boundary, later rerun and reporting changes could disagree about plan identity, policy-denied execution, task completion, or manifest-only runs.

This PR adds the minimal contract and Harbor-state foundation for verification. It is the first verification split for the Fixer work tracked in [sii-system/tasks#115](https://github.com/sii-system/tasks/issues/115).

## 2. Summary of the change

- Add schema-versioned validators for Fixer verification inputs and results.
- Bind verification inputs to validated Fix Plan and execution artifacts, including matching plan IDs, smoke-test limits, and monitor policy.
- Model execution and policy outcomes explicitly, including `policy_denied`, `execution_failed`, and the empty-plan `no_verifiable_tasks` result.
- Require each task verification status to match its execution status and Harbor rerun completion status.
- Add Harbor-state readers that reuse the existing monitor manifest, queue-record, task-classification, and snapshot logic.
- Support both `task-manifest.tsv` and legacy `tasks.txt` run layouts when collecting results and generating monitor snapshots.
- Add focused contract and manifest-only monitor regression tests, plus shared execution-result test fixtures.

This PR intentionally stops at contracts and read-only Harbor-state interpretation. Task selection, rerun execution, verification orchestration, and CLI integration remain in subsequent staged PRs.

## 3. Other details

Prerequisite:

- Fixer execution: #89

Validation performed:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` — 162 tests passed
- `python3 -m ruff check Agents/utils/common/Harbor/scripts/harbor_fixer Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_contracts.py` — passed
- `git diff --check` — passed

Related issue: https://github.com/sii-system/tasks/issues/115
