### PR TITLE
fix(harbor): propagate Fixer runner agent metadata

### DIFF
--- a/Agents/utils/common/Harbor/ANALYZER_ARCHITECTURE.md
+++ b/Agents/utils/common/Harbor/ANALYZER_ARCHITECTURE.md
@@ -86,6 +86,7 @@ snapshot paths named inside it.
 | `analyzer-artifacts-latest.json` `artifacts.benchmark_report_path` | `analyzer-runs/<handover_id>/<publication_id>.json` | benchmark-level report containing every task analysis |
 | `analyzer-artifacts-latest.json` `artifacts.env_infra_tasks_path` | `env-infra-tasks/<handover_id>/<publication_id>.json` | only tasks classified as `env_fail` or `infra_fail` |
 | `analyzer-artifacts-latest.json` `artifacts.fix_line_index_path` | `fix-line-index/<handover_id>/<publication_id>.jsonl` | legacy-named evidence index; each row points to lines used by the analyzer |
+| `analyzer-artifacts-latest.json` `monitor_path` | external monitor snapshot | monitor used to recover the Harbor runner agent; may be unavailable after relocation |
 
 `fix-line-index` is a historical artifact name. Its rows are root-cause
 evidence references, not repair instructions.

--- a/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
+++ b/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
@@ -106,6 +106,7 @@ def _config(args: argparse.Namespace) -> AnalyzerConfig:
         run_dir=run_dir,
         queue_dir=queue_dir.resolve() if queue_dir else None,
         output_dir=output_dir,
+        monitor_path=args.handover.resolve().parent / "monitor-latest.json",
         run_id=args.run_id,
         pi_bin=args.pi_bin,
         provider=args.pi_provider,

--- a/Agents/utils/common/Harbor/scripts/fixer.py
+++ b/Agents/utils/common/Harbor/scripts/fixer.py
@@ -44,7 +44,11 @@ def build_pi_config(args: argparse.Namespace) -> PiInvocationConfig:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Harbor Fixer MVP CLI")
-    parser.add_argument("--analyzer-output", type=Path)
+    parser.add_argument(
+        "--analyzer-output",
+        type=Path,
+        default=os.environ.get("HARBOR_ANALYZER_OUTPUT_DIR"),
+    )
     parser.add_argument("--output-dir", required=True, type=Path)
     parser.add_argument("--pi-bin", default=os.environ.get("HARBOR_FIXER_PI_BIN", "pi"))
     parser.add_argument(

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
@@ -41,6 +41,7 @@ class AnalyzerConfig:
     run_dir: Path
     queue_dir: Path | None
     output_dir: Path
+    monitor_path: Path | None = None
     run_id: str | None = None
     pi_bin: str = "pi"
     provider: str = "harbor-analyzer"
@@ -542,6 +543,7 @@ def _write_outputs(
         "handover_id": handover_id,
         "publication_id": publication_id,
         "run_id": benchmark_report.get("run_id"),
+        "monitor_path": str(config.monitor_path) if config.monitor_path else "",
         "generated_at": generated_at,
         "artifacts": artifacts,
     }

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/analyzer_inputs.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/analyzer_inputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,33 @@ def _path_component(value: Any, name: str) -> str:
     return text
 
 
+def _resolve_run_agent(
+    manifest: dict[str, Any], run_id: str
+) -> tuple[str, Path | None]:
+    recorded_path = str(manifest.get("monitor_path") or "")
+    monitor_dir = os.environ.get("HARBOR_MONITOR_DIR")
+    candidates = [
+        Path(path).expanduser()
+        for path in (
+            recorded_path,
+            str(Path(monitor_dir) / "monitor-latest.json") if monitor_dir else "",
+        )
+        if path
+    ]
+    for monitor_path in dict.fromkeys(candidates):
+        if not monitor_path.is_file():
+            continue
+        monitor = read_json(monitor_path)
+        handover = monitor.get("analyzer_handover")
+        if not isinstance(handover, dict) or handover.get("run_id") != run_id:
+            continue
+        agent = handover.get("agent")
+        if not agent:
+            continue
+        return _path_component(agent, "monitor agent"), monitor_path
+    return "", None
+
+
 def resolve_analyzer_paths(analyzer_output_path: Path) -> dict[str, Any]:
     """Resolve every handover's current publication from the Analyzer manifest."""
 
@@ -32,6 +60,7 @@ def resolve_analyzer_paths(analyzer_output_path: Path) -> dict[str, Any]:
     manifest_path = analyzer_root / "analyzer-artifacts-latest.json"
     manifest = read_json(manifest_path)
     validate_analyzer_manifest(manifest)
+    agent, monitor_path = _resolve_run_agent(manifest, manifest["run_id"])
 
     publications: list[dict[str, str]] = []
     for index, item in enumerate(manifest["publications"]):
@@ -64,7 +93,9 @@ def resolve_analyzer_paths(analyzer_output_path: Path) -> dict[str, Any]:
     return {
         "analyzer_root": analyzer_root,
         "manifest_path": manifest_path,
+        "monitor_path": monitor_path,
         "run_id": manifest["run_id"],
+        "agent": agent,
         "publications": publications,
     }
 
@@ -94,7 +125,9 @@ def build_task_inputs(
     source = {
         "analyzer_root": str(resolved["analyzer_root"]),
         "manifest_path": str(resolved["manifest_path"]),
+        "monitor_path": str(resolved["monitor_path"] or ""),
         "run_id": resolved["run_id"],
+        "agent": resolved["agent"],
         "publications": resolved["publications"],
     }
 

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -217,6 +217,12 @@ def validate_analyzer_manifest(payload: dict[str, Any]) -> None:
         name="analyzer artifact manifest",
     )
     require_string(payload.get("run_id"), "analyzer artifact manifest run_id")
+    if "monitor_path" in payload:
+        require_string(
+            payload["monitor_path"],
+            "analyzer artifact manifest monitor_path",
+            allow_empty=True,
+        )
     seen_handovers: set[str] = set()
     for index, item in enumerate(
         require_list(payload.get("publications"), "analyzer artifact manifest publications")

--- a/Agents/utils/common/Harbor/tests/fixer_test_support.py
+++ b/Agents/utils/common/Harbor/tests/fixer_test_support.py
@@ -44,6 +44,7 @@ def write_analyzer_fixture(
     root: Path,
     count: int = 1,
     *,
+    agent: str = "claude-code",
     handover_task_indexes: tuple[tuple[int, ...], ...] | None = None,
 ) -> Path:
     analyzer_dir = root / "analyzer"
@@ -128,12 +129,28 @@ def write_analyzer_fixture(
             "handover_id": publications[-1]["handover_id"],
             "publication_id": publications[-1]["publication_id"],
             "run_id": "run-1",
+            "monitor_path": str(root / "monitor" / "monitor-latest.json"),
             "generated_at": "2026-07-16T00:00:00Z",
             "artifacts": {
                 "env_infra_tasks_path": "/stale-copy/env-infra-tasks.json",
                 "fix_line_index_path": "/stale-copy/fix-line-index.jsonl",
             },
             "publications": publications,
+        },
+    )
+    queue_dir = root / "queue" / agent
+    write_json(
+        root / "monitor" / "monitor-latest.json",
+        {
+            "analyzer_handover": {
+                "agent": agent,
+                "run_id": "run-1",
+                "paths": {
+                    "run_dir": str(root),
+                    "queue_dir": str(queue_dir),
+                },
+            },
+            "user_notify": {"paths": {"queue_dir": str(queue_dir)}},
         },
     )
     return analyzer_dir

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -754,6 +754,7 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
                 run_dir=Path(root) / "run",
                 queue_dir=Path(root) / "run" / "queue",
                 output_dir=output_dir,
+                monitor_path=Path(root) / "monitor" / "monitor-latest.json",
             )
 
             _write_outputs(
@@ -769,6 +770,10 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
             self.assertTrue(manifest_path.is_file())
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             self.assertEqual(manifest["handover_id"], HANDOVER_ID)
+            self.assertEqual(
+                manifest["monitor_path"],
+                str(Path(root) / "monitor" / "monitor-latest.json"),
+            )
             publication_id = manifest["publication_id"]
             self.assertEqual(
                 manifest["artifacts"]["benchmark_report_path"],

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_plan.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_plan.py
@@ -45,8 +45,19 @@ from harbor_fixer.validation import (
 
 class HarborFixerPlanTest(FixerTestCase):
     def test_task_summary_retry_identity_and_contract(self) -> None:
-        analyzer_dir = write_analyzer_fixture(self.root)
-        task_input = build_task_inputs(analyzer_dir)[0][0]
+        analyzer_dir = write_analyzer_fixture(self.root, agent="opencode")
+        env_monitor_root = self.root / "environment-monitor"
+        write_analyzer_fixture(env_monitor_root, agent="claude-code")
+        with mock.patch.dict(
+            os.environ, {"HARBOR_MONITOR_DIR": str(env_monitor_root / "monitor")}
+        ):
+            task_inputs, source = build_task_inputs(analyzer_dir)
+        task_input = task_inputs[0]
+        self.assertEqual(source["agent"], "opencode")
+        self.assertEqual(
+            source["monitor_path"],
+            str(self.root / "monitor" / "monitor-latest.json"),
+        )
 
         invoker = SequenceInvoker(["not-json", json.dumps(task_summary_for(task_input))])
         summaries, errors = collect_task_summaries([task_input], invoker, self.root / "out")
@@ -59,6 +70,62 @@ class HarborFixerPlanTest(FixerTestCase):
         bad_summary["analyzer_alignment"]["final_class"] = "infra_fail"
         with self.assertRaises(ValidationError):
             validate_task_summary(bad_summary, expected_input=task_input)
+
+        monitor_path = Path(source["monitor_path"])
+        monitor = json.loads(monitor_path.read_text(encoding="utf-8"))
+        monitor["analyzer_handover"]["run_id"] = "other-run"
+        monitor_path.write_text(json.dumps(monitor), encoding="utf-8")
+        with mock.patch.dict(
+            os.environ, {"HARBOR_MONITOR_DIR": str(env_monitor_root / "monitor")}
+        ):
+            _, source = build_task_inputs(analyzer_dir)
+        self.assertEqual(source["agent"], "claude-code")
+        self.assertEqual(
+            source["monitor_path"],
+            str(env_monitor_root / "monitor" / "monitor-latest.json"),
+        )
+
+        fallback_root = self.root / "fallback-monitor"
+        fallback_analyzer = write_analyzer_fixture(fallback_root, agent="opencode")
+        fallback_manifest_path = fallback_analyzer / "analyzer-artifacts-latest.json"
+        fallback_manifest = json.loads(fallback_manifest_path.read_text(encoding="utf-8"))
+        fallback_manifest["monitor_path"] = "/missing/monitor-latest.json"
+        fallback_manifest_path.write_text(json.dumps(fallback_manifest), encoding="utf-8")
+        with mock.patch.dict(
+            os.environ, {"HARBOR_MONITOR_DIR": str(fallback_root / "monitor")}
+        ):
+            _, source = build_task_inputs(fallback_analyzer)
+        self.assertEqual(source["agent"], "opencode")
+
+        analyzer_without_monitor = write_analyzer_fixture(self.root / "no-monitor")
+        (analyzer_without_monitor.parent / "monitor" / "monitor-latest.json").unlink()
+        with mock.patch.dict(os.environ, {"HARBOR_MONITOR_DIR": ""}):
+            _, source = build_task_inputs(analyzer_without_monitor)
+        self.assertEqual(source["agent"], "")
+        self.assertEqual(source["monitor_path"], "")
+
+    def test_analyzer_output_uses_environment_when_cli_is_omitted(self) -> None:
+        analyzer_dir = write_analyzer_fixture(self.root)
+        output_dir = self.root / "prepared"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_DIR / "fixer.py"),
+                "--prepare-only",
+                "--output-dir",
+                str(output_dir),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                "PATH": "/usr/bin:/bin",
+                "HARBOR_ANALYZER_OUTPUT_DIR": str(analyzer_dir),
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        source = json.loads((output_dir / "source.json").read_text(encoding="utf-8"))
+        self.assertEqual(source["analyzer_root"], str(analyzer_dir.resolve()))
 
     def test_main_plan_contract_and_generation_error_ownership(self) -> None:
         task_input = build_task_inputs(write_analyzer_fixture(self.root))[0][0]
@@ -303,6 +370,7 @@ class HarborFixerPlanTest(FixerTestCase):
                 "HARBOR_FIXER_AGENT_TIMEOUT": "bad",
                 "HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS": "1",
                 "HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS": "200000",
+                "HARBOR_ANALYZER_OUTPUT_DIR": str(self.root / "wrong-analyzer"),
             },
         )
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -312,6 +380,8 @@ class HarborFixerPlanTest(FixerTestCase):
         validate_fix_plan_set(plan)
         main_input_path = cli_out / "main-agent-input.json"
         main_input = json.loads(main_input_path.read_text(encoding="utf-8"))
+        self.assertEqual(plan["source"]["agent"], "claude-code")
+        self.assertEqual(plan["source"], main_input["source"])
         for name in ("target_environment_artifact", "target_context_artifact"):
             artifact = main_input[name]
             self.assertEqual(


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer needs the runner agent that produced an Analyzer result so later smoke reruns can read and write the correct agent queue. Analyzer artifacts currently omit that provenance, while inferring it from an Analyzer output directory only works for the default sibling directory layout and breaks for `HARBOR_ANALYZER_OUTPUT_DIR` overrides or relocated artifacts.

This PR adds a location-independent handoff from Analyzer output into the Fix Plan source. It is part of the Fixer work tracked in [sii-system/tasks#115](https://github.com/sii-system/tasks/issues/115).

## 2. Summary of the change

- Record the actual Monitor snapshot path as top-level `monitor_path` provenance in `analyzer-artifacts-latest.json`.
- Resolve the runner agent from the recorded Monitor after binding it to the Analyzer `run_id`.
- Fall back to `HARBOR_MONITOR_DIR/monitor-latest.json` only when the recorded path is unavailable; leave agent provenance empty when neither source exists.
- Copy `agent` and `monitor_path` into the Fixer main-agent input and therefore into the validated Fix Plan source.
- Allow `HARBOR_ANALYZER_OUTPUT_DIR` as the fallback when `--analyzer-output` is omitted, while keeping the CLI argument authoritative.
- Keep older Analyzer manifests valid by making `monitor_path` optional.
- Add focused coverage for recorded-path priority, environment fallbacks, missing Monitor behavior, CLI priority, and Analyzer manifest publication.

## 3. Other details

This PR stops at Analyzer-to-Fix-Plan provenance. It does not select a default agent when provenance is unavailable; downstream verification can require an explicit supported agent instead of guessing.

Validation performed:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_*.py'` — 159 tests passed
- `uvx ruff==0.16.0 check --config .github/ruff.toml <changed Python files>` — passed
- `git diff --check` — passed

Related issue: https://github.com/sii-system/tasks/issues/115
