### PR TITLE
feat(harbor): add verification runtime

### DIFF
--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -50,7 +50,7 @@ Agents/utils/common/Harbor/
     │   ├── planning_context/   # Runtime inventory and workspace evidence
     │   ├── policy/             # T1 rules, path routing, and T2/T3 Agent policy
     │   ├── prompts.py          # Task and plan agent contracts
-    │   ├── verification/       # Verification contracts and Harbor-state readers
+    │   ├── verification/       # Verification selection, rerun, and Harbor-state helpers
     │   └── validation.py       # Plan and execution artifact validation
     ├── online_rule_analyzer.py # Optional console-only online analysis
     └── write_harbor_registry_summary.py # Native registry summary writer

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -49,6 +49,16 @@ harbor_is_native_registry_main() {
     && [[ "${HARBOR_QUEUE_WORKER:-0}" != "1" ]]
 }
 
+harbor_is_fixer_verification_main() {
+  [[ "${HARBOR_FIXER_VERIFICATION_RERUN:-0}" == "1" ]] \
+    && [[ "${HARBOR_QUEUE_WORKER:-0}" != "1" ]]
+}
+
+harbor_publishes_job_dir() {
+  harbor_is_native_registry_main \
+    || harbor_is_fixer_verification_main
+}
+
 harbor_uses_local_opensandbox_dataset() {
   [[ "$TB_ENVIRONMENT_TYPE" == "opensandbox" ]] \
     && [[ -n "${TB_PATH:-}" ]] \
@@ -67,7 +77,7 @@ write_harbor_registry_summary() {
     "$job_dir" "$OUTPUT_PATH/summary.txt" "$exit_code" "$dataset"
 }
 
-if harbor_is_native_registry_main; then
+if harbor_publishes_job_dir; then
   : > "$HARBOR_JOB_DIR_FILE"
   rm -f "$HARBOR_BENCHMARK_EXIT_FILE"
   # BASHPID needs bash >= 4; at this top-level scope $$ is the same pid.
@@ -78,14 +88,19 @@ if harbor_is_native_registry_main; then
     > "$HARBOR_BENCHMARK_PID_FILE"
   record_harbor_benchmark_exit() {
     local rc="$?"
-    # The exit file is the completion contract with the registry monitor;
+    # The exit file is the completion contract with the native monitor;
     # write it before the best-effort summary and analyzer teardown.
     printf '%s\n' "$rc" > "$HARBOR_BENCHMARK_EXIT_FILE"
-    if ! write_harbor_registry_summary "$rc"; then
-      echo "[WARN] failed to write registry summary: $OUTPUT_PATH/summary.txt" >&2
+    if harbor_is_native_registry_main; then
+      if ! write_harbor_registry_summary "$rc"; then
+        echo "[WARN] failed to write registry summary: $OUTPUT_PATH/summary.txt" >&2
+      fi
     fi
     if ! harbor_stop_online_analysis; then
       echo "[WARN] failed to stop online analyzer for $OUTPUT_PATH" >&2
+    fi
+    if harbor_is_fixer_verification_main; then
+      cleanup_verifier_uv_bin_dir
     fi
   }
   trap record_harbor_benchmark_exit EXIT
@@ -743,6 +758,9 @@ run_oracle_task() {
   local job_name out_dir
   job_name="$(date +%Y-%m-%d__%H-%M-%S)"
   out_dir="$effective_jobs_root/$job_name"
+  if harbor_is_fixer_verification_main; then
+    printf '%s\n' "$out_dir" > "$HARBOR_JOB_DIR_FILE"
+  fi
   mkdir -p "$out_dir"
 
   VERIFIER_UV_BIN_DIR_SOURCE="$(mktemp -d "${RUNTIME_DIR%/}/verifier-uv.oracle.XXXXXX" 2>/dev/null || true)"
@@ -892,7 +910,7 @@ run_tb() {
   local job_name out_dir
   job_name="$(date +%Y-%m-%d__%H-%M-%S)"
   out_dir="$effective_jobs_root/$job_name"
-  if harbor_is_native_registry_main; then
+  if harbor_publishes_job_dir; then
     printf '%s\n' "$out_dir" > "$HARBOR_JOB_DIR_FILE"
   fi
   mkdir -p "$out_dir"
@@ -1337,7 +1355,7 @@ run_opencode_task() {
   local job_name out_dir
   job_name="$(date +%Y-%m-%d__%H-%M-%S)"
   out_dir="$JOBS_ROOT/$job_name"
-  if harbor_is_native_registry_main; then
+  if harbor_publishes_job_dir; then
     printf '%s\n' "$out_dir" > "$HARBOR_JOB_DIR_FILE"
   fi
   mkdir -p "$out_dir"
@@ -1366,9 +1384,9 @@ PY
 
   local cmd opencode_n_concurrent
   opencode_n_concurrent="1"
-  if harbor_is_native_registry_main; then
-    # Registry runs use one Harbor process, so it must own the requested
-    # concurrency. Local task lists already shard work across queue workers.
+  if harbor_is_native_registry_main || harbor_is_fixer_verification_main; then
+    # Registry and Fixer verification runs use one Harbor process, so it must
+    # own the requested concurrency. Normal local runs shard across workers.
     opencode_n_concurrent="$TB_N_CONCURRENT"
   fi
   build_opencode_cmd() {

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/outcomes.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/outcomes.py
@@ -1,0 +1,52 @@
+"""Derive verification outcomes from execution and Harbor task state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def verification_status(exec_status: str, run_record: dict[str, Any] | None) -> str:
+    if exec_status != "success":
+        return "exec_failed"
+    if run_record is None:
+        return "not_sampled"
+    return {
+        "complete_success": "fixed",
+        "complete_failed": "not_fixed",
+        "complete_unknown": "unknown",
+        "not_complete": "not_complete",
+    }[str(run_record["task_complete_status"])]
+
+
+def exec_failure_reason(exec_status: str, policy_status: str) -> str | None:
+    if exec_status == "success":
+        return None
+    return "policy_denied" if policy_status == "denied" else "execution_failed"
+
+
+def aggregate_status(statuses: list[str], rerun_exit_code: int | None) -> str:
+    statuses = [status for status in statuses if status != "not_sampled"]
+    if rerun_exit_code not in (None, 0) or not statuses:
+        return "inconclusive"
+    if "exec_failed" in statuses:
+        return "exec_failed"
+    if all(status == "fixed" for status in statuses):
+        return "fixed"
+    if "fixed" in statuses:
+        return "partially_fixed"
+    if any(status in {"unknown", "not_complete"} for status in statuses):
+        return "inconclusive"
+    return "not_fixed"
+
+
+def plan_status(statuses: list[str]) -> str:
+    statuses = [status for status in statuses if status != "not_sampled"]
+    if "exec_failed" in statuses:
+        return "exec_failed"
+    if statuses and all(status == "fixed" for status in statuses):
+        return "fixed"
+    if "fixed" in statuses:
+        return "partially_fixed"
+    if any(status in {"unknown", "not_complete"} for status in statuses):
+        return "inconclusive"
+    return "not_fixed" if statuses else "inconclusive"

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
@@ -1,0 +1,305 @@
+"""Launch and inspect a Harbor verification rerun."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..validation import task_key
+from .run_state import generate_monitor_snapshot
+from .selection import sort_task_index
+
+RUN_SCOPED_ENV_VARS = {
+    "RUN_ID",
+    "QUEUE_DIR",
+    "RUNTIME_DIR",
+    "LAYOUT_FILE",
+    "JOBS_ROOT",
+    "HARBOR_ONLINE_ANALYSIS_DIR",
+    "HARBOR_ONLINE_ANALYSIS_PID_FILE",
+    "HARBOR_ONLINE_ANALYSIS_LOG_FILE",
+    "HARBOR_MONITOR_DIR",
+    "HARBOR_MONITOR_PID_FILE",
+    "HARBOR_MONITOR_LOG_FILE",
+    "HARBOR_BENCHMARK_PID_FILE",
+    "HARBOR_BENCHMARK_EXIT_FILE",
+    "HARBOR_JOB_DIR_FILE",
+    "HARBOR_MONITOR_RESTART_CMD",
+    "HARBOR_MONITOR_STOP_CMD",
+    "HARBOR_ANALYZER_OUTPUT_DIR",
+    "HARBOR_ANALYZER_PID_FILE",
+    "HARBOR_ANALYZER_SUPERVISOR_PID_FILE",
+    "HARBOR_ANALYZER_SUPERVISOR_ID_FILE",
+    "HARBOR_ANALYZER_LOG_FILE",
+    "HARBOR_ZELLIJ_SESSION_NAME",
+    "HARBOR_QUEUE_WORKER",
+    "RL_ZELLIJ_SESSION_NAME",
+    "ZELLIJ_SESSION_NAME",
+    "ZELLIJ",
+    "ZELLIJ_PANE_ID",
+    "FLEET_TASKS",
+    "INCLUDE_TASKS",
+    "TB_INCLUDE_TASKS",
+    "TB_AGENT",
+    "TB_AGENT_IMPORT_PATH",
+    "TB_TASK_ID",
+    "NEXT_INDEX_FILE",
+    "LOCK_FILE",
+    "WORKERS_READY_FILE",
+    "WORKERS_FAILED_FILE",
+    "RL_TRACE_LOG",
+    "RL_SERVER_LOG",
+    "RL_SERVER_PID_FILE",
+    "RL_QUEUE_DIR",
+    "RL_ACTIVE_DIR",
+    "RL_JOB_QUEUE_ROOT",
+    "RL_JOB_RUNTIME_ROOT",
+}
+
+TERMINATION_GRACE_SECONDS = 5.0
+
+GENERATED_MONITOR_FILES = {
+    "monitor-state.json",
+    "monitor-latest.json",
+    "user-notify-latest.json",
+    "analyzer-handover-latest.json",
+    "runner-action-latest.json",
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _read_log_tail(stream: Any) -> str:
+    end = stream.seek(0, os.SEEK_END)
+    stream.seek(max(0, end - 16384))
+    return stream.read().decode(errors="replace")[-4000:]
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=TERMINATION_GRACE_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait()
+
+
+def _cleanup_verifier_backups(run_dir: Path, agent: str) -> None:
+    runtime_dir = run_dir / "runtime" / agent
+    for path in runtime_dir.glob("verifier-uv.*"):
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def monitor_is_terminal(snapshot: dict[str, Any]) -> bool:
+    return snapshot.get("benchmark_status") == "completed" or snapshot.get(
+        "monitor_follow_decision"
+    ) in {"stop_completed", "stop_action_required"}
+
+
+def wait_for_monitor(
+    run_dir: Path,
+    output_dir: Path,
+    agent: str,
+    *,
+    timeout_seconds: int,
+    poll_interval: float,
+) -> tuple[dict[str, Any] | None, str, bool]:
+    monitor_dir = output_dir / "verification-monitor"
+    for name in GENERATED_MONITOR_FILES:
+        (monitor_dir / name).unlink(missing_ok=True)
+
+    deadline = time.monotonic() + timeout_seconds
+    latest: tuple[dict[str, Any] | None, str] = (None, "")
+    while time.monotonic() < deadline:
+        latest = generate_monitor_snapshot(run_dir, output_dir, agent, startup_grace=1)
+        if latest[0] is not None and monitor_is_terminal(latest[0]):
+            return *latest, False
+        time.sleep(max(0.1, poll_interval))
+    return *latest, True
+
+
+def run_command(
+    command: str | None,
+    run_dir: Path,
+    agent: str,
+    *,
+    task_source_path: str,
+    selection_path: str,
+    should_run: bool,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    skipped_reason = "" if should_run else "no_sampled_tasks"
+    if not command or not should_run:
+        return {
+            "command": command or "",
+            "exit_code": None,
+            "started_at": "",
+            "finished_at": "",
+            "duration_ms": 0,
+            "stdout_summary": "",
+            "stderr_summary": "",
+            "skipped_reason": skipped_reason,
+        }
+    argv = shlex.split(command)
+    if not argv:
+        raise ValueError("--rerun-command must not be empty")
+    run_dir = run_dir.resolve()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    task_source = Path(task_source_path).resolve()
+    task_text = task_source.read_text(encoding="utf-8")
+    task_file = run_dir / "tasks.txt"
+    task_file.write_text(task_text, encoding="utf-8")
+    smoke_tasks = ",".join(
+        task.strip() for task in task_text.splitlines() if task.strip()
+    )
+    inherited_queue_worker = os.environ.get("HARBOR_QUEUE_WORKER") == "1"
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in RUN_SCOPED_ENV_VARS
+    }
+    if inherited_queue_worker:
+        # Queue workers force one Harbor task per process. Verification runs a
+        # complete smoke set directly, so env.sh must restore normal concurrency.
+        env.pop("TB_N_CONCURRENT", None)
+    env.update(
+        {
+            "AGENT": agent,
+            "TB_AGENT": agent,
+            "TB_AGENT_IMPORT_PATH": "",
+            "TASK_SOURCE_FILE": str(task_source),
+            "TASK_FILE": str(task_file),
+            "FLEET_TASKS": smoke_tasks,
+            "INCLUDE_TASKS": smoke_tasks,
+            "TB_INCLUDE_TASKS": smoke_tasks,
+            "TB_LIMIT": "",
+            "TB_RUNS": "1",
+            "N_ATTEMPTS": "1",
+            "MIN_TEST": "0",
+            "OUTPUT_PATH": str(run_dir),
+            "RESET_RUN": "1",
+            "ROLLOUT": "0",
+            "HARBOR_ONLINE_ANALYSIS": "0",
+            "HARBOR_EARLY_STOP": "0",
+            "HARBOR_MONITOR_ENABLED": "0",
+            "HARBOR_ANALYZER_ENABLED": "0",
+            "HARBOR_QUEUE_WORKER": "0",
+            "HARBOR_FIXER_VERIFICATION_RERUN": "1",
+            "HARBOR_FIXER_SMOKE_SELECTION": str(Path(selection_path).resolve()),
+        }
+    )
+    started_at = _utc_now()
+    started = time.monotonic()
+    timed_out = False
+    with (
+        tempfile.TemporaryFile() as stdout_file,
+        tempfile.TemporaryFile() as stderr_file,
+    ):
+        process = subprocess.Popen(
+            argv,
+            cwd=run_dir,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            env=env,
+            start_new_session=True,
+        )
+        try:
+            exit_code = process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            _terminate_process_group(process)
+            _cleanup_verifier_backups(run_dir, agent)
+            exit_code = 124
+            timed_out = True
+        stdout_summary = _read_log_tail(stdout_file)
+        stderr_summary = _read_log_tail(stderr_file)
+    if timed_out:
+        stderr_summary = (
+            stderr_summary
+            + f"\nverification rerun timed out after {timeout_seconds:g} seconds"
+        )[-4000:]
+    return {
+        "command": command,
+        "exit_code": exit_code,
+        "started_at": started_at,
+        "finished_at": _utc_now(),
+        "duration_ms": int((time.monotonic() - started) * 1000),
+        "stdout_summary": stdout_summary,
+        "stderr_summary": stderr_summary,
+        "skipped_reason": "",
+    }
+
+
+def map_run_records(
+    records: dict[str, dict[str, Any]], selection: dict[str, Any]
+) -> tuple[
+    dict[tuple[str, str, str], dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+]:
+    selected = {str(task["smoke_task_index"]): task for task in selection["tasks"]}
+    errors: list[dict[str, Any]] = []
+    if set(records) != set(selected):
+        errors.append(
+            {
+                "error": "smoke_task_index_set_mismatch",
+                "expected": sorted(selected, key=sort_task_index),
+                "actual": sorted(records, key=sort_task_index),
+            }
+        )
+
+    mapped: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for smoke_index, task in selected.items():
+        identity = {
+            "task_index": task["original_task_index"],
+            "task_name": task["task_name"],
+            "attempt_id": task["attempt_id"],
+        }
+        record = records.get(smoke_index)
+        if record is None:
+            record = {
+                "task_index": identity["task_index"],
+                "task_name": identity["task_name"],
+                "task_complete_status": "complete_unknown",
+                "task_result_signals": ["result_missing"],
+                "evidence": {},
+                "result_path": "",
+            }
+        elif record["task_name"] != identity["task_name"]:
+            errors.append(
+                {
+                    "error": "smoke_task_name_mismatch",
+                    "smoke_task_index": smoke_index,
+                    "expected_task_name": identity["task_name"],
+                    "actual_task_name": record["task_name"],
+                }
+            )
+        mapped[task_key(identity)] = {
+            **record,
+            "task_index": identity["task_index"],
+            "task_name": identity["task_name"],
+            "smoke_task_index": smoke_index,
+        }
+
+    unexpected = [
+        records[index]
+        for index in sorted(set(records) - set(selected), key=sort_task_index)
+    ]
+    return mapped, unexpected, errors

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/selection.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/selection.py
@@ -1,0 +1,127 @@
+"""Select stable smoke tasks from a validated Fix Plan."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ..artifact_io import write_json, write_text
+from ..validation import task_key
+
+
+def sort_task_index(value: str) -> tuple[int, int | str]:
+    try:
+        return 0, int(value)
+    except ValueError:
+        return 1, value
+
+
+def plan_exec_map(exec_result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(plan["plan_id"]): plan for plan in exec_result["plans"]}
+
+
+def plan_tasks(fix_plan: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    return {str(plan["plan_id"]): list(plan["task_list"]) for plan in fix_plan["plans"]}
+
+
+def selection_hash(source: dict[str, Any], plan_id: str, task: dict[str, Any]) -> str:
+    raw = json.dumps(
+        {"source": source, "plan_id": plan_id, "task": task_key(task)},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def build_smoke_selection(
+    fix_plan: dict[str, Any],
+    exec_plans: dict[str, dict[str, Any]],
+    *,
+    limit_per_plan: int,
+    output_dir: Path,
+) -> dict[str, Any]:
+    selected_tasks: list[dict[str, Any]] = []
+    selected_task_names: set[str] = set()
+    plan_records: list[dict[str, Any]] = []
+    source = fix_plan["source"]
+
+    for plan_id, tasks in plan_tasks(fix_plan).items():
+        exec_status = str(exec_plans[plan_id]["status"])
+        ranked = sorted(
+            ((selection_hash(source, plan_id, task), task) for task in tasks),
+            key=lambda item: item[0],
+        )
+        selected: list[tuple[str, dict[str, Any]]] = []
+        if exec_status == "success":
+            for digest, task in ranked:
+                task_name = str(task["task_name"])
+                if task_name in selected_task_names:
+                    continue
+                selected.append((digest, task))
+                selected_task_names.add(task_name)
+                if len(selected) == limit_per_plan:
+                    break
+        selected_keys = {task_key(task) for _, task in selected}
+        for digest, task in selected:
+            selected_tasks.append(
+                {
+                    "plan_id": plan_id,
+                    "original_task_index": str(task["task_index"]),
+                    "task_name": str(task["task_name"]),
+                    "attempt_id": task["attempt_id"],
+                    "selection_hash": digest,
+                }
+            )
+        plan_records.append(
+            {
+                "plan_id": plan_id,
+                "exec_status": exec_status,
+                "total_task_count": len(tasks),
+                "sampled_task_indexes": sorted(
+                    [str(task["task_index"]) for _, task in selected],
+                    key=sort_task_index,
+                ),
+                "unsampled_task_indexes": sorted(
+                    [
+                        str(task["task_index"])
+                        for task in tasks
+                        if task_key(task) not in selected_keys
+                    ],
+                    key=sort_task_index,
+                ),
+            }
+        )
+
+    selected_tasks.sort(
+        key=lambda task: (
+            task["selection_hash"],
+            sort_task_index(task["original_task_index"]),
+        )
+    )
+    for index, task in enumerate(selected_tasks, start=1):
+        task["smoke_task_index"] = str(index)
+
+    task_source = output_dir / "verification-smoke-tasks.txt"
+    selection_path = output_dir / "verification-smoke-selection.json"
+    write_text(
+        task_source, "".join(f"{task['task_name']}\n" for task in selected_tasks)
+    )
+    payload = {
+        "schema_version": 2,
+        "kind": "harbor_fixer_verification_smoke_selection",
+        "verification_mode": "smoke_test",
+        "selection_policy": "stable_hash",
+        "limit_per_plan": limit_per_plan,
+        "source": {
+            "task_source_path": str(task_source),
+            "selection_path": str(selection_path),
+        },
+        "plans": plan_records,
+        "tasks": selected_tasks,
+        "sampled_task_count": len(selected_tasks),
+    }
+    write_json(selection_path, payload)
+    return payload

--- a/Agents/utils/common/Harbor/start.sh
+++ b/Agents/utils/common/Harbor/start.sh
@@ -25,6 +25,14 @@ if [[ "${1:-}" == "--detach" ]]; then
   DETACH_MODE=true
   shift
 fi
+if [[ "${HARBOR_FIXER_VERIFICATION_RERUN:-0}" == "1" ]]; then
+  # Fixer verification owns monitoring and must not inherit or create a
+  # benchmark Zellij session. A bare start.sh invocation runs Harbor directly.
+  DETACH_MODE=false
+  if [[ $# -eq 0 ]]; then
+    set -- "$SCRIPT_DIR/harboropik.sh"
+  fi
+fi
 if [[ -z "$HARBOR_ZELLIJ_KEEP_ON_FAILURE" ]]; then
   if [[ "$DETACH_MODE" == "true" || ( -t 0 && -t 1 ) ]]; then
     HARBOR_ZELLIJ_KEEP_ON_FAILURE=1
@@ -495,7 +503,7 @@ if [[ "${RESET_RUN:-0}" == "1" ]]; then
   if [[ "$ROLLOUT" == "1" ]]; then
     "$RL_UTILS_DIR/run_rl_rollout_server.sh" --stop >/dev/null 2>&1 || true
     harbor_stop_rollout_zellij_sessions
-  else
+  elif [[ "${HARBOR_FIXER_VERIFICATION_RERUN:-0}" != "1" ]]; then
     zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
     zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
   fi

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_runtime.py
@@ -1,0 +1,300 @@
+"""Tests for deterministic verification selection and rerun helpers."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from pathlib import Path
+from unittest import mock
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+HARBOR_DIR = TEST_DIR.parent
+for path in (TEST_DIR, SCRIPT_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from fixer_test_support import FixerTestCase, make_exec_result, make_fix_plan
+from harbor_fixer.validation import task_key
+from harbor_fixer.verification.outcomes import aggregate_status, exec_failure_reason
+from harbor_fixer.verification.rerun import (
+    GENERATED_MONITOR_FILES,
+    map_run_records,
+    run_command,
+    wait_for_monitor,
+)
+from harbor_fixer.verification.selection import build_smoke_selection, plan_exec_map
+
+
+def _fix_plan(count: int = 3) -> dict:
+    plan = make_fix_plan()
+    plan["plans"][0]["task_list"] = [
+        {
+            "task_index": str(index),
+            "task_name": f"task-{index}",
+            "attempt_id": None,
+            "root_cause_code": "fixture",
+            "final_class": "env_fail",
+        }
+        for index in range(1, count + 1)
+    ]
+    plan["plans"][0]["verification_hint"]["target_task_indexes"] = [
+        str(index) for index in range(1, count + 1)
+    ]
+    return plan
+
+
+class HarborFixerVerificationRuntimeTest(FixerTestCase):
+    def _run_local_start(
+        self, agent: str, tasks: list[str], **env_overrides: str
+    ) -> dict:
+        task_source = self.root / "tasks.txt"
+        task_source.write_text("".join(f"{task}\n" for task in tasks), encoding="utf-8")
+        dataset = self.root / "dataset"
+        for task in tasks:
+            task_dir = dataset / task
+            task_dir.mkdir(parents=True)
+            (task_dir / "task.yaml").write_text("version: 1\n", encoding="utf-8")
+        env = {
+            "API_KEY": "fake-key",
+            "BASE_URL": "https://gateway.example.invalid",
+            "DATASET_NAME": "auto",
+            "DATASET_PATH": str(dataset),
+            "MODEL": "fake-model",
+            "TB_DRY_RUN": "1",
+            "TRACE_TO_OPIK": "false",
+            **env_overrides,
+        }
+        with mock.patch.dict(os.environ, env):
+            return run_command(
+                shlex.join(["bash", str(HARBOR_DIR / "start.sh")]),
+                self.root / "run",
+                agent,
+                task_source_path=str(task_source),
+                selection_path=str(self.root / "selection.json"),
+                should_run=True,
+                timeout_seconds=10,
+            )
+
+    def test_outcomes_distinguish_policy_and_execution_failures(self) -> None:
+        self.assertEqual(exec_failure_reason("failed", "denied"), "policy_denied")
+        self.assertEqual(exec_failure_reason("failed", "allowed"), "execution_failed")
+        self.assertEqual(aggregate_status(["fixed", "not_fixed"], 0), "partially_fixed")
+
+    def test_selection_is_stable_and_maps_full_task_identity(self) -> None:
+        plan = _fix_plan()
+        exec_plans = plan_exec_map(make_exec_result())
+
+        first = build_smoke_selection(
+            plan, exec_plans, limit_per_plan=2, output_dir=self.root / "first"
+        )
+        second = build_smoke_selection(
+            plan, exec_plans, limit_per_plan=2, output_dir=self.root / "second"
+        )
+
+        selected = first["tasks"]
+        self.assertEqual(len(selected), 2)
+        self.assertEqual(
+            [task["selection_hash"] for task in selected],
+            [task["selection_hash"] for task in second["tasks"]],
+        )
+        task = selected[0]
+        record = {
+            "task_index": task["smoke_task_index"],
+            "task_name": task["task_name"],
+            "task_complete_status": "complete_success",
+        }
+        mapped, unexpected, errors = map_run_records(
+            {task["smoke_task_index"]: record},
+            {**first, "tasks": [task]},
+        )
+        identity = {
+            "task_index": task["original_task_index"],
+            "task_name": task["task_name"],
+            "attempt_id": task["attempt_id"],
+        }
+        self.assertIn(task_key(identity), mapped)
+        self.assertEqual((unexpected, errors), ([], []))
+
+    def test_selection_uses_unique_runnable_task_names(self) -> None:
+        plan = _fix_plan()
+        for index, task in enumerate(plan["plans"][0]["task_list"], start=1):
+            task.update(task_name="same-task", attempt_id=f"attempt-{index}")
+
+        selection = build_smoke_selection(
+            plan,
+            plan_exec_map(make_exec_result()),
+            limit_per_plan=3,
+            output_dir=self.root / "unique",
+        )
+
+        self.assertEqual(
+            [task["task_name"] for task in selection["tasks"]], ["same-task"]
+        )
+
+    def test_run_command_clears_inherited_run_paths(self) -> None:
+        task_source = self.root / "tasks.txt"
+        task_source.write_text("task-b\ntask-a\n", encoding="utf-8")
+        stale = {
+            "QUEUE_DIR": "/stale/queue",
+            "FLEET_TASKS": "old-task",
+            "INCLUDE_TASKS": "old-task",
+            "TB_LIMIT": "1",
+            "TB_RUNS": "3",
+            "N_ATTEMPTS": "4",
+            "MIN_TEST": "1",
+            "TB_AGENT": "claude-code",
+            "TB_AGENT_IMPORT_PATH": "/stale/agent.py",
+            "TB_N_CONCURRENT": "1",
+            "TB_TASK_ID": "old-task",
+            "HARBOR_ANALYZER_OUTPUT_DIR": "/stale/analyzer",
+            "HARBOR_QUEUE_WORKER": "1",
+            "HARBOR_ZELLIJ_SESSION_NAME": "original-run",
+        }
+        process = mock.Mock(returncode=0)
+        process.wait.return_value = 0
+        with (
+            mock.patch.dict(os.environ, stale),
+            mock.patch(
+                "harbor_fixer.verification.rerun.subprocess.Popen",
+                return_value=process,
+            ) as popen,
+        ):
+            result = run_command(
+                "verify",
+                self.root / "run",
+                "opencode",
+                task_source_path=str(task_source),
+                selection_path=str(self.root / "selection.json"),
+                should_run=True,
+                timeout_seconds=9,
+            )
+
+        self.assertEqual(result["exit_code"], 0)
+        call = popen.call_args.kwargs
+        env = call["env"]
+        self.assertNotIn("QUEUE_DIR", env)
+        self.assertNotIn("HARBOR_ANALYZER_OUTPUT_DIR", env)
+        self.assertNotIn("HARBOR_ZELLIJ_SESSION_NAME", env)
+        self.assertEqual(env["AGENT"], "opencode")
+        self.assertEqual(env["TB_AGENT"], "opencode")
+        self.assertEqual(env["TB_AGENT_IMPORT_PATH"], "")
+        self.assertEqual(env["HARBOR_QUEUE_WORKER"], "0")
+        self.assertNotIn("TB_N_CONCURRENT", env)
+        self.assertNotIn("TB_TASK_ID", env)
+        self.assertEqual(env["FLEET_TASKS"], "task-b,task-a")
+        self.assertEqual(env["INCLUDE_TASKS"], "task-b,task-a")
+        self.assertEqual(env["TB_LIMIT"], "")
+        self.assertEqual(env["TB_RUNS"], "1")
+        self.assertEqual(env["N_ATTEMPTS"], "1")
+        self.assertEqual(env["MIN_TEST"], "0")
+        self.assertEqual(call["cwd"], self.root / "run")
+        self.assertTrue(call["start_new_session"])
+        self.assertTrue(call["stdout"].closed)
+        self.assertTrue(call["stderr"].closed)
+        process.wait.assert_called_once_with(timeout=9)
+        self.assertEqual(
+            (self.root / "run" / "tasks.txt").read_text(), "task-b\ntask-a\n"
+        )
+
+    def test_run_command_times_out(self) -> None:
+        task_source = self.root / "tasks.txt"
+        task_source.write_text("task-a\n", encoding="utf-8")
+        term_marker = self.root / "term-received"
+        verifier_backup = (
+            self.root / "run" / "runtime" / "claude-code" / "verifier-uv.timeout"
+        )
+        verifier_backup.mkdir(parents=True)
+        code = (
+            "import signal,sys,time; from pathlib import Path; "
+            "signal.signal(signal.SIGTERM, lambda *_: "
+            "(Path(sys.argv[1]).write_text('term'), sys.exit(0))); time.sleep(10)"
+        )
+
+        result = run_command(
+            shlex.join([sys.executable, "-c", code, str(term_marker)]),
+            self.root / "run",
+            "claude-code",
+            task_source_path=str(task_source),
+            selection_path=str(self.root / "selection.json"),
+            should_run=True,
+            timeout_seconds=0.2,
+        )
+
+        self.assertEqual(result["exit_code"], 124)
+        self.assertIn("timed out after 0.2 seconds", result["stderr_summary"])
+        self.assertEqual(term_marker.read_text(), "term")
+        self.assertFalse(verifier_backup.exists())
+
+    def test_wait_for_monitor_resets_generated_state(self) -> None:
+        monitor_dir = self.root / "output" / "verification-monitor"
+        monitor_dir.mkdir(parents=True)
+        for name in GENERATED_MONITOR_FILES:
+            (monitor_dir / name).write_text("stale\n", encoding="utf-8")
+
+        def snapshot(*_args: object, startup_grace: int) -> tuple[dict, str]:
+            self.assertFalse(
+                any((monitor_dir / name).exists() for name in GENERATED_MONITOR_FILES)
+            )
+            self.assertEqual(startup_grace, 1)
+            return {"benchmark_status": "completed"}, str(
+                monitor_dir / "monitor-latest.json"
+            )
+
+        with mock.patch(
+            "harbor_fixer.verification.rerun.generate_monitor_snapshot",
+            side_effect=snapshot,
+        ):
+            monitor, _, timed_out = wait_for_monitor(
+                self.root / "run",
+                self.root / "output",
+                "claude-code",
+                timeout_seconds=1,
+                poll_interval=0.1,
+            )
+
+        self.assertEqual(monitor, {"benchmark_status": "completed"})
+        self.assertFalse(timed_out)
+
+    def test_verification_start_runs_directly_without_zellij(self) -> None:
+        fake_bin = self.root / "bin"
+        fake_bin.mkdir()
+        zellij_marker = self.root / "zellij-called"
+        fake_zellij = fake_bin / "zellij"
+        fake_zellij.write_text(
+            f"#!/usr/bin/env bash\ntouch {shlex.quote(str(zellij_marker))}\n",
+            encoding="utf-8",
+        )
+        fake_zellij.chmod(0o755)
+        result = self._run_local_start(
+            "claude-code",
+            ["fix-git"],
+            PATH=f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        )
+
+        self.assertEqual(result["exit_code"], 0, result["stderr_summary"])
+        self.assertIn("TB_DRY_RUN=1", result["stdout_summary"])
+        self.assertNotIn("Zellij session", result["stdout_summary"])
+        self.assertFalse(zellij_marker.exists())
+        job_dir_file = self.root / "run" / "runtime" / "claude-code" / "harbor-job-dir"
+        self.assertTrue(Path(job_dir_file.read_text().strip()).is_dir())
+        exit_file = (
+            self.root / "run" / "runtime" / "claude-code" / "harbor-benchmark.exit"
+        )
+        self.assertEqual(exit_file.read_text(), "0\n")
+        self.assertEqual(list(exit_file.parent.glob("verifier-uv.*")), [])
+
+    def test_verification_local_opencode_owns_concurrency(self) -> None:
+        result = self._run_local_start(
+            "opencode", ["task-a", "task-b"], TB_N_CONCURRENT="8"
+        )
+
+        self.assertEqual(result["exit_code"], 0, result["stderr_summary"])
+        self.assertIn("  --n-concurrent\n  8\n", result["stdout_summary"])
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer has verification contracts and Harbor-state readers, but it cannot yet select a deterministic smoke set, launch an isolated rerun, or map rerun outcomes back to the original Fix Plan tasks. Reusing the parent Harbor environment can also cross-contaminate analyzer, Zellij, task-selection, agent, attempt, and monitor state.

## 2. Summary of the change

- Add stable-hash smoke selection with unique runnable task names and full task-identity mapping.
- Add an isolated verification rerun runtime that materializes the ordered smoke manifest, fixes the effective agent and single-attempt settings, enforces a process timeout, and bounds captured logs.
- Run verification directly without Analyzer or Zellij while publishing native Harbor job and exit metadata for registry and local datasets.
- Reset generated verification-monitor state between reruns and preserve verifier temporary-file cleanup.
- Add focused runtime tests for selection, environment isolation, timeout handling, direct execution, native metadata, and monitor-state reset.

## 3. Other details

Validation:
- python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p test_harbor_fixer*.py (51 tests)
- python3 -m unittest Agents.utils.common.Harbor.tests.test_task_selection (8 tests)
- bash Agents/utils/common/Harbor/tests/test_start_user_feedback.sh
- bash -n Agents/utils/common/Harbor/start.sh Agents/utils/common/Harbor/harboropik.sh
- Ruff 0.16.0 check and format check for verification runtime and tests
- git diff --check

This PR builds directly on verification contracts merged in #97.