### PR TITLE
feat(harbor): add QZ template manager

### DIFF
--- a/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
+++ b/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
@@ -29,6 +29,9 @@ Entry point: 作业中心 (Job Center) → Sandbox.
      (镜像管理) first.
 3. Wait until the Template status is ready.
 
+For the repository-side `create`, `list`, and `get` workflow, see the
+[QZ Template Manager](QZ_TEMPLATE_MANAGER.md).
+
 ## Repository-side configuration
 
 Add to `config.local.env` (never commit the key):

--- a/Agents/utils/common/Harbor/QZ_TEMPLATE_MANAGER.md
+++ b/Agents/utils/common/Harbor/QZ_TEMPLATE_MANAGER.md
@@ -1,0 +1,64 @@
+# QZ Template Manager
+
+`qz_template_manager.py` creates a QZ sandbox Template from an image that is
+already available to the platform. It is a standalone, Python-standard-library
+tool; it does not build or push images and does not depend on Harbor's QZ
+sandbox provider.
+
+## Configure
+
+Set a Sandbox API key. QZ-specific variables take precedence over their
+platform aliases:
+
+```bash
+export QZ_SANDBOX_API_KEY=sbx_example
+# or: export SBX_API_KEY=sbx_example
+```
+
+The default API URL is `https://qz-sbx-api.sii.edu.cn`. Override it with
+`QZ_SANDBOX_API_URL` or `SBX_API_URL`; the manager adds `/v1` when needed.
+
+## Create a Template
+
+```bash
+cd Agents/utils/common/Harbor
+
+python qz_template_manager.py create \
+  --name harbor_task_demo \
+  --image docker.sii.shaipower.online/example/task:tag \
+  --spec g.c1 \
+  --image-source official
+```
+
+Template names may contain only ASCII letters, digits, and underscores.
+
+The command reserves the Template, binds the image, waits for the build to
+reach `ready`, and writes only the Template ID to stdout. Progress and errors
+go to stderr, so the result can be passed directly to the QZ provider:
+
+```bash
+QZ_SANDBOX_TEMPLATE="$(
+  python qz_template_manager.py create \
+    --name harbor_task_demo \
+    --image docker.sii.shaipower.online/example/task:tag \
+    --exists-ok
+)" || exit 1
+export QZ_SANDBOX_TEMPLATE
+```
+
+Creation refuses to touch an existing Template. `--exists-ok` returns an
+existing Template only when its latest build is already `ready`; it never
+rebuilds it. Concurrent creation of the same name is outside this first
+version's scope.
+
+## Inspect Templates
+
+```bash
+python qz_template_manager.py list
+python qz_template_manager.py get --name harbor_task_demo
+```
+
+Both inspection commands print JSON. This version intentionally has no
+rebuild or delete command. `official` is the verified `imageSource` for
+platform images; other values are passed through for later validation with
+custom registries.

--- a/Agents/utils/common/Harbor/qz_template_manager.py
+++ b/Agents/utils/common/Harbor/qz_template_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sys
@@ -22,6 +23,7 @@ POLL_INTERVAL_SEC = 2.0
 SPEC_CHOICES = ("g.c1", "g.c2", "g.c4")
 FAILED_BUILD_STATUSES = frozenset({"error", "failed"})
 TEMPLATE_NAME_PATTERN = re.compile(r"[A-Za-z0-9_]+")
+BUILD_TIMESTAMP_KEYS = ("createdAt", "startedAt", "updatedAt", "created")
 
 
 class QzTemplateError(RuntimeError):
@@ -35,6 +37,18 @@ class QzTemplateApiError(QzTemplateError):
         self.status = status
         self.message = message
         super().__init__(f"QZ template API returned HTTP {status}: {message}")
+
+
+class _RejectRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Keep the Sandbox API key on the configured origin."""
+
+    def redirect_request(self, request, file, code, message, headers, new_url):
+        raise QzTemplateError("QZ template API refused an HTTP redirect")
+
+
+def _urlopen_without_redirects(request, *, timeout):
+    opener = urllib.request.build_opener(_RejectRedirectHandler())
+    return opener.open(request, timeout=timeout)
 
 
 def normalize_api_url(value: str) -> str:
@@ -111,7 +125,7 @@ class QzTemplateClient:
         self.api_key = api_key
         self.api_url = normalize_api_url(api_url)
         self.request_timeout = request_timeout
-        self._opener = opener or urllib.request.urlopen
+        self._opener = opener or _urlopen_without_redirects
 
     def _request(
         self,
@@ -232,15 +246,42 @@ class QzTemplateClient:
         return payload
 
 
-def _latest_build_status(template: Mapping[str, Any]) -> str:
-    builds = template.get("builds")
-    if isinstance(builds, list) and builds and isinstance(builds[0], dict):
-        status = builds[0].get("status")
-        if isinstance(status, str) and status.strip():
-            return status.strip().lower()
-    status = template.get("buildStatus")
+def _status_value(payload: Mapping[str, Any], key: str) -> str:
+    status = payload.get(key)
     if isinstance(status, str) and status.strip():
         return status.strip().lower()
+    return ""
+
+
+def _build_timestamp(build: Mapping[str, Any]) -> str:
+    for key in BUILD_TIMESTAMP_KEYS:
+        value = build.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _latest_build_status(template: Mapping[str, Any]) -> str:
+    builds = template.get("builds")
+    valid_builds = (
+        [build for build in builds if isinstance(build, dict)]
+        if isinstance(builds, list)
+        else []
+    )
+    timestamped = [
+        (_build_timestamp(build), build)
+        for build in valid_builds
+        if _build_timestamp(build)
+    ]
+    if timestamped:
+        latest_build = max(timestamped, key=lambda item: item[0])[1]
+        return _status_value(latest_build, "status") or "unknown"
+
+    status = _status_value(template, "buildStatus")
+    if status:
+        return status
+    if valid_builds:
+        return _status_value(valid_builds[0], "status") or "unknown"
     return "unknown"
 
 
@@ -265,6 +306,15 @@ def create_template_from_image(
     stderr = stderr or sys.stderr
     clock = clock or time.monotonic
     sleep = sleep or time.sleep
+
+    image = image.strip()
+    image_source = image_source.strip()
+    if not image:
+        raise QzTemplateError("image must not be empty")
+    if not image_source:
+        raise QzTemplateError("image source must not be empty")
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise QzTemplateError("timeout must be a finite number greater than zero")
 
     existing = client.get_by_name(name)
     if existing is not None:
@@ -342,9 +392,25 @@ def _positive_timeout(value: str) -> float:
         parsed = float(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError("timeout must be a number") from exc
-    if parsed <= 0:
-        raise argparse.ArgumentTypeError("timeout must be greater than zero")
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError(
+            "timeout must be a finite number greater than zero"
+        )
     return parsed
+
+
+def _image_reference(value: str) -> str:
+    image = value.strip()
+    if not image:
+        raise argparse.ArgumentTypeError("image must not be empty")
+    return image
+
+
+def _image_source(value: str) -> str:
+    source = value.strip()
+    if not source:
+        raise argparse.ArgumentTypeError("image source must not be empty")
+    return source
 
 
 def _template_name(value: str) -> str:
@@ -371,7 +437,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=_template_name,
         help="new template name (ASCII letters, digits, and underscores only)",
     )
-    create.add_argument("--image", required=True, help="existing image reference")
+    create.add_argument(
+        "--image",
+        required=True,
+        type=_image_reference,
+        help="existing image reference",
+    )
     create.add_argument(
         "--spec",
         choices=SPEC_CHOICES,
@@ -381,6 +452,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     create.add_argument(
         "--image-source",
         default="official",
+        type=_image_source,
         help="QZ image source value (default: official)",
     )
     create.add_argument(

--- a/Agents/utils/common/Harbor/qz_template_manager.py
+++ b/Agents/utils/common/Harbor/qz_template_manager.py
@@ -1,0 +1,445 @@
+"""Create and inspect QZ sandbox templates backed by existing images."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, TextIO
+
+DEFAULT_API_URL = "https://qz-sbx-api.sii.edu.cn"
+API_VERSION_SUFFIX = "/v1"
+DEFAULT_BUILD_TIMEOUT_SEC = 600.0
+DEFAULT_REQUEST_TIMEOUT_SEC = 30.0
+POLL_INTERVAL_SEC = 2.0
+SPEC_CHOICES = ("g.c1", "g.c2", "g.c4")
+FAILED_BUILD_STATUSES = frozenset({"error", "failed"})
+TEMPLATE_NAME_PATTERN = re.compile(r"[A-Za-z0-9_]+")
+
+
+class QzTemplateError(RuntimeError):
+    """Base error for QZ template operations."""
+
+
+class QzTemplateApiError(QzTemplateError):
+    """An HTTP error returned by the QZ template API."""
+
+    def __init__(self, status: int, message: str) -> None:
+        self.status = status
+        self.message = message
+        super().__init__(f"QZ template API returned HTTP {status}: {message}")
+
+
+def normalize_api_url(value: str) -> str:
+    """Normalize a QZ Sandbox API URL so it ends in exactly one ``/v1``."""
+    base = value.strip().rstrip("/")
+    if not base:
+        base = DEFAULT_API_URL
+    if base.endswith(API_VERSION_SUFFIX):
+        return base
+    return base + API_VERSION_SUFFIX
+
+
+def resolve_api_key(environ: Mapping[str, str] = os.environ) -> str:
+    """Resolve the Sandbox API key using the QZ adapter's precedence."""
+    key = (
+        environ.get("QZ_SANDBOX_API_KEY", "").strip()
+        or environ.get("SBX_API_KEY", "").strip()
+    )
+    if not key:
+        raise QzTemplateError(
+            "set QZ_SANDBOX_API_KEY or SBX_API_KEY before using the manager"
+        )
+    return key
+
+
+def resolve_api_url(environ: Mapping[str, str] = os.environ) -> str:
+    """Resolve the Sandbox API URL using the QZ adapter's precedence."""
+    value = (
+        environ.get("QZ_SANDBOX_API_URL", "").strip()
+        or environ.get("SBX_API_URL", "").strip()
+        or DEFAULT_API_URL
+    )
+    return normalize_api_url(value)
+
+
+def _json_payload(raw: bytes, context: str) -> Any:
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise QzTemplateError(f"{context} returned invalid JSON") from exc
+
+
+def _api_error_message(raw: bytes) -> str:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        text = raw.decode("utf-8", errors="replace").strip()
+        return text[:500] or "empty error response"
+    if isinstance(payload, dict) and payload.get("message"):
+        return str(payload["message"])
+    return str(payload)[:500]
+
+
+def _required_string(payload: Mapping[str, Any], key: str, context: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise QzTemplateError(f"{context} response is missing {key}")
+    return value.strip()
+
+
+class QzTemplateClient:
+    """Small urllib client for QZ's E2B-compatible template routes."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        api_url: str,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT_SEC,
+        opener: Callable[..., Any] | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.api_url = normalize_api_url(api_url)
+        self.request_timeout = request_timeout
+        self._opener = opener or urllib.request.urlopen
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: Mapping[str, Any] | None = None,
+    ) -> Any:
+        data = None
+        headers = {
+            "Accept": "application/json",
+            "X-API-Key": self.api_key,
+        }
+        if body is not None:
+            data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            self.api_url + path,
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with self._opener(request, timeout=self.request_timeout) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            raise QzTemplateApiError(
+                exc.code,
+                _api_error_message(raw),
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise QzTemplateError(
+                f"QZ template API request failed: {exc.reason}"
+            ) from exc
+        return _json_payload(raw, f"{method} {path}")
+
+    def list_templates(self) -> list[dict[str, Any]]:
+        payload = self._request("GET", "/templates")
+        if not isinstance(payload, list) or not all(
+            isinstance(item, dict) for item in payload
+        ):
+            raise QzTemplateError("list templates response must be a JSON array")
+        return payload
+
+    def resolve_alias(self, name: str) -> dict[str, Any] | None:
+        encoded_name = urllib.parse.quote(name, safe="")
+        try:
+            payload = self._request("GET", f"/templates/aliases/{encoded_name}")
+        except QzTemplateApiError as exc:
+            if exc.status == 404:
+                return None
+            raise
+        if not isinstance(payload, dict):
+            raise QzTemplateError("template alias response must be a JSON object")
+        return payload
+
+    def get_template(self, template_id: str) -> dict[str, Any]:
+        encoded_id = urllib.parse.quote(template_id, safe="")
+        payload = self._request("GET", f"/templates/{encoded_id}")
+        if not isinstance(payload, dict):
+            raise QzTemplateError("get template response must be a JSON object")
+        return payload
+
+    def get_by_name(self, name: str) -> dict[str, Any] | None:
+        alias = self.resolve_alias(name)
+        if alias is None:
+            return None
+        template_id = _required_string(alias, "templateID", "resolve alias")
+        return self.get_template(template_id)
+
+    def create_template(self, name: str, spec: str) -> tuple[str, str]:
+        payload = self._request(
+            "POST",
+            "/templates",
+            {"name": name, "sbxSpecCode": spec},
+        )
+        if not isinstance(payload, dict):
+            raise QzTemplateError("create template response must be a JSON object")
+        return (
+            _required_string(payload, "templateID", "create template"),
+            _required_string(payload, "buildID", "create template"),
+        )
+
+    def start_build(
+        self,
+        *,
+        template_id: str,
+        build_id: str,
+        image: str,
+        image_source: str,
+    ) -> None:
+        encoded_template_id = urllib.parse.quote(template_id, safe="")
+        encoded_build_id = urllib.parse.quote(build_id, safe="")
+        self._request(
+            "POST",
+            f"/templates/{encoded_template_id}/builds/{encoded_build_id}",
+            {
+                "fromImage": image,
+                "imageSource": image_source,
+                "steps": [],
+            },
+        )
+
+    def get_build_status(
+        self,
+        *,
+        template_id: str,
+        build_id: str,
+    ) -> dict[str, Any]:
+        encoded_template_id = urllib.parse.quote(template_id, safe="")
+        encoded_build_id = urllib.parse.quote(build_id, safe="")
+        payload = self._request(
+            "GET",
+            f"/templates/{encoded_template_id}/builds/{encoded_build_id}/status",
+        )
+        if not isinstance(payload, dict):
+            raise QzTemplateError("build status response must be a JSON object")
+        return payload
+
+
+def _latest_build_status(template: Mapping[str, Any]) -> str:
+    builds = template.get("builds")
+    if isinstance(builds, list) and builds and isinstance(builds[0], dict):
+        status = builds[0].get("status")
+        if isinstance(status, str) and status.strip():
+            return status.strip().lower()
+    status = template.get("buildStatus")
+    if isinstance(status, str) and status.strip():
+        return status.strip().lower()
+    return "unknown"
+
+
+def _log(message: str, stream: TextIO) -> None:
+    print(message, file=stream)
+
+
+def create_template_from_image(
+    client: QzTemplateClient,
+    *,
+    name: str,
+    image: str,
+    spec: str,
+    image_source: str,
+    timeout: float,
+    exists_ok: bool,
+    stderr: TextIO | None = None,
+    clock: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> str:
+    """Create one new template and wait for its image build to finish."""
+    stderr = stderr or sys.stderr
+    clock = clock or time.monotonic
+    sleep = sleep or time.sleep
+
+    existing = client.get_by_name(name)
+    if existing is not None:
+        template_id = _required_string(existing, "templateID", "get template")
+        status = _latest_build_status(existing)
+        if exists_ok and status == "ready":
+            _log(
+                f"template {name!r} already exists and is ready: {template_id}",
+                stderr,
+            )
+            return template_id
+        raise QzTemplateError(
+            f"template {name!r} already exists with status {status!r} "
+            f"(templateID={template_id}); refusing to rebuild it"
+        )
+
+    template_id, build_id = client.create_template(name, spec)
+    _log(
+        f"allocated templateID={template_id} buildID={build_id}",
+        stderr,
+    )
+    try:
+        client.start_build(
+            template_id=template_id,
+            build_id=build_id,
+            image=image,
+            image_source=image_source,
+        )
+    except QzTemplateError as exc:
+        raise QzTemplateError(
+            f"failed to start build for templateID={template_id} "
+            f"buildID={build_id}: {exc}"
+        ) from exc
+
+    deadline = clock() + timeout
+    previous_status = ""
+    while True:
+        payload = client.get_build_status(
+            template_id=template_id,
+            build_id=build_id,
+        )
+        status = _required_string(payload, "status", "build status").lower()
+        if status != previous_status:
+            _log(f"buildID={build_id} status={status}", stderr)
+            previous_status = status
+        if status == "ready":
+            return template_id
+        if status in FAILED_BUILD_STATUSES:
+            raise QzTemplateError(
+                f"template build ended with status {status!r} "
+                f"(templateID={template_id}, buildID={build_id})"
+            )
+
+        now = clock()
+        if now >= deadline:
+            raise QzTemplateError(
+                f"template build timed out after {timeout:g}s "
+                f"(templateID={template_id}, buildID={build_id}, "
+                f"last_status={status})"
+            )
+        sleep(min(POLL_INTERVAL_SEC, deadline - now))
+
+
+def client_from_environment(
+    environ: Mapping[str, str] = os.environ,
+) -> QzTemplateClient:
+    return QzTemplateClient(
+        api_key=resolve_api_key(environ),
+        api_url=resolve_api_url(environ),
+    )
+
+
+def _positive_timeout(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("timeout must be a number") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("timeout must be greater than zero")
+    return parsed
+
+
+def _template_name(value: str) -> str:
+    if TEMPLATE_NAME_PATTERN.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError(
+            "template name must contain only ASCII letters, digits, and underscores"
+        )
+    return value
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create and inspect QZ sandbox templates.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser(
+        "create",
+        help="create a template from an existing image and wait until ready",
+    )
+    create.add_argument(
+        "--name",
+        required=True,
+        type=_template_name,
+        help="new template name (ASCII letters, digits, and underscores only)",
+    )
+    create.add_argument("--image", required=True, help="existing image reference")
+    create.add_argument(
+        "--spec",
+        choices=SPEC_CHOICES,
+        default="g.c1",
+        help="QZ sandbox specification (default: g.c1)",
+    )
+    create.add_argument(
+        "--image-source",
+        default="official",
+        help="QZ image source value (default: official)",
+    )
+    create.add_argument(
+        "--timeout",
+        type=_positive_timeout,
+        default=DEFAULT_BUILD_TIMEOUT_SEC,
+        help="build polling timeout in seconds (default: 600)",
+    )
+    create.add_argument(
+        "--exists-ok",
+        action="store_true",
+        help="return an existing ready template instead of failing",
+    )
+
+    subparsers.add_parser("list", help="list templates as JSON")
+    get = subparsers.add_parser("get", help="get one template by name as JSON")
+    get.add_argument(
+        "--name",
+        required=True,
+        type=_template_name,
+        help="template name (ASCII letters, digits, and underscores only)",
+    )
+    return parser.parse_args(argv)
+
+
+def _print_json(payload: Any) -> None:
+    json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        client = client_from_environment()
+        if args.command == "list":
+            _print_json(client.list_templates())
+            return 0
+        if args.command == "get":
+            template = client.get_by_name(args.name)
+            if template is None:
+                raise QzTemplateError(f"template {args.name!r} was not found")
+            _print_json(template)
+            return 0
+
+        template_id = create_template_from_image(
+            client,
+            name=args.name,
+            image=args.image,
+            spec=args.spec,
+            image_source=args.image_source,
+            timeout=args.timeout,
+            exists_ok=args.exists_ok,
+        )
+        print(template_id)
+        return 0
+    except QzTemplateError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
@@ -7,7 +7,7 @@ import sys
 import unittest
 import urllib.error
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 HARBOR_DIR = Path(__file__).resolve().parents[1]
 if str(HARBOR_DIR) not in sys.path:
@@ -57,6 +57,45 @@ def request_body(call):
     return json.loads(request.data.decode())
 
 
+class RedirectSecurityTest(unittest.TestCase):
+    def test_default_opener_installs_redirect_rejection(self):
+        director = Mock()
+        response = FakeResponse({})
+        director.open.return_value = response
+        request = manager.urllib.request.Request(
+            "https://qz.example/v1/templates",
+            headers={"X-API-Key": "sbx-secret"},
+        )
+
+        with patch.object(
+            manager.urllib.request,
+            "build_opener",
+            return_value=director,
+        ) as build_opener:
+            actual = manager._urlopen_without_redirects(request, timeout=30)
+
+        self.assertIs(actual, response)
+        handler = build_opener.call_args.args[0]
+        self.assertIsInstance(handler, manager._RejectRedirectHandler)
+        director.open.assert_called_once_with(request, timeout=30)
+
+    def test_redirect_handler_stops_cross_origin_key_forwarding(self):
+        request = manager.urllib.request.Request(
+            "https://qz.example/v1/templates",
+            headers={"X-API-Key": "sbx-secret"},
+        )
+
+        with self.assertRaisesRegex(manager.QzTemplateError, "refused"):
+            manager._RejectRedirectHandler().redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                "https://attacker.example/collect",
+            )
+
+
 class ConfigurationTest(unittest.TestCase):
     def test_qz_variables_take_precedence(self):
         environ = {
@@ -82,6 +121,58 @@ class ConfigurationTest(unittest.TestCase):
     def test_missing_key_fails(self):
         with self.assertRaisesRegex(manager.QzTemplateError, "SBX_API_KEY"):
             manager.resolve_api_key({})
+
+    def test_timeout_rejects_non_finite_values(self):
+        for value in ("nan", "inf", "-inf", "0"):
+            with (
+                self.subTest(value=value),
+                self.assertRaisesRegex(
+                    argparse.ArgumentTypeError,
+                    "finite number greater than zero",
+                ),
+            ):
+                manager._positive_timeout(value)
+
+    def test_create_args_reject_blank_build_inputs(self):
+        cases = (
+            (["--image", ""], "image must not be empty"),
+            (
+                ["--image", "registry.example/task:tag", "--image-source", " "],
+                "image source must not be empty",
+            ),
+        )
+        for options, message in cases:
+            stderr = io.StringIO()
+            with (
+                self.subTest(options=options),
+                contextlib.redirect_stderr(stderr),
+                self.assertRaises(SystemExit),
+            ):
+                manager.parse_args(["create", "--name", "harbor_task_demo", *options])
+            self.assertIn(message, stderr.getvalue())
+
+    def test_latest_build_status_uses_timestamps_and_top_level_fallback(self):
+        self.assertEqual(
+            manager._latest_build_status(
+                {
+                    "builds": [
+                        {
+                            "status": "ready",
+                            "createdAt": "2026-08-18T10:00:00+08:00",
+                        },
+                        {
+                            "status": "building",
+                            "createdAt": "2026-08-18T10:01:00+08:00",
+                        },
+                    ]
+                }
+            ),
+            "building",
+        )
+        self.assertEqual(
+            manager._latest_build_status({"buildStatus": "READY"}),
+            "ready",
+        )
 
     def test_template_name_accepts_platform_format(self):
         self.assertEqual(
@@ -212,6 +303,22 @@ class CreateTemplateTest(unittest.TestCase):
             self.create(opener, exists_ok=True)
 
         self.assertEqual(len(opener.calls), 2)
+
+    def test_invalid_build_inputs_fail_before_api_calls(self):
+        cases = (
+            ({"image": " "}, "image must not be empty"),
+            ({"image_source": " "}, "image source must not be empty"),
+            ({"timeout": float("nan")}, "finite number greater than zero"),
+            ({"timeout": float("inf")}, "finite number greater than zero"),
+        )
+        for overrides, message in cases:
+            opener = QueueOpener()
+            with (
+                self.subTest(overrides=overrides),
+                self.assertRaisesRegex(manager.QzTemplateError, message),
+            ):
+                self.create(opener, **overrides)
+            self.assertEqual(opener.calls, [])
 
     def test_build_error_reports_allocated_ids(self):
         opener = QueueOpener(

--- a/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
@@ -1,0 +1,308 @@
+import argparse
+import contextlib
+import io
+import json
+import os
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+HARBOR_DIR = Path(__file__).resolve().parents[1]
+if str(HARBOR_DIR) not in sys.path:
+    sys.path.insert(0, str(HARBOR_DIR))
+
+import qz_template_manager as manager
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.raw = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return self.raw
+
+
+class QueueOpener:
+    def __init__(self, *responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, request, timeout):
+        self.calls.append((request, timeout))
+        response = self.responses.pop(0)
+        if isinstance(response, tuple) and response[0] == "error":
+            _, status, payload = response
+            raise urllib.error.HTTPError(
+                request.full_url,
+                status,
+                str(payload),
+                hdrs=None,
+                fp=io.BytesIO(json.dumps(payload).encode()),
+            )
+        return FakeResponse(response)
+
+
+def request_body(call):
+    request, _ = call
+    if request.data is None:
+        return None
+    return json.loads(request.data.decode())
+
+
+class ConfigurationTest(unittest.TestCase):
+    def test_qz_variables_take_precedence(self):
+        environ = {
+            "QZ_SANDBOX_API_KEY": "qz-key",
+            "SBX_API_KEY": "sbx-key",
+            "QZ_SANDBOX_API_URL": "https://qz.example/v1/",
+            "SBX_API_URL": "https://sbx.example",
+        }
+        self.assertEqual(manager.resolve_api_key(environ), "qz-key")
+        self.assertEqual(manager.resolve_api_url(environ), "https://qz.example/v1")
+
+    def test_platform_aliases_and_default_url(self):
+        self.assertEqual(
+            manager.resolve_api_url({"SBX_API_URL": "https://sbx.example"}),
+            "https://sbx.example/v1",
+        )
+        self.assertEqual(
+            manager.resolve_api_url({}),
+            "https://qz-sbx-api.sii.edu.cn/v1",
+        )
+        self.assertEqual(manager.resolve_api_key({"SBX_API_KEY": "sbx-key"}), "sbx-key")
+
+    def test_missing_key_fails(self):
+        with self.assertRaisesRegex(manager.QzTemplateError, "SBX_API_KEY"):
+            manager.resolve_api_key({})
+
+    def test_template_name_accepts_platform_format(self):
+        self.assertEqual(
+            manager._template_name("harbor_task_123"),
+            "harbor_task_123",
+        )
+
+    def test_template_name_rejects_unsupported_characters(self):
+        for name in ("harbor-task", "harbor task", "模板"):
+            with (
+                self.subTest(name=name),
+                self.assertRaisesRegex(
+                    argparse.ArgumentTypeError,
+                    "ASCII letters, digits, and underscores",
+                ),
+            ):
+                manager._template_name(name)
+
+
+class CreateTemplateTest(unittest.TestCase):
+    def client(self, opener):
+        return manager.QzTemplateClient(
+            api_key="sbx-test",
+            api_url="https://qz.example",
+            opener=opener,
+        )
+
+    def create(self, opener, **overrides):
+        options = {
+            "name": "harbor_task_demo",
+            "image": "registry.example/task:tag",
+            "spec": "g.c1",
+            "image_source": "official",
+            "timeout": 10.0,
+            "exists_ok": False,
+            "stderr": io.StringIO(),
+            "clock": lambda: 0.0,
+            "sleep": lambda _seconds: None,
+        }
+        options.update(overrides)
+        return manager.create_template_from_image(self.client(opener), **options)
+
+    def test_create_binds_image_and_polls_until_ready(self):
+        opener = QueueOpener(
+            ("error", 404, {"message": "not found"}),
+            {"templateID": "template-1", "buildID": "build-1"},
+            {},
+            {"status": "waiting"},
+            {"status": "ready"},
+        )
+        clock = iter([0.0, 1.0]).__next__
+        sleeps = []
+        stderr = io.StringIO()
+
+        template_id = self.create(
+            opener,
+            stderr=stderr,
+            clock=clock,
+            sleep=sleeps.append,
+        )
+
+        self.assertEqual(template_id, "template-1")
+        self.assertEqual(sleeps, [2.0])
+        self.assertEqual(
+            [call[0].get_method() for call in opener.calls],
+            ["GET", "POST", "POST", "GET", "GET"],
+        )
+        self.assertEqual(
+            request_body(opener.calls[1]),
+            {"name": "harbor_task_demo", "sbxSpecCode": "g.c1"},
+        )
+        self.assertEqual(
+            request_body(opener.calls[2]),
+            {
+                "fromImage": "registry.example/task:tag",
+                "imageSource": "official",
+                "steps": [],
+            },
+        )
+        self.assertIn("templateID=template-1 buildID=build-1", stderr.getvalue())
+        self.assertIn("status=ready", stderr.getvalue())
+        headers = dict(opener.calls[1][0].header_items())
+        self.assertEqual(headers["X-api-key"], "sbx-test")
+
+    def test_existing_template_is_rejected_before_create(self):
+        opener = QueueOpener(
+            {"templateID": "template-1"},
+            {
+                "templateID": "template-1",
+                "builds": [{"status": "ready"}],
+            },
+        )
+
+        with self.assertRaisesRegex(manager.QzTemplateError, "refusing to rebuild"):
+            self.create(opener)
+
+        self.assertEqual(len(opener.calls), 2)
+        self.assertTrue(
+            opener.calls[0][0].full_url.endswith(
+                "/v1/templates/aliases/harbor_task_demo"
+            )
+        )
+
+    def test_exists_ok_returns_only_an_existing_ready_template(self):
+        opener = QueueOpener(
+            {"templateID": "template-1"},
+            {
+                "templateID": "template-1",
+                "builds": [{"status": "ready"}],
+            },
+        )
+
+        template_id = self.create(opener, exists_ok=True)
+
+        self.assertEqual(template_id, "template-1")
+        self.assertEqual(len(opener.calls), 2)
+
+    def test_exists_ok_rejects_non_ready_template(self):
+        opener = QueueOpener(
+            {"templateID": "template-1"},
+            {
+                "templateID": "template-1",
+                "builds": [{"status": "building"}],
+            },
+        )
+
+        with self.assertRaisesRegex(manager.QzTemplateError, "status 'building'"):
+            self.create(opener, exists_ok=True)
+
+        self.assertEqual(len(opener.calls), 2)
+
+    def test_build_error_reports_allocated_ids(self):
+        opener = QueueOpener(
+            ("error", 404, {"message": "not found"}),
+            {"templateID": "template-1", "buildID": "build-1"},
+            {},
+            {"status": "error"},
+        )
+
+        with self.assertRaisesRegex(
+            manager.QzTemplateError,
+            r"templateID=template-1, buildID=build-1",
+        ):
+            self.create(opener)
+
+    def test_polling_timeout_reports_last_status(self):
+        opener = QueueOpener(
+            ("error", 404, {"message": "not found"}),
+            {"templateID": "template-1", "buildID": "build-1"},
+            {},
+            {"status": "building"},
+        )
+        clock = iter([0.0, 11.0]).__next__
+
+        with self.assertRaisesRegex(
+            manager.QzTemplateError,
+            r"timed out.*last_status=building",
+        ):
+            self.create(opener, clock=clock)
+
+
+class InspectTemplateTest(unittest.TestCase):
+    def test_list_and_get_by_name(self):
+        opener = QueueOpener(
+            [{"templateID": "template-1", "names": ["harbor_task_demo"]}],
+            {"templateID": "template-1"},
+            {
+                "templateID": "template-1",
+                "builds": [{"status": "ready"}],
+            },
+        )
+        client = manager.QzTemplateClient(
+            api_key="sbx-test",
+            api_url="https://qz.example",
+            opener=opener,
+        )
+
+        templates = client.list_templates()
+        template = client.get_by_name("harbor_task_demo")
+
+        self.assertEqual(templates[0]["templateID"], "template-1")
+        self.assertEqual(template["templateID"], "template-1")
+        self.assertEqual(
+            [call[0].full_url for call in opener.calls],
+            [
+                "https://qz.example/v1/templates",
+                "https://qz.example/v1/templates/aliases/harbor_task_demo",
+                "https://qz.example/v1/templates/template-1",
+            ],
+        )
+
+
+class CliOutputTest(unittest.TestCase):
+    def test_create_writes_only_template_id_to_stdout(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            patch.dict(os.environ, {"SBX_API_KEY": "sbx-test"}, clear=True),
+            patch.object(manager, "client_from_environment", return_value=object()),
+            patch.object(
+                manager,
+                "create_template_from_image",
+                return_value="template-1",
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            result = manager.main(
+                [
+                    "create",
+                    "--name",
+                    "harbor_task_demo",
+                    "--image",
+                    "registry.example/task:tag",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stdout.getvalue(), "template-1\n")
+        self.assertEqual(stderr.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

QZ Sandbox creation consumes an existing Template ID, while task environments start from already-published Docker images. Operators need a small, auditable tool to create and inspect QZ Templates without expanding the Harbor runtime into Template lifecycle management.

## 2. Summary of the change

- add a Python-standard-library QZ Template Manager with `create`, `list`, and `get` commands
- map the existing `QZ_SANDBOX_*` / `SBX_*` configuration onto the QZ `/v1` Template API
- reject existing aliases by default and allow `--exists-ok` only for an existing ready Template
- select the latest build deterministically from platform timestamps
- reject redirects so `X-API-Key` remains bound to the configured API origin
- validate image inputs and finite positive timeouts before any API allocation
- keep Template IDs on stdout and progress/errors on stderr for safe shell composition
- add focused unit coverage and operator documentation
- link the Manager guide from the QZ Sandbox quick start

## 3. Other details

This is intentionally Template Manager v1 only. It does not add mapping/resolution, batch materialization, image build/push, rebuild, or delete.

`--exists-ok` checks the alias and latest ready status only; it does not prove that an existing Template was created from the requested image/spec. Stable identity mapping remains follow-up work.

The QZ-specific `/v1/templates` write flow is distinct from the unmounted upstream E2B `/v2/templates` API. Before this PR, the Manager's `POST /v1/templates`, build-start POST, and build-status polling path was exercised live for three Templates; all reached `ready`. Two task Templates then launched through the Harbor QZ adapter and completed Oracle runs with reward 1.0 and zero exceptions.

Validation:

- `ruff 0.16.0 check --config .github/ruff.toml`
- `ruff 0.16.0 format --check --config .github/ruff.toml Agents/utils/common/Harbor/qz_template_manager.py Agents/utils/common/Harbor/tests/test_qz_template_manager.py`
- `ruff 0.16.3 check` and `format --check` for the changed Python files
- `python3 -B -m unittest Agents.utils.common.Harbor.tests.test_qz_template_manager` — 19 tests passed
- `python3 -B -m py_compile Agents/utils/common/Harbor/qz_template_manager.py Agents/utils/common/Harbor/tests/test_qz_template_manager.py`
- live read-only `get` and `create --exists-ok` checks against an existing ready QZ Template
