### PR TITLE
feat(harbor): add verification workflow

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -366,6 +366,30 @@ Execution writes `exec-input.json`, `execution-policy-decision.json`,
 blocks the complete plan set. A failed action skips the remainder of its plan;
 later plans continue. `--execution-timeout` applies to each command action.
 
+### Verify an executed plan
+
+Verification is code-only and samples at most two successfully executed tasks
+per plan by default:
+
+```bash
+python3 Agents/utils/common/Harbor/scripts/fixer.py \
+  --verify-only \
+  --fix-plan /path/to/fixer-output/fix-plan-latest.json \
+  --exec-result /path/to/fixer-output/exec-result-latest.json \
+  --verification-run-dir /path/to/new-harbor-run \
+  --output-dir /path/to/fixer-output
+```
+
+Use `--rerun-command` to launch the smoke run. The wrapper receives an ordered
+`TASK_SOURCE_FILE` and `HARBOR_FIXER_SMOKE_SELECTION`; it must preserve their
+line-to-task mapping. `--rerun-timeout` limits that command to 600 seconds by
+default and can also be set with `HARBOR_FIXER_RERUN_TIMEOUT`. Task identities
+come directly from Fix Plan v2.
+Verification writes
+`verification-smoke-selection.json`, `verification-smoke-tasks.txt`, and
+`verification-result-latest.json`. If the Fix Plan was generated without a
+local monitor, select `claude-code`, `opencode`, or `oracle` with `--agent`.
+
 ## More Details
 
 Architecture, script roles, task resolution, and full variable descriptions are in [STRUCT.md](./STRUCT.md).

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -50,8 +50,9 @@ Agents/utils/common/Harbor/
     │   ├── planning_context/   # Runtime inventory and workspace evidence
     │   ├── policy/             # T1 rules, path routing, and T2/T3 Agent policy
     │   ├── prompts.py          # Task and plan agent contracts
-    │   ├── verification/       # Verification selection, rerun, and Harbor-state helpers
-    │   └── validation.py       # Plan and execution artifact validation
+    │   ├── validation.py       # Plan, execution, and verification validation
+    │   ├── verification/       # Selection, rerun, and Harbor-state details
+    │   └── verifier.py         # Verification public entry points
     ├── online_rule_analyzer.py # Optional console-only online analysis
     └── write_harbor_registry_summary.py # Native registry summary writer
 ```

--- a/Agents/utils/common/Harbor/scripts/fixer.py
+++ b/Agents/utils/common/Harbor/scripts/fixer.py
@@ -19,6 +19,8 @@ from harbor_fixer.plan_generation import (
     task_artifact_label,
 )
 from harbor_fixer.prompts import MAIN_AGENT_PROMPT, TASK_SUBAGENT_PROMPT
+from harbor_fixer.validation import HARBOR_AGENTS, ValidationError
+from harbor_fixer.verifier import run_verification_from_paths
 
 
 def _default_model() -> str:
@@ -104,6 +106,20 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=[],
     )
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--exec-result", type=Path)
+    parser.add_argument("--verification-run-dir", type=Path)
+    parser.add_argument("--agent", choices=sorted(HARBOR_AGENTS))
+    parser.add_argument("--rerun-command", default=None)
+    parser.add_argument(
+        "--rerun-timeout",
+        type=int,
+        default=os.environ.get("HARBOR_FIXER_RERUN_TIMEOUT", "600"),
+    )
+    parser.add_argument("--monitor-policy", choices=["auto", "on", "off"], default="auto")
+    parser.add_argument("--monitor-wait-timeout", type=int, default=3600)
+    parser.add_argument("--monitor-poll-interval", type=float, default=30.0)
+    parser.add_argument("--verification-task-limit-per-plan", type=int, default=2)
     return parser.parse_args()
 
 
@@ -115,6 +131,8 @@ def main() -> int:
         raise SystemExit("--timeout must be positive")
     if args.execution_timeout <= 0:
         raise SystemExit("--execution-timeout must be positive")
+    if args.rerun_timeout <= 0:
+        raise SystemExit("--rerun-timeout must be positive")
     if not 0 < args.summary_limit <= MAX_SUMMARY_LIMIT:
         raise SystemExit(
             f"--summary-limit must be between 1 and {MAX_SUMMARY_LIMIT}"
@@ -123,8 +141,13 @@ def main() -> int:
         raise SystemExit("--max-task-summary-chars must be positive")
     if args.max_task_summaries_chars <= 0:
         raise SystemExit("--max-task-summaries-chars must be positive")
-    if args.prepare_only and args.exec_only:
-        raise SystemExit("--prepare-only and --exec-only are mutually exclusive")
+    if args.verification_task_limit_per_plan <= 0:
+        raise SystemExit("--verification-task-limit-per-plan must be positive")
+    selected_modes = [args.prepare_only, args.exec_only, args.verify_only]
+    if sum(1 for selected in selected_modes if selected) > 1:
+        raise SystemExit(
+            "--prepare-only, --exec-only, and --verify-only are mutually exclusive"
+        )
     args.output_dir.mkdir(parents=True, exist_ok=True)
     if args.write_prompts:
         write_text(args.output_dir / "prompts" / "task-subagent-prompt.md", TASK_SUBAGENT_PROMPT)
@@ -146,6 +169,30 @@ def main() -> int:
             summary_limit=args.summary_limit,
         )
         return 0 if result["status"] == "success" else 1
+    if args.verify_only:
+        if args.fix_plan is None:
+            raise SystemExit("--fix-plan is required with --verify-only")
+        if args.exec_result is None:
+            raise SystemExit("--exec-result is required with --verify-only")
+        if args.verification_run_dir is None:
+            raise SystemExit("--verification-run-dir is required with --verify-only")
+        try:
+            result = run_verification_from_paths(
+                args.fix_plan,
+                args.exec_result,
+                args.verification_run_dir,
+                args.output_dir,
+                agent=args.agent,
+                rerun_command=args.rerun_command,
+                rerun_timeout=args.rerun_timeout,
+                monitor_policy=args.monitor_policy,
+                monitor_wait_timeout=args.monitor_wait_timeout,
+                monitor_poll_interval=args.monitor_poll_interval,
+                verification_task_limit_per_plan=args.verification_task_limit_per_plan,
+            )
+        except ValidationError as exc:
+            raise SystemExit(str(exc)) from None
+        return 0 if result["status"] in {"fixed", "partially_fixed"} else 1
     if args.analyzer_output is None:
         raise SystemExit("--analyzer-output is required unless --exec-only is used")
     if args.prepare_only:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import shlex
 from typing import Any
 
 
@@ -658,6 +659,47 @@ def validate_verification_input(payload: dict[str, Any]) -> None:
     ):
         require_string(payload.get(key), key)
     require_enum(payload.get("monitor_policy"), "monitor_policy", MONITOR_POLICIES)
+    rerun_command = payload.get("rerun_command")
+    if rerun_command is not None:
+        rerun_command = require_string(
+            rerun_command, "rerun_command", allow_empty=True
+        )
+        if rerun_command:
+            try:
+                argv = shlex.split(rerun_command)
+            except ValueError as exc:
+                raise ValidationError(f"rerun_command is invalid: {exc}") from None
+            if not argv:
+                raise ValidationError("rerun_command must not be blank")
+    rerun_timeout = payload.get("rerun_timeout")
+    if "rerun_timeout" in payload and (
+        isinstance(rerun_timeout, bool)
+        or not isinstance(rerun_timeout, int)
+        or rerun_timeout <= 0
+    ):
+        raise ValidationError("rerun_timeout must be a positive integer")
+    monitor_wait_timeout = payload.get("monitor_wait_timeout")
+    if "monitor_wait_timeout" in payload and (
+        isinstance(monitor_wait_timeout, bool)
+        or not isinstance(monitor_wait_timeout, int)
+        or monitor_wait_timeout <= 0
+    ):
+        raise ValidationError("monitor_wait_timeout must be a positive integer")
+    monitor_poll_interval = payload.get("monitor_poll_interval")
+    valid_poll_interval = "monitor_poll_interval" not in payload or (
+        not isinstance(monitor_poll_interval, bool)
+        and isinstance(monitor_poll_interval, (int, float))
+        and monitor_poll_interval > 0
+    )
+    if valid_poll_interval and "monitor_poll_interval" in payload:
+        try:
+            valid_poll_interval = math.isfinite(float(monitor_poll_interval))
+        except OverflowError:
+            valid_poll_interval = False
+    if not valid_poll_interval:
+        raise ValidationError(
+            "monitor_poll_interval must be a positive finite number"
+        )
     if payload.get("verification_mode") != "smoke_test":
         raise ValidationError("verification_mode must be smoke_test")
     limit = payload.get("verification_task_limit_per_plan")

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from ..validation import task_key
+from ..validation import ValidationError, task_key
 from .run_state import generate_monitor_snapshot
 from .selection import sort_task_index
 
@@ -86,20 +86,33 @@ def _read_log_tail(stream: Any) -> str:
 
 
 def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    deadline = time.monotonic() + TERMINATION_GRACE_SECONDS
     try:
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
         pass
     try:
         process.wait(timeout=TERMINATION_GRACE_SECONDS)
-        return
     except subprocess.TimeoutExpired:
         pass
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
+    while _process_group_exists(process.pid) and time.monotonic() < deadline:
+        time.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
+    if _process_group_exists(process.pid):
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
     process.wait()
+
+
+def _process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 def _cleanup_verifier_backups(run_dir: Path, agent: str) -> None:
@@ -132,7 +145,10 @@ def wait_for_monitor(
         latest = generate_monitor_snapshot(run_dir, output_dir, agent, startup_grace=1)
         if latest[0] is not None and monitor_is_terminal(latest[0]):
             return *latest, False
-        time.sleep(max(0.1, poll_interval))
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(max(0.1, poll_interval), remaining))
     return *latest, True
 
 
@@ -158,15 +174,21 @@ def run_command(
             "stderr_summary": "",
             "skipped_reason": skipped_reason,
         }
-    argv = shlex.split(command)
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        raise ValidationError(f"--rerun-command is invalid: {exc}") from None
     if not argv:
-        raise ValueError("--rerun-command must not be empty")
-    run_dir = run_dir.resolve()
-    run_dir.mkdir(parents=True, exist_ok=True)
-    task_source = Path(task_source_path).resolve()
-    task_text = task_source.read_text(encoding="utf-8")
-    task_file = run_dir / "tasks.txt"
-    task_file.write_text(task_text, encoding="utf-8")
+        raise ValidationError("--rerun-command must not be blank")
+    try:
+        run_dir = run_dir.resolve()
+        run_dir.mkdir(parents=True, exist_ok=True)
+        task_source = Path(task_source_path).resolve()
+        task_text = task_source.read_text(encoding="utf-8")
+        task_file = run_dir / "tasks.txt"
+        task_file.write_text(task_text, encoding="utf-8")
+    except OSError as exc:
+        raise ValidationError(f"cannot prepare verification rerun: {exc}") from None
     smoke_tasks = ",".join(
         task.strip() for task in task_text.splitlines() if task.strip()
     )
@@ -209,27 +231,30 @@ def run_command(
     started_at = _utc_now()
     started = time.monotonic()
     timed_out = False
-    with (
-        tempfile.TemporaryFile() as stdout_file,
-        tempfile.TemporaryFile() as stderr_file,
-    ):
-        process = subprocess.Popen(
-            argv,
-            cwd=run_dir,
-            stdout=stdout_file,
-            stderr=stderr_file,
-            env=env,
-            start_new_session=True,
-        )
-        try:
-            exit_code = process.wait(timeout=timeout_seconds)
-        except subprocess.TimeoutExpired:
-            _terminate_process_group(process)
-            _cleanup_verifier_backups(run_dir, agent)
-            exit_code = 124
-            timed_out = True
-        stdout_summary = _read_log_tail(stdout_file)
-        stderr_summary = _read_log_tail(stderr_file)
+    try:
+        with (
+            tempfile.TemporaryFile() as stdout_file,
+            tempfile.TemporaryFile() as stderr_file,
+        ):
+            process = subprocess.Popen(
+                argv,
+                cwd=run_dir,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                env=env,
+                start_new_session=True,
+            )
+            try:
+                exit_code = process.wait(timeout=timeout_seconds)
+            except subprocess.TimeoutExpired:
+                _terminate_process_group(process)
+                _cleanup_verifier_backups(run_dir, agent)
+                exit_code = 124
+                timed_out = True
+            stdout_summary = _read_log_tail(stdout_file)
+            stderr_summary = _read_log_tail(stderr_file)
+    except OSError as exc:
+        raise ValidationError(f"cannot launch verification rerun: {exc}") from None
     if timed_out:
         stderr_summary = (
             stderr_summary

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/workflow.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/workflow.py
@@ -1,0 +1,350 @@
+"""Deterministic smoke-verification workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from harbor_monitor.runner import process_is_alive
+
+from ..artifact_io import read_json, write_json, write_json_atomic
+from ..validation import (
+    HARBOR_AGENTS,
+    TASK_VERIFICATION_STATUSES,
+    ValidationError,
+    task_key,
+    validate_fix_plan_set,
+    validate_verification_input,
+    validate_verification_result,
+)
+from .outcomes import (
+    aggregate_status,
+    exec_failure_reason,
+    plan_status,
+    verification_status,
+)
+from .rerun import map_run_records, run_command, wait_for_monitor
+from .run_state import (
+    collect_task_results,
+    generate_monitor_snapshot,
+    locate_native_runtime_files,
+    read_monitor_snapshot,
+)
+from .selection import build_smoke_selection, plan_exec_map, plan_tasks
+
+DEFAULT_RERUN_TIMEOUT_SECONDS = 600
+
+
+def _prepare_verification_output(output_dir: Path) -> None:
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "verification-result-latest.json").unlink(missing_ok=True)
+    except OSError as exc:
+        raise ValidationError(f"cannot prepare verification output: {exc}") from None
+
+
+def build_verification_input(
+    fix_plan_path: Path,
+    exec_result_path: Path,
+    verification_run_dir: Path,
+    *,
+    rerun_command: str | None,
+    monitor_policy: str,
+    output_dir: Path,
+    agent: str | None = None,
+    rerun_timeout: int = DEFAULT_RERUN_TIMEOUT_SECONDS,
+    monitor_wait_timeout: int = 3600,
+    monitor_poll_interval: float = 30.0,
+    verification_task_limit_per_plan: int = 2,
+) -> dict[str, Any]:
+    fix_plan = read_json(fix_plan_path)
+    exec_result = read_json(exec_result_path)
+    validate_fix_plan_set(fix_plan)
+    source_agent = str(fix_plan["source"].get("agent") or "")
+    if source_agent and agent and source_agent != agent:
+        raise ValidationError("--agent does not match fix plan source")
+    agent = source_agent or agent
+    if not agent:
+        choices = ", ".join(sorted(HARBOR_AGENTS))
+        raise ValidationError(
+            f"fix plan does not identify an agent; pass --agent with one of: {choices}"
+        )
+    payload = {
+        "schema_version": 2,
+        "kind": "harbor_fixer_verification_input",
+        "agent": agent,
+        "fix_plan_path": str(fix_plan_path),
+        "exec_result_path": str(exec_result_path),
+        "verification_run_dir": str(verification_run_dir),
+        "output_dir": str(output_dir),
+        "rerun_command": rerun_command or "",
+        "rerun_timeout": rerun_timeout,
+        "monitor_policy": monitor_policy,
+        "monitor_wait_timeout": monitor_wait_timeout,
+        "monitor_poll_interval": monitor_poll_interval,
+        "verification_mode": "smoke_test",
+        "verification_task_limit_per_plan": verification_task_limit_per_plan,
+        "fix_plan": fix_plan,
+        "exec_result": exec_result,
+    }
+    validate_verification_input(payload)
+    return payload
+
+
+def run_verification(
+    verification_input: dict[str, Any], output_dir: Path
+) -> dict[str, Any]:
+    _prepare_verification_output(output_dir)
+    validate_verification_input(verification_input)
+    write_json(output_dir / "verification-input.json", verification_input)
+
+    fix_plan = verification_input["fix_plan"]
+    exec_result = verification_input["exec_result"]
+    agent = str(verification_input["agent"])
+    exec_plans = plan_exec_map(exec_result)
+    policy_status = str(exec_result["policy_status"])
+    tasks_by_plan = plan_tasks(fix_plan)
+    run_dir = Path(verification_input["verification_run_dir"])
+    monitor_policy = verification_input["monitor_policy"]
+    limit = int(verification_input["verification_task_limit_per_plan"])
+    rerun_command = str(verification_input.get("rerun_command") or "")
+    selection = build_smoke_selection(
+        fix_plan, exec_plans, limit_per_plan=limit, output_dir=output_dir
+    )
+    selected = selection["tasks"]
+    rerun = run_command(
+        rerun_command or None,
+        run_dir,
+        agent,
+        task_source_path=selection["source"]["task_source_path"],
+        selection_path=selection["source"]["selection_path"],
+        should_run=bool(selected),
+        timeout_seconds=int(
+            verification_input.get(
+                "rerun_timeout", DEFAULT_RERUN_TIMEOUT_SECONDS
+            )
+        ),
+    )
+
+    monitor, monitor_path = read_monitor_snapshot(run_dir)
+    monitor_timed_out = False
+    if selected and monitor_policy in {"auto", "on"}:
+        _, benchmark_pid_file, _ = locate_native_runtime_files(run_dir, agent)
+        should_wait_for_rerun = rerun["exit_code"] == 0 or process_is_alive(
+            benchmark_pid_file
+        )
+        if should_wait_for_rerun:
+            monitor, monitor_path, monitor_timed_out = wait_for_monitor(
+                run_dir,
+                output_dir,
+                agent,
+                timeout_seconds=int(verification_input.get("monitor_wait_timeout", 3600)),
+                poll_interval=float(verification_input.get("monitor_poll_interval", 30.0)),
+            )
+        elif monitor is None:
+            monitor, monitor_path = generate_monitor_snapshot(
+                run_dir, output_dir, agent
+            )
+
+    empty_summary = {
+        "total": 0,
+        "complete_success": 0,
+        "complete_failed": 0,
+        "complete_unknown": 0,
+        "not_complete": 0,
+        "finished": 0,
+        "success_rate": 0.0,
+    }
+    records, run_summary = (
+        collect_task_results(run_dir, agent) if selected else ({}, empty_summary)
+    )
+    mapped, unexpected, mapping_errors = map_run_records(records, selection)
+    sampled_keys = {
+        task_key(
+            {
+                "task_index": task["original_task_index"],
+                "task_name": task["task_name"],
+                "attempt_id": task["attempt_id"],
+            }
+        )
+        for task in selected
+    }
+    smoke_indexes = {
+        task_key(
+            {
+                "task_index": task["original_task_index"],
+                "task_name": task["task_name"],
+                "attempt_id": task["attempt_id"],
+            }
+        ): task["smoke_task_index"]
+        for task in selected
+    }
+
+    task_results: list[dict[str, Any]] = []
+    plan_results: list[dict[str, Any]] = []
+    for plan_id, tasks in tasks_by_plan.items():
+        exec_status = str(exec_plans[plan_id]["status"])
+        plan_task_results: list[dict[str, Any]] = []
+        for task in tasks:
+            key = task_key(task)
+            record = mapped.get(key) if key in sampled_keys else None
+            result = {
+                "task": {
+                    "task_index": str(task["task_index"]),
+                    "task_name": str(task["task_name"]),
+                    "attempt_id": task["attempt_id"],
+                },
+                "plan_id": plan_id,
+                "sampled": key in sampled_keys,
+                "smoke_task_index": smoke_indexes.get(key, ""),
+                "exec_status": exec_status,
+                "exec_failure_reason": exec_failure_reason(exec_status, policy_status),
+                "new_run": record,
+                "verification_status": verification_status(exec_status, record),
+            }
+            task_results.append(result)
+            plan_task_results.append(result)
+
+        sampled_indexes = [
+            result["task"]["task_index"]
+            for result in plan_task_results
+            if result["sampled"]
+        ]
+        statuses = [result["verification_status"] for result in plan_task_results]
+        all_indexes = [str(task["task_index"]) for task in tasks]
+        unsampled_indexes = [
+            result["task"]["task_index"]
+            for result in plan_task_results
+            if not result["sampled"]
+        ]
+        plan_results.append(
+            {
+                "plan_id": plan_id,
+                "exec_status": exec_status,
+                "exec_failure_reason": exec_failure_reason(exec_status, policy_status),
+                "task_indexes": all_indexes,
+                "sampled_task_indexes": sampled_indexes,
+                "unsampled_task_indexes": unsampled_indexes,
+                "sampled_task_count": len(sampled_indexes),
+                "unsampled_task_count": len(unsampled_indexes),
+                "status": plan_status(statuses),
+                "verification_status_counts": {
+                    status: statuses.count(status)
+                    for status in sorted(TASK_VERIFICATION_STATUSES)
+                },
+            }
+        )
+
+    plan_task_count = sum(len(tasks) for tasks in tasks_by_plan.values())
+    run_summary.update(
+        {
+            "scope": "smoke_sample",
+            "verification_mode": "smoke_test",
+            "sampled_task_count": len(selected),
+            "plan_task_count": plan_task_count,
+            "unsampled_task_count": plan_task_count - len(selected),
+        }
+    )
+    status = aggregate_status(
+        [result["verification_status"] for result in task_results],
+        rerun["exit_code"],
+    )
+    if (
+        mapping_errors
+        or monitor_timed_out
+        or (selected and monitor_policy == "on" and monitor is None)
+    ):
+        status = "inconclusive"
+
+    reason_codes: list[str] = []
+    if plan_task_count == 0:
+        reason_codes.append("no_verifiable_tasks")
+    if exec_result["status"] != "success":
+        reason_codes.append(
+            "policy_denied" if policy_status == "denied" else "execution_failed"
+        )
+    if rerun["exit_code"] not in (None, 0):
+        reason_codes.append("rerun_failed")
+    if mapping_errors:
+        reason_codes.append("mapping_error")
+    if monitor_timed_out:
+        reason_codes.append("monitor_timed_out")
+    if selected and monitor_policy == "on" and monitor is None:
+        reason_codes.append("monitor_unavailable")
+
+    payload = {
+        "schema_version": 2,
+        "kind": "harbor_fixer_verification_result",
+        "agent": agent,
+        "verification_mode": "smoke_test",
+        "source": {
+            "fix_plan_path": verification_input["fix_plan_path"],
+            "exec_result_path": verification_input["exec_result_path"],
+            "verification_run_dir": verification_input["verification_run_dir"],
+            "analyzer_monitor_path": str(fix_plan["source"].get("monitor_path") or ""),
+            "monitor_output_path": monitor_path,
+            "smoke_task_source_path": selection["source"]["task_source_path"],
+            "smoke_selection_path": selection["source"]["selection_path"],
+        },
+        "execution": {
+            "status": exec_result["status"],
+            "policy_status": policy_status,
+        },
+        "status": status,
+        "reason_codes": reason_codes,
+        "rerun": {
+            **rerun,
+            "agent": agent,
+            "monitor_policy": monitor_policy,
+            "monitor_available": monitor is not None,
+            "monitor_timed_out": monitor_timed_out,
+        },
+        "sampling": {
+            "mode": "smoke_test",
+            "selection_policy": "stable_hash",
+            "limit_per_plan": limit,
+            "sampled_task_count": len(selected),
+            "plan_task_count": plan_task_count,
+            "unsampled_task_count": plan_task_count - len(selected),
+            "sampled_task_indexes": [task["original_task_index"] for task in selected],
+            "mapping_errors": mapping_errors,
+        },
+        "new_run_summary": run_summary,
+        "plan_results": plan_results,
+        "task_results": task_results,
+        "unexpected_run_task_results": unexpected,
+    }
+    validate_verification_result(payload)
+    write_json_atomic(output_dir / "verification-result-latest.json", payload)
+    return payload
+
+
+def run_verification_from_paths(
+    fix_plan_path: Path,
+    exec_result_path: Path,
+    verification_run_dir: Path,
+    output_dir: Path,
+    *,
+    agent: str | None = None,
+    rerun_command: str | None = None,
+    rerun_timeout: int = DEFAULT_RERUN_TIMEOUT_SECONDS,
+    monitor_policy: str = "auto",
+    monitor_wait_timeout: int = 3600,
+    monitor_poll_interval: float = 30.0,
+    verification_task_limit_per_plan: int = 2,
+) -> dict[str, Any]:
+    _prepare_verification_output(output_dir)
+    payload = build_verification_input(
+        fix_plan_path,
+        exec_result_path,
+        verification_run_dir,
+        agent=agent,
+        rerun_command=rerun_command,
+        rerun_timeout=rerun_timeout,
+        monitor_policy=monitor_policy,
+        output_dir=output_dir,
+        monitor_wait_timeout=monitor_wait_timeout,
+        monitor_poll_interval=monitor_poll_interval,
+        verification_task_limit_per_plan=verification_task_limit_per_plan,
+    )
+    return run_verification(payload, output_dir)

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verifier.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verifier.py
@@ -1,0 +1,13 @@
+"""Public entry points for Harbor Fixer verification."""
+
+from .verification.workflow import (
+    build_verification_input,
+    run_verification,
+    run_verification_from_paths,
+)
+
+__all__ = [
+    "build_verification_input",
+    "run_verification",
+    "run_verification_from_paths",
+]

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_contracts.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_contracts.py
@@ -115,6 +115,24 @@ class HarborFixerVerificationContractsTest(FixerTestCase):
         }
         validate_verification_input(payload)
 
+        invalid_options = (
+            ("rerun_command", '"'),
+            ("rerun_command", "   "),
+            ("monitor_wait_timeout", 0),
+            ("monitor_poll_interval", 0),
+            ("monitor_poll_interval", float("inf")),
+            ("rerun_timeout", None),
+            ("monitor_wait_timeout", None),
+            ("monitor_poll_interval", None),
+        )
+        for field, value in invalid_options:
+            invalid = copy.deepcopy(payload)
+            invalid[field] = value
+            with self.subTest(field=field, value=value), self.assertRaisesRegex(
+                ValidationError, field
+            ):
+                validate_verification_input(invalid)
+
         wrong_agent = copy.deepcopy(payload)
         wrong_agent["agent"] = "opencode"
         with self.assertRaisesRegex(ValidationError, "does not match fix_plan source"):

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import signal
 import sys
 from pathlib import Path
 from unittest import mock
@@ -16,10 +17,11 @@ for path in (TEST_DIR, SCRIPT_DIR):
         sys.path.insert(0, str(path))
 
 from fixer_test_support import FixerTestCase, make_exec_result, make_fix_plan
-from harbor_fixer.validation import task_key
+from harbor_fixer.validation import ValidationError, task_key
 from harbor_fixer.verification.outcomes import aggregate_status, exec_failure_reason
 from harbor_fixer.verification.rerun import (
     GENERATED_MONITOR_FILES,
+    _terminate_process_group,
     map_run_records,
     run_command,
     wait_for_monitor,
@@ -227,35 +229,92 @@ class HarborFixerVerificationRuntimeTest(FixerTestCase):
         self.assertEqual(term_marker.read_text(), "term")
         self.assertFalse(verifier_backup.exists())
 
+    def test_run_command_rejects_invalid_commands_and_setup(self) -> None:
+        task_source = self.root / "tasks.txt"
+        task_source.write_text("task-a\n", encoding="utf-8")
+
+        cases = (
+            ('"', task_source, "invalid"),
+            ("   ", task_source, "blank"),
+            ("/missing/verification-command", task_source, "cannot launch"),
+            ("true", self.root / "missing-tasks.txt", "cannot prepare"),
+        )
+        for command, source, message in cases:
+            with self.subTest(command=command), self.assertRaisesRegex(
+                ValidationError, message
+            ):
+                run_command(
+                    command,
+                    self.root / "run",
+                    "claude-code",
+                    task_source_path=str(source),
+                    selection_path=str(self.root / "selection.json"),
+                    should_run=True,
+                    timeout_seconds=1,
+                )
+
+    def test_termination_kills_descendants_after_leader_exits(self) -> None:
+        process = mock.Mock(pid=123)
+        process.wait.return_value = 0
+        with (
+            mock.patch(
+                "harbor_fixer.verification.rerun._process_group_exists",
+                return_value=True,
+            ),
+            mock.patch(
+                "harbor_fixer.verification.rerun.time.monotonic",
+                side_effect=[0.0, 6.0],
+            ),
+            mock.patch("harbor_fixer.verification.rerun.os.killpg") as killpg,
+        ):
+            _terminate_process_group(process)
+
+        self.assertEqual(
+            killpg.call_args_list,
+            [mock.call(123, signal.SIGTERM), mock.call(123, signal.SIGKILL)],
+        )
+
     def test_wait_for_monitor_resets_generated_state(self) -> None:
         monitor_dir = self.root / "output" / "verification-monitor"
         monitor_dir.mkdir(parents=True)
         for name in GENERATED_MONITOR_FILES:
             (monitor_dir / name).write_text("stale\n", encoding="utf-8")
 
+        snapshots = iter(
+            [{"benchmark_status": "running"}, {"benchmark_status": "completed"}]
+        )
+
         def snapshot(*_args: object, startup_grace: int) -> tuple[dict, str]:
             self.assertFalse(
                 any((monitor_dir / name).exists() for name in GENERATED_MONITOR_FILES)
             )
             self.assertEqual(startup_grace, 1)
-            return {"benchmark_status": "completed"}, str(
+            return next(snapshots), str(
                 monitor_dir / "monitor-latest.json"
             )
 
-        with mock.patch(
-            "harbor_fixer.verification.rerun.generate_monitor_snapshot",
-            side_effect=snapshot,
+        with (
+            mock.patch(
+                "harbor_fixer.verification.rerun.generate_monitor_snapshot",
+                side_effect=snapshot,
+            ),
+            mock.patch(
+                "harbor_fixer.verification.rerun.time.monotonic",
+                side_effect=[0.0, 0.0, 0.75, 0.75],
+            ),
+            mock.patch("harbor_fixer.verification.rerun.time.sleep") as sleep,
         ):
             monitor, _, timed_out = wait_for_monitor(
                 self.root / "run",
                 self.root / "output",
                 "claude-code",
                 timeout_seconds=1,
-                poll_interval=0.1,
+                poll_interval=30,
             )
 
         self.assertEqual(monitor, {"benchmark_status": "completed"})
         self.assertFalse(timed_out)
+        sleep.assert_called_once_with(0.25)
 
     def test_verification_start_runs_directly_without_zellij(self) -> None:
         fake_bin = self.root / "bin"

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_workflow.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_workflow.py
@@ -1,0 +1,237 @@
+"""Integration tests for the Fixer verification workflow."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for path in (TEST_DIR, SCRIPT_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from fixer_test_support import (
+    FixerTestCase,
+    make_exec_result,
+    make_fix_plan,
+    write_json,
+)
+from harbor_fixer.validation import ValidationError
+from harbor_fixer.verification import workflow
+from harbor_fixer.verifier import run_verification_from_paths
+
+
+class HarborFixerVerificationWorkflowTest(FixerTestCase):
+    def _fix_plan(self, agent: str = "claude-code") -> dict:
+        plan = make_fix_plan()
+        plan["source"].update(
+            {
+                "agent": agent,
+                "monitor_path": "/source/monitor/monitor-latest.json",
+            }
+        )
+        return plan
+
+    def _inputs(self, plan: dict, execution: dict) -> tuple[Path, Path]:
+        plan_path = self.root / "fix-plan.json"
+        exec_path = self.root / "exec-result.json"
+        write_json(plan_path, plan)
+        write_json(exec_path, execution)
+        return plan_path, exec_path
+
+    def _run(
+        self,
+        plan: dict,
+        plan_status: str = "success",
+        *,
+        policy_status: str = "allowed",
+        agent: str | None = None,
+        rerun_command: str | None = None,
+        monitor_policy: str = "off",
+    ) -> dict:
+        execution = make_exec_result(
+            plan_status, policy_status=policy_status, fix_plan=plan
+        )
+        if not plan["plans"]:
+            execution["plans"] = []
+        plan_path, exec_path = self._inputs(plan, execution)
+        return run_verification_from_paths(
+            plan_path,
+            exec_path,
+            self.root / "verification-run",
+            self.root / "verification-output",
+            agent=agent,
+            rerun_command=rerun_command,
+            monitor_policy=monitor_policy,
+        )
+
+    def test_successful_smoke_record_is_fixed(self) -> None:
+        run_dir = self.root / "verification-run"
+        queue_dir = run_dir / "queue" / "claude-code"
+        queue_dir.mkdir(parents=True)
+        (run_dir / "tasks.txt").write_text("task-1\n", encoding="utf-8")
+        (queue_dir / "done.txt").write_text(
+            "1\ttask-1\t1.0\t\t\n", encoding="utf-8"
+        )
+        (queue_dir / "failed.txt").write_text("", encoding="utf-8")
+
+        result = self._run(self._fix_plan())
+
+        self.assertEqual(result["status"], "fixed")
+        self.assertEqual(result["reason_codes"], [])
+        self.assertEqual(result["agent"], "claude-code")
+        self.assertEqual(result["rerun"]["agent"], "claude-code")
+        self.assertEqual(
+            result["source"]["analyzer_monitor_path"],
+            "/source/monitor/monitor-latest.json",
+        )
+        self.assertEqual(
+            result["task_results"][0]["verification_status"], "fixed"
+        )
+
+    def test_execution_failure_reason_reaches_result(self) -> None:
+        denied = self._run(
+            self._fix_plan(), "failed", policy_status="denied"
+        )
+        self.assertEqual(denied["reason_codes"], ["policy_denied"])
+        self.assertEqual(
+            denied["task_results"][0]["exec_failure_reason"], "policy_denied"
+        )
+
+        failed = self._run(self._fix_plan(), "failed")
+        self.assertEqual(failed["reason_codes"], ["execution_failed"])
+
+    def test_failed_rerun_does_not_wait_for_monitor(self) -> None:
+        plan = self._fix_plan()
+
+        with mock.patch.object(workflow, "wait_for_monitor") as wait_for_monitor:
+            result = self._run(
+                plan,
+                rerun_command="false",
+                monitor_policy="auto",
+            )
+
+        wait_for_monitor.assert_not_called()
+        self.assertIn("rerun_failed", result["reason_codes"])
+
+    def test_valid_input_defaults_optional_source_and_rerun_fields(self) -> None:
+        plan = self._fix_plan()
+        plan["source"].pop("monitor_path")
+        execution = make_exec_result(fix_plan=plan)
+        plan_path, exec_path = self._inputs(plan, execution)
+        verification_input = workflow.build_verification_input(
+            plan_path,
+            exec_path,
+            self.root / "verification-run",
+            rerun_command=None,
+            monitor_policy="off",
+            output_dir=self.root / "verification-output",
+        )
+        verification_input.pop("rerun_command")
+
+        result = workflow.run_verification(
+            verification_input, self.root / "verification-output"
+        )
+
+        self.assertEqual(result["rerun"]["command"], "")
+        self.assertEqual(result["source"]["analyzer_monitor_path"], "")
+        self.assertEqual(verification_input["rerun_timeout"], 600)
+
+    def test_clears_stale_result_before_input_validation(self) -> None:
+        result_path = self.root / "verification-output" / "verification-result-latest.json"
+        result_path.parent.mkdir(parents=True)
+        result_path.write_text("stale\n", encoding="utf-8")
+        plan = self._fix_plan()
+        plan.pop("source")
+        execution = make_exec_result(fix_plan=plan)
+        plan_path, exec_path = self._inputs(plan, execution)
+
+        with self.assertRaises(ValidationError):
+            run_verification_from_paths(
+                plan_path,
+                exec_path,
+                self.root / "verification-run",
+                result_path.parent,
+                monitor_policy="off",
+            )
+
+        self.assertFalse(result_path.exists())
+
+    def test_duplicate_attempt_index_is_reported_as_unsampled(self) -> None:
+        plan = self._fix_plan()
+        first = plan["plans"][0]["task_list"][0]
+        first["attempt_id"] = "attempt-1"
+        plan["plans"][0]["task_list"].append(
+            {**first, "attempt_id": "attempt-2"}
+        )
+        plan["plans"][0]["verification_hint"]["target_task_indexes"] = ["1", "1"]
+
+        result = self._run(plan)
+
+        plan_result = result["plan_results"][0]
+        self.assertEqual(plan_result["sampled_task_indexes"], ["1"])
+        self.assertEqual(plan_result["unsampled_task_indexes"], ["1"])
+        self.assertEqual(plan_result["unsampled_task_count"], 1)
+
+    def test_prestarted_benchmark_waits_without_rerun_command(self) -> None:
+        completed = {"benchmark_status": "completed"}
+        with (
+            mock.patch.object(workflow, "process_is_alive", return_value=True),
+            mock.patch.object(
+                workflow,
+                "wait_for_monitor",
+                return_value=(completed, "monitor.json", False),
+            ) as wait_for_monitor,
+        ):
+            self._run(self._fix_plan(), monitor_policy="auto")
+
+        wait_for_monitor.assert_called_once()
+
+    def test_empty_plan_reports_no_verifiable_tasks(self) -> None:
+        plan = self._fix_plan()
+        plan["plans"] = []
+
+        result = self._run(plan)
+
+        self.assertEqual(result["status"], "inconclusive")
+        self.assertEqual(result["reason_codes"], ["no_verifiable_tasks"])
+
+    def test_missing_plan_agent_requires_cli_selection(self) -> None:
+        plan = self._fix_plan("")
+        plan["source"]["monitor_path"] = ""
+        execution = make_exec_result(fix_plan=plan)
+        plan_path, exec_path = self._inputs(plan, execution)
+
+        missing = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_DIR / "fixer.py"),
+                "--verify-only",
+                "--fix-plan",
+                str(plan_path),
+                "--exec-result",
+                str(exec_path),
+                "--verification-run-dir",
+                str(self.root / "verification-run"),
+                "--output-dir",
+                str(self.root / "verification-output"),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("pass --agent", missing.stderr)
+
+        result = self._run(plan, agent="opencode")
+        self.assertEqual(result["agent"], "opencode")
+        self.assertEqual(result["rerun"]["agent"], "opencode")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer can generate and execute fix plans, but it lacks a deterministic workflow for verifying those changes against a bounded smoke sample and publishing a validated status artifact.

## 2. Summary of the change

- Add the verify-only workflow and public verifier entry points.
- Build schema-validated verification inputs and results, map smoke-run records back to full Fix Plan task identities, and report plan/task outcomes.
- Add configurable rerun and monitor controls, including a 600-second default rerun timeout and support for prestarted verification runs.
- Isolate rerun state, clear stale latest results, and convert launcher errors into structured rerun failures.
- Document the workflow and add focused workflow/runtime regression coverage.

## 3. Other details

This PR is based on main after the verification contracts and verification runtime changes were merged.

Validation:
- 61 Harbor Fixer unit/integration tests passed.
- Ruff 0.16.0 check with .github/ruff.toml passed.