### PR TITLE
feat(harbor): include Fixer report in benchmark summary

### DIFF
--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -711,6 +711,7 @@ harbor_reset_run_state() {
   rm -rf "$HARBOR_MONITOR_DIR"
   rm -f "$HARBOR_ANALYZER_PID_FILE" "$HARBOR_ANALYZER_SUPERVISOR_PID_FILE" "$HARBOR_ANALYZER_SUPERVISOR_ID_FILE" "$HARBOR_ANALYZER_LOG_FILE" "$HARBOR_ANALYZER_OUTPUT_DIR/.analyzer_state.json" "$HARBOR_ANALYZER_OUTPUT_DIR/.analyzer-ready" "$HARBOR_ANALYZER_OUTPUT_DIR/analyzer-artifacts-latest.json" "$HARBOR_ANALYZER_OUTPUT_DIR/benchmark-summary.md"
   rm -rf "$HARBOR_ANALYZER_OUTPUT_DIR/benchmark-summary"
+  rm -f "$OUTPUT_PATH/fixer/fix-report-latest.md"
   rm -f "$HARBOR_ONLINE_ANALYSIS_PID_FILE" "$HARBOR_ONLINE_ANALYSIS_LOG_FILE"
   rm -f "$HARBOR_ONLINE_ANALYSIS_DIR/environment-events.jsonl" "$HARBOR_ONLINE_ANALYSIS_DIR/environment-summary.json"
   : > "$QUEUE_DIR/done.txt"

--- a/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
+++ b/Agents/utils/common/Harbor/scripts/write_benchmark_summary.py
@@ -1,4 +1,4 @@
-"""Write a human-readable benchmark summary from Monitor and Analyzer artifacts."""
+"""Write a human-readable benchmark summary from Monitor, Analyzer, and Fixer artifacts."""
 
 from __future__ import annotations
 
@@ -429,11 +429,95 @@ def _render_markdown(
     return "\n".join(lines) + "\n"
 
 
+def _markdown_section(markdown: str, heading: str) -> str | None:
+    lines = markdown.splitlines()
+    target = f"## {heading}".casefold()
+    start: int | None = None
+    for index, line in enumerate(lines):
+        if line.strip().casefold() == target:
+            start = index + 1
+            break
+    if start is None:
+        return None
+
+    end = len(lines)
+    for index in range(start, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+    content = "\n".join(lines[start:end]).strip()
+    return content or None
+
+
+def _first_markdown_section(markdown: str, headings: tuple[str, ...]) -> str | None:
+    for heading in headings:
+        if section := _markdown_section(markdown, heading):
+            return section
+    return None
+
+
+def _markdown_preamble(markdown: str) -> str | None:
+    lines = markdown.splitlines()
+    start = 1 if lines and lines[0].startswith("# ") else 0
+    end = next(
+        (index for index in range(start, len(lines)) if lines[index].startswith("## ")),
+        len(lines),
+    )
+    content = "\n".join(lines[start:end]).strip()
+    return content or None
+
+
+def _fixer_report_link(fixer_report_path: Path, output_path: Path) -> str:
+    target = Path(os.path.relpath(fixer_report_path, start=output_path.parent)).as_posix()
+    if any(character.isspace() for character in target):
+        target = f"<{target}>"
+    return f"[fix-report-latest.md]({target})"
+
+
+def _render_fixer_markdown(fixer_report_path: Path, output_path: Path) -> str:
+    lines = ["## Fixer Results", ""]
+    if not fixer_report_path.is_file():
+        lines.append("No Fixer report has been generated for this benchmark run.")
+        return "\n".join(lines) + "\n"
+
+    report = fixer_report_path.read_text(encoding="utf-8")
+    summary = _markdown_section(report, "Summary")
+    if summary is None:
+        human_summary = _markdown_section(report, "Human summary")
+        summary = "\n\n".join(
+            section
+            for section in (human_summary, _markdown_preamble(report))
+            if section
+        ) or None
+    changes = _first_markdown_section(
+        report,
+        ("Changes Applied", "Trial execution"),
+    )
+    remaining_issues = _first_markdown_section(
+        report,
+        ("Remaining Issues", "Failures and interruptions"),
+    )
+
+    lines.append(summary or "The Fixer report does not contain a summary.")
+    lines.extend(["", "### What Fixer Changed", ""])
+    lines.append(changes or "No applied changes were recorded.")
+    lines.extend(["", "### Remaining Issues", ""])
+    lines.append(remaining_issues or "No remaining issues were recorded.")
+    lines.extend(
+        [
+            "",
+            f"Full Fixer report: {_fixer_report_link(fixer_report_path, output_path)}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
 def write_benchmark_summary(
     monitor_path: Path,
     manifest_path: Path,
     output_path: Path,
     expected_run_id: str | None = None,
+    fixer_report_path: Path | None = None,
 ) -> None:
     monitor = _load_json(monitor_path)
     if monitor.get("benchmark_status") == "running":
@@ -453,20 +537,25 @@ def write_benchmark_summary(
         model_output = _fallback_model_output(payload)
     else:
         write_json_atomic(summary_output_path, model_output)
-    write_text_atomic(output_path, _render_markdown(payload, model_output))
+    markdown = _render_markdown(payload, model_output)
+    if fixer_report_path is not None:
+        markdown += "\n" + _render_fixer_markdown(fixer_report_path, output_path)
+    write_text_atomic(output_path, markdown)
 
 
 def main() -> int:
-    if len(sys.argv) not in {4, 5}:
+    if len(sys.argv) not in {4, 5, 6}:
         print(
-            f"usage: {Path(sys.argv[0]).name} MONITOR_JSON ANALYZER_MANIFEST OUTPUT_MD [RUN_ID]",
+            f"usage: {Path(sys.argv[0]).name} MONITOR_JSON ANALYZER_MANIFEST "
+            "OUTPUT_MD [RUN_ID] [FIXER_REPORT_MD]",
             file=sys.stderr,
         )
         return 2
     try:
         write_benchmark_summary(
             *(Path(value) for value in sys.argv[1:4]),
-            expected_run_id=sys.argv[4] if len(sys.argv) == 5 else None,
+            expected_run_id=sys.argv[4] if len(sys.argv) >= 5 else None,
+            fixer_report_path=Path(sys.argv[5]) if len(sys.argv) == 6 else None,
         )
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
         print(f"benchmark summary not written: {exc}", file=sys.stderr)

--- a/Agents/utils/common/Harbor/start.sh
+++ b/Agents/utils/common/Harbor/start.sh
@@ -361,6 +361,7 @@ harbor_write_benchmark_summary() {
     "$HARBOR_MONITOR_DIR/monitor-latest.json" \
     "$HARBOR_ANALYZER_OUTPUT_DIR/analyzer-artifacts-latest.json" \
     "$HARBOR_ANALYZER_OUTPUT_DIR/benchmark-summary.md" "$RUN_ID" \
+    "$OUTPUT_PATH/fixer/fix-report-latest.md" \
     || echo "[WARN] failed to write Harbor benchmark summary" >&2
 }
 

--- a/Agents/utils/common/Harbor/tests/test_benchmark_summary.py
+++ b/Agents/utils/common/Harbor/tests/test_benchmark_summary.py
@@ -622,6 +622,181 @@ class BenchmarkSummaryTests(unittest.TestCase):
 
             self.assertFalse(output_path.exists())
 
+    def test_appends_selected_fixer_report_sections_without_duplicate_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            monitor_path = root_path / "monitor-latest.json"
+            output_path = root_path / "analyzer" / "benchmark-summary.md"
+            fixer_report_path = root_path / "fixer" / "fix-report-latest.md"
+            _write_json(
+                monitor_path,
+                {
+                    "benchmark_status": "completed",
+                    "task_summary": {
+                        "complete_success": 1,
+                        "complete_failed": 0,
+                        "complete_unknown": 0,
+                        "not_complete": 0,
+                        "total_evaluated": 1,
+                    },
+                },
+            )
+            fixer_report_path.parent.mkdir(parents=True)
+            fixer_report_path.write_text(
+                """# Fixer Report
+
+## Summary
+
+Fixer attempted four tasks and verified three fixes.
+
+| Item | Result |
+| --- | --- |
+| Status | Partially fixed |
+| Verification | 3 fixed, 1 still failing |
+
+## Changes Applied
+
+- `task-001`: Corrected the configuration path.
+
+## Verification Result
+
+This detail is already represented by the Summary table.
+
+## Remaining Issues
+
+- `task-004`: The expected configuration file is missing.
+
+## Execution Details
+
+Internal command output that should remain in the full report.
+""",
+                encoding="utf-8",
+            )
+            model_output = {
+                "summary": "The benchmark completed successfully.",
+                "analysis_summary": [],
+                "recommended_actions": [],
+            }
+
+            with mock.patch.object(
+                summary_writer,
+                "run_pi_json_process",
+                return_value=_pi_result(model_output),
+            ):
+                summary_writer.write_benchmark_summary(
+                    monitor_path,
+                    root_path / "missing-manifest.json",
+                    output_path,
+                    fixer_report_path=fixer_report_path,
+                )
+
+            summary = output_path.read_text(encoding="utf-8")
+            self.assertIn("## Fixer Results", summary)
+            self.assertIn("Fixer attempted four tasks and verified three fixes.", summary)
+            self.assertIn("| Verification | 3 fixed, 1 still failing |", summary)
+            self.assertIn("### What Fixer Changed", summary)
+            self.assertIn("Corrected the configuration path.", summary)
+            self.assertIn("### Remaining Issues", summary)
+            self.assertIn("The expected configuration file is missing.", summary)
+            self.assertIn(
+                "Full Fixer report: [fix-report-latest.md](../fixer/fix-report-latest.md)",
+                summary,
+            )
+            self.assertNotIn("## Verification Result", summary)
+            self.assertNotIn("Internal command output", summary)
+
+    def test_reports_missing_fixer_report_without_changing_existing_callers(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            monitor_path = root_path / "monitor-latest.json"
+            output_path = root_path / "benchmark-summary.md"
+            missing_fixer_report = root_path / "fixer" / "fix-report-latest.md"
+            _write_json(
+                monitor_path,
+                {
+                    "benchmark_status": "completed",
+                    "task_summary": {
+                        "complete_success": 1,
+                        "complete_failed": 0,
+                        "complete_unknown": 0,
+                        "not_complete": 0,
+                        "total_evaluated": 1,
+                    },
+                },
+            )
+            model_output = {
+                "summary": "The benchmark completed successfully.",
+                "analysis_summary": [],
+                "recommended_actions": [],
+            }
+
+            with mock.patch.object(
+                summary_writer,
+                "run_pi_json_process",
+                return_value=_pi_result(model_output),
+            ):
+                summary_writer.write_benchmark_summary(
+                    monitor_path,
+                    root_path / "missing-manifest.json",
+                    output_path,
+                    fixer_report_path=missing_fixer_report,
+                )
+
+            summary = output_path.read_text(encoding="utf-8")
+            self.assertIn("## Fixer Results", summary)
+            self.assertIn(
+                "No Fixer report has been generated for this benchmark run.",
+                summary,
+            )
+
+    def test_supports_current_fixer_report_headings(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            output_path = root_path / "analyzer" / "benchmark-summary.md"
+            fixer_report_path = root_path / "fixer" / "fix-report-latest.md"
+            fixer_report_path.parent.mkdir(parents=True)
+            fixer_report_path.write_text(
+                """# Harbor Fixer Report: run-001
+
+| Field | Value |
+| --- | --- |
+| Overall status | partially_fixed |
+| Sampled tasks | 4 |
+
+## Human summary
+
+Three sampled tasks were fixed and one still fails.
+
+## Trial execution
+
+| Plan | Command | Status | Purpose |
+| --- | --- | --- | --- |
+| fix-001 | cmd-001 | success | Correct the configuration path. |
+
+## Verification
+
+Detailed verification data remains in the full report.
+
+## Failures and interruptions
+
+| Stage | Item | Cause |
+| --- | --- | --- |
+| verification | task-004 | configuration file missing |
+""",
+                encoding="utf-8",
+            )
+
+            summary = summary_writer._render_fixer_markdown(
+                fixer_report_path,
+                output_path,
+            )
+
+            self.assertIn("Three sampled tasks were fixed and one still fails.", summary)
+            self.assertIn("| Overall status | partially_fixed |", summary)
+            self.assertIn("Correct the configuration path.", summary)
+            self.assertIn("configuration file missing", summary)
+            self.assertNotIn("Detailed verification data", summary)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_task_selection.py
+++ b/Agents/utils/common/Harbor/tests/test_task_selection.py
@@ -134,23 +134,33 @@ class HarborTaskSelectionTest(unittest.TestCase):
             self.assertIn("unknown task(s): missing-a, missing-b", result.stderr)
             self.assertFalse((output / "tasks.txt").exists())
 
-    def test_reset_removes_generated_benchmark_summary(self) -> None:
+    def test_reset_removes_generated_benchmark_and_fixer_summaries(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             output, common = self.local_fixture(Path(tmp), "task-a")
             analyzer_dir = output / "analyzer"
             summary_dir = analyzer_dir / "benchmark-summary"
+            fixer_dir = output / "fixer"
             summary_dir.mkdir(parents=True)
+            fixer_dir.mkdir()
             (analyzer_dir / "benchmark-summary.md").write_text("old summary\n", encoding="utf-8")
             (summary_dir / "summary-input.json").write_text("{}\n", encoding="utf-8")
+            (fixer_dir / "fix-report-latest.md").write_text(
+                "old fixer report\n",
+                encoding="utf-8",
+            )
             unrelated = analyzer_dir / "keep.txt"
             unrelated.write_text("keep\n", encoding="utf-8")
+            fixer_unrelated = fixer_dir / "keep.json"
+            fixer_unrelated.write_text("{}\n", encoding="utf-8")
 
             result = self.run_env('mkdir -p "$QUEUE_DIR"; harbor_reset_run_state', **common)
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse((analyzer_dir / "benchmark-summary.md").exists())
             self.assertFalse(summary_dir.exists())
+            self.assertFalse((fixer_dir / "fix-report-latest.md").exists())
             self.assertTrue(unrelated.exists())
+            self.assertTrue(fixer_unrelated.exists())
 
     def test_start_passes_run_id_to_analyzer(self) -> None:
         self.assertIn('--run-id "$RUN_ID"', START_SH.read_text(encoding="utf-8"))


### PR DESCRIPTION
## 1. Why the change?

The human-readable benchmark summary currently covers Monitor and Analyzer results only. When Fixer produces fix-report-latest.md, users must open that full report separately to understand the fix outcome.

## 2. Summary of the change

- Accept the Fixer Markdown report as an optional benchmark-summary input.
- Append only the report summary, applied changes, and remaining issues.
- Keep verification statistics in the summary table and omit the duplicate verification subsection and execution details.
- Link the full Fixer report and show a clear message when it has not been generated.
- Pass the conventional OUTPUT_PATH/fixer/fix-report-latest.md location from the Harbor launcher.
- Support both the agreed section names and the current experimental Reporter headings without reading Fixer JSON artifacts.

## 3. Other details

This does not start or control Fixer and does not add Controller UI. The summary writer remains backward-compatible for callers that do not provide a Fixer report path.

Validation:
- 11 benchmark summary tests passed.
- 140 sandbox-compatible Harbor tests passed; the one loopback-socket test passed outside the sandbox.
- Ruff checks and bash syntax checks passed.