### PR TITLE
Add ASCII fallback for unsupported Pi diagrams

### DIFF
--- a/.github/scripts/pi_pr_summary.py
+++ b/.github/scripts/pi_pr_summary.py
@@ -77,7 +77,7 @@ def _validate_diagram(value: Any) -> str | None:
     if first_line != "sequenceDiagram" and not first_line.startswith(
         ("flowchart ", "graph ")
     ):
-        raise PiSummaryError("diagram must be a Mermaid flowchart or sequence")
+        return None
     lowered = diagram.casefold()
     if any(
         token in lowered

--- a/.github/scripts/pi_pr_summary.py
+++ b/.github/scripts/pi_pr_summary.py
@@ -69,15 +69,22 @@ def _required_text(value: Any, field: str, limit: int) -> str:
     return text
 
 
+def _is_supported_mermaid(diagram: str) -> bool:
+    first_line = diagram.splitlines()[0].strip()
+    return first_line == "sequenceDiagram" or first_line.startswith(
+        ("flowchart ", "graph ")
+    )
+
+
 def _validate_diagram(value: Any) -> str | None:
     if value is None or value == "":
         return None
     diagram = _required_text(value, "diagram", MAX_DIAGRAM_CHARS)
+    if not _is_supported_mermaid(diagram):
+        if "```" in diagram:
+            raise PiSummaryError("diagram contains unsupported content")
+        return diagram
     first_line = diagram.splitlines()[0].strip()
-    if first_line != "sequenceDiagram" and not first_line.startswith(
-        ("flowchart ", "graph ")
-    ):
-        return None
     lowered = diagram.casefold()
     if any(
         token in lowered
@@ -232,7 +239,7 @@ def render_summary(title: str, summary: Summary) -> str:
                 "<details>",
                 "<summary>Diagram</summary>",
                 "",
-                "```mermaid",
+                f"```{'mermaid' if _is_supported_mermaid(summary.diagram) else 'text'}",
                 summary.diagram,
                 "```",
                 "",

--- a/.github/scripts/pi_summary_prompt.md
+++ b/.github/scripts/pi_summary_prompt.md
@@ -13,12 +13,14 @@ Return exactly one JSON object and no surrounding prose:
   "description": [
     "one to six concise bullets explaining what changed and why"
   ],
-  "diagram": "optional Mermaid source, or null",
+  "diagram": "optional Mermaid or ASCII diagram source, or null",
   "assessment": "one concise paragraph assessing the overall approach"
 }
 
-Use a Mermaid `sequenceDiagram`, `flowchart`, or `graph` only when component
-interaction is meaningful. Return Mermaid source without code fences. Otherwise
-set `diagram` to null. For flowcharts and graphs, use simple alphanumeric node
-IDs, rectangular or diamond nodes, and double-quote all node text, for example
-`A["Start"] --> B{"Ready?"}`. Keep edge text to simple words.
+When component interaction is meaningful, use a Mermaid `sequenceDiagram`,
+`flowchart`, or `graph`. If the interaction cannot be represented with one of
+those supported Mermaid forms, use an ASCII diagram. Return diagram source
+without code fences. Otherwise set `diagram` to null. For flowcharts and graphs,
+use simple alphanumeric node IDs, rectangular or diamond nodes, and double-quote
+all node text, for example `A["Start"] --> B{"Ready?"}`. Keep edge text to simple
+words.

--- a/.github/scripts/tests/test_pi_pr_summary.py
+++ b/.github/scripts/tests/test_pi_pr_summary.py
@@ -51,6 +51,17 @@ class SummaryContractTest(unittest.TestCase):
                 }
             )
 
+    def test_omits_unsupported_diagram_type(self) -> None:
+        result = summary.validate_summary(
+            {
+                "description": ["Summarizes the pull request."],
+                "diagram": "classDiagram\n  Controller --> Worker",
+                "assessment": "The change keeps the existing architecture.",
+            }
+        )
+
+        self.assertIsNone(result.diagram)
+
     def test_rejects_unsafe_mermaid(self) -> None:
         with self.assertRaisesRegex(summary.PiSummaryError, "diagram"):
             summary.validate_summary(

--- a/.github/scripts/tests/test_pi_pr_summary.py
+++ b/.github/scripts/tests/test_pi_pr_summary.py
@@ -51,16 +51,26 @@ class SummaryContractTest(unittest.TestCase):
                 }
             )
 
-    def test_omits_unsupported_diagram_type(self) -> None:
+    def test_accepts_ascii_diagram_fallback(self) -> None:
         result = summary.validate_summary(
             {
                 "description": ["Summarizes the pull request."],
-                "diagram": "classDiagram\n  Controller --> Worker",
+                "diagram": "Controller\n    |\n    v\nWorker",
                 "assessment": "The change keeps the existing architecture.",
             }
         )
 
-        self.assertIsNone(result.diagram)
+        self.assertEqual(result.diagram, "Controller\n    |\n    v\nWorker")
+
+    def test_rejects_fenced_ascii_diagram(self) -> None:
+        with self.assertRaisesRegex(summary.PiSummaryError, "diagram"):
+            summary.validate_summary(
+                {
+                    "description": ["Summary."],
+                    "diagram": "Controller\n```\n</details>",
+                    "assessment": "Assessment.",
+                }
+            )
 
     def test_rejects_unsafe_mermaid(self) -> None:
         with self.assertRaisesRegex(summary.PiSummaryError, "diagram"):
@@ -468,6 +478,21 @@ class SummaryRenderingTest(unittest.TestCase):
         body = summary.render_summary("Update docs", value)
 
         self.assertNotIn("<summary>Diagram</summary>", body)
+
+    def test_renders_ascii_diagram_as_plain_text(self) -> None:
+        value = summary.Summary(
+            description=("Uses an ASCII fallback.",),
+            diagram="Controller\n    |\n    v\nWorker",
+            assessment="The interaction remains visible without Mermaid.",
+        )
+
+        body = summary.render_summary("Update workflow", value)
+
+        self.assertIn(
+            "```text\nController\n    |\n    v\nWorker\n```",
+            body,
+        )
+        self.assertNotIn("```mermaid", body)
 
     def test_escapes_markdown_links_in_untrusted_prose(self) -> None:
         value = summary.Summary(


### PR DESCRIPTION
## 1. Why the change?

The [Pi PR Summary job](https://github.com/sii-system/agent-fleet/actions/runs/32007641223/job/95320323985?pr=100) failed before publishing an otherwise valid summary because the model returned an unsupported optional Mermaid diagram type. The validator raised `diagram must be a Mermaid flowchart or sequence`, causing the whole workflow to exit 1.

## 2. Summary of the change

- Continue rendering supported Mermaid `sequenceDiagram`, `flowchart`, and `graph` output normally.
- Ask Pi to return an ASCII diagram when the interaction cannot use those supported Mermaid forms.
- Render ASCII fallback diagrams as inert plain text while preventing Markdown fence breakout.
- Keep rejecting unsafe content in supported Mermaid diagrams.
- Add regression coverage for ASCII validation, rendering, and safety.

## 3. Other details

Verification:

- `python3 -m unittest discover -s .github/scripts/tests` — 183 tests passed
- `python3 -m py_compile .github/scripts/pi_pr_summary.py .github/scripts/tests/test_pi_pr_summary.py`
- `uvx --from ruff==0.16.0 ruff check --config .github/ruff.toml`
- `git diff --check`