### PR TITLE
Retry malformed Pi summary responses

### DIFF
--- a/.github/scripts/pi_pr_summary.py
+++ b/.github/scripts/pi_pr_summary.py
@@ -325,7 +325,7 @@ def run_summary(
         "\n".join(chunks),
         truncated=truncated or bool(skipped),
     )
-    payload = pi_client.review(prompt, model_input)
+    payload = pi_client.review(prompt, model_input, retry_malformed=True)
     summary = validate_summary(payload)
     github.create_issue_comment(
         pull_number,

--- a/.github/scripts/pi_pr_summary.py
+++ b/.github/scripts/pi_pr_summary.py
@@ -204,6 +204,13 @@ def validate_summary(payload: dict[str, Any]) -> Summary:
     return Summary(description, _validate_diagram(payload.get("diagram")), assessment)
 
 
+def _validate_summary_response(payload: dict[str, Any]) -> None:
+    try:
+        validate_summary(payload)
+    except PiSummaryError as exc:
+        raise _review.ModelResponseError(str(exc)) from exc
+
+
 def _safe_prose(value: str) -> str:
     escaped = value.replace("@", "@\u200b").translate(MARKDOWN_ESCAPE_TABLE)
     return html.escape(escaped)
@@ -325,7 +332,12 @@ def run_summary(
         "\n".join(chunks),
         truncated=truncated or bool(skipped),
     )
-    payload = pi_client.review(prompt, model_input, retry_malformed=True)
+    payload = pi_client.review(
+        prompt,
+        model_input,
+        retry_malformed=True,
+        response_validator=_validate_summary_response,
+    )
     summary = validate_summary(payload)
     github.create_issue_comment(
         pull_number,

--- a/.github/scripts/tests/test_pi_pr_summary.py
+++ b/.github/scripts/tests/test_pi_pr_summary.py
@@ -549,9 +549,17 @@ class FakeGitHub:
 class FakePi:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
+        self.retry_malformed: list[bool] = []
 
-    def review(self, prompt: str, model_input: str) -> dict[str, object]:
+    def review(
+        self,
+        prompt: str,
+        model_input: str,
+        *,
+        retry_malformed: bool = False,
+    ) -> dict[str, object]:
         self.calls.append((prompt, model_input))
+        self.retry_malformed.append(retry_malformed)
         return {
             "description": ["Adds an initial PR summary."],
             "diagram": "flowchart TD\n  PR --> Pi --> Comment",
@@ -579,6 +587,13 @@ class SummaryOrchestrationTest(unittest.TestCase):
         self.assertIn("PR TITLE: Add one-time PR summary", model_input)
         self.assertIn("src/summary.py (modified, +12/-3)", model_input)
         self.assertIn("UNTRUSTED DIFF:", model_input)
+
+    def test_retries_one_malformed_model_response(self) -> None:
+        pi = FakePi()
+
+        summary.run_summary(FakeGitHub(), pi, 17, "summary prompt")
+
+        self.assertEqual(pi.retry_malformed, [True])
 
     def test_large_diff_is_bounded_without_extra_pi_calls(self) -> None:
         github = FakeGitHub()

--- a/.github/scripts/tests/test_pi_pr_summary.py
+++ b/.github/scripts/tests/test_pi_pr_summary.py
@@ -550,6 +550,7 @@ class FakePi:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
         self.retry_malformed: list[bool] = []
+        self.response_validators: list[object] = []
 
     def review(
         self,
@@ -557,14 +558,19 @@ class FakePi:
         model_input: str,
         *,
         retry_malformed: bool = False,
+        response_validator: object = None,
     ) -> dict[str, object]:
         self.calls.append((prompt, model_input))
         self.retry_malformed.append(retry_malformed)
-        return {
+        self.response_validators.append(response_validator)
+        payload = {
             "description": ["Adds an initial PR summary."],
             "diagram": "flowchart TD\n  PR --> Pi --> Comment",
             "assessment": "The implementation is isolated to PR automation.",
         }
+        if callable(response_validator):
+            response_validator(payload)
+        return payload
 
 
 class SummaryOrchestrationTest(unittest.TestCase):
@@ -588,12 +594,22 @@ class SummaryOrchestrationTest(unittest.TestCase):
         self.assertIn("src/summary.py (modified, +12/-3)", model_input)
         self.assertIn("UNTRUSTED DIFF:", model_input)
 
-    def test_retries_one_malformed_model_response(self) -> None:
+    def test_retries_malformed_or_schema_invalid_model_response(self) -> None:
         pi = FakePi()
 
         summary.run_summary(FakeGitHub(), pi, 17, "summary prompt")
 
         self.assertEqual(pi.retry_malformed, [True])
+        validator = pi.response_validators[0]
+        self.assertTrue(callable(validator))
+        with self.assertRaises(summary._review.ModelResponseError):
+            validator(
+                {
+                    "description": [],
+                    "diagram": None,
+                    "assessment": "Assessment.",
+                }
+            )
 
     def test_large_diff_is_bounded_without_extra_pi_calls(self) -> None:
         github = FakeGitHub()


### PR DESCRIPTION
## 1. Why the change?

The self-hosted Pi PR Summary job failed when Pi returned a malformed JSON response. The summary path made only one model attempt even though the shared Pi client already supports one bounded retry for malformed responses.

Failed job: https://github.com/sii-system/agent-fleet/actions/runs/32096512194/job/95588823168?pr=105

## 2. Summary of the change

- Enable the existing malformed-response retry for the one-time PR summary call.
- Add regression coverage that verifies the summary path opts into the bounded retry.

## 3. Other details

Verification:

- `python3 -m unittest discover -s .github/scripts/tests` (184 tests)
- `python3 -m py_compile .github/scripts/pi_pr_summary.py .github/scripts/tests/test_pi_pr_summary.py`
- `uvx ruff@0.16.0 check --config .github/ruff.toml .github/scripts/pi_pr_summary.py .github/scripts/tests/test_pi_pr_summary.py`
- `git diff --cached --check`
