### PR TITLE
feat(harbor): add fixer report runtime

### DIFF
--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/__init__.py
@@ -1,0 +1,6 @@
+"""Harbor Fixer report generation and summary runtime."""
+
+from .deterministic import render_fix_report, write_fix_report
+from .runtime import generate_report_summary
+
+__all__ = ["generate_report_summary", "render_fix_report", "write_fix_report"]

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/deterministic.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/deterministic.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from .artifact_io import write_text_atomic
-from .validation import (
+from ..artifact_io import write_text_atomic
+from ..validation import (
     validate_exec_result,
     validate_fix_plan_set,
     validate_verification_result,

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/prompt.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/prompt.py
@@ -1,0 +1,48 @@
+"""Prompt contract for the bounded report summary agent."""
+
+REPORT_MAIN_AGENT_PROMPT = """You are the Fixer report main agent for Harbor Fixer MVP.
+
+Read one validated report summary input and return JSON only.
+
+You must:
+- Summarize only the provided structured facts.
+- Make the summary useful for a human reviewing the fix outcome.
+- Report sampled task outcomes separately from unsampled tasks.
+- When verification_mode is smoke_test, describe fixed/not-fixed labels as sampled-task
+  results and never imply that all planned tasks or the full benchmark were fixed.
+- Mention important caveats from missing monitor data, inconclusive verification, or summary generation inputs.
+- Preserve all task/plan counts and statuses semantically.
+
+You must not:
+- Execute commands.
+- Produce a fix plan or shell commands.
+- Reclassify task statuses.
+- Infer values for missing data or describe unavailable data as zero.
+- Invent old or new run results.
+- Perform root cause analysis beyond the provided Analyzer and Verification facts.
+- Include credentials, model names, or endpoint values.
+
+Return exactly one JSON object with no Markdown or explanatory text.
+
+Required fields and constraints:
+- Include every top-level field shown in the template below and no report-detail objects.
+- schema_version must be 1.
+- kind must be "harbor_fixer_report_summary".
+- status describes summary generation, not the verification outcome. It must be "success"
+  for a generated summary or "failed" when no summary can be produced. Never copy input.status
+  values such as fixed, partially_fixed, not_fixed, inconclusive, or exec_failed into this field.
+- text must be a string. Put the human-readable summary here.
+- highlights, caveats, and generation_errors must be arrays; use [] when empty.
+- highlights and caveats contain strings, not nested report objects.
+
+Output template:
+{
+  "schema_version": 1,
+  "kind": "harbor_fixer_report_summary",
+  "status": "success | failed",
+  "text": "<concise human-readable summary>",
+  "highlights": ["<important result>"],
+  "caveats": ["<important limitation>"],
+  "generation_errors": []
+}
+"""

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/runtime.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/runtime.py
@@ -1,0 +1,134 @@
+"""Summary-agent runtime for Harbor Fixer reports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from harbor_pi_runtime import sleep_before_retry
+
+from ..agent_invocation import AgentInvoker
+from ..artifact_io import write_text
+from ..prompts import build_validation_retry_prompt
+from ..validation import (
+    ValidationError,
+    parse_strict_json_object,
+    validate_report_summary,
+)
+from .prompt import REPORT_MAIN_AGENT_PROMPT
+
+
+def _fallback_summary(
+    summary_input: dict[str, Any],
+    errors: list[dict[str, Any]],
+) -> dict[str, Any]:
+    new_run = (
+        summary_input.get("new_run")
+        if isinstance(summary_input.get("new_run"), dict)
+        else {}
+    )
+    sampling = (
+        new_run.get("sampling") if isinstance(new_run.get("sampling"), dict) else {}
+    )
+    task_results = [
+        item for item in summary_input.get("task_results", []) if isinstance(item, dict)
+    ]
+    sampled = [item for item in task_results if item.get("sampled")]
+    plan_task_count = int(sampling.get("plan_task_count") or len(task_results))
+    sampled_task_count = int(sampling.get("sampled_task_count") or len(sampled))
+    unsampled_task_count = int(
+        sampling.get("unsampled_task_count")
+        or max(0, plan_task_count - sampled_task_count)
+    )
+    fixed_count = sum(item.get("verification_status") == "fixed" for item in sampled)
+    not_fixed_count = sum(
+        item.get("verification_status") == "not_fixed" for item in sampled
+    )
+    other_count = len(sampled) - fixed_count - not_fixed_count
+    unsampled_exec_failed_count = sum(
+        not item.get("sampled") and item.get("verification_status") == "exec_failed"
+        for item in task_results
+    )
+    mode = str(new_run.get("verification_mode") or "verification run")
+    text = (
+        "Deterministic fallback summary: report-main-agent was unavailable. "
+        f"Fixer recorded {mode} results for {sampled_task_count} of {plan_task_count} planned task(s). "
+        f"Among sampled tasks, verifier labels were: {fixed_count} fixed, "
+        f"{not_fixed_count} not_fixed, and {other_count} other or inconclusive. "
+        f"{unsampled_task_count} task(s) were not sampled and have no rerun result."
+    )
+    if unsampled_exec_failed_count:
+        text += (
+            f" This includes {unsampled_exec_failed_count} unsampled task(s) labeled "
+            "exec_failed from Fixer execution; they have no rerun result."
+        )
+    if not summary_input.get("old_run", {}).get("monitor_available"):
+        text += " Baseline monitor data was unavailable, so no before/after comparison is claimed."
+    return {
+        "schema_version": 1,
+        "kind": "harbor_fixer_report_summary",
+        "status": "failed",
+        "text": text,
+        "highlights": [
+            f"sampled task labels: {fixed_count} fixed, {not_fixed_count} not_fixed, {other_count} other or inconclusive",
+            f"unsampled tasks: {unsampled_task_count}",
+            f"unsampled exec_failed tasks: {unsampled_exec_failed_count}",
+        ],
+        "caveats": [
+            "summary generated without report-main-agent due to summary generation failure",
+            *summary_input.get("caveats", []),
+        ],
+        "generation_errors": errors,
+    }
+
+
+def generate_report_summary(
+    invoker: AgentInvoker,
+    summary_input: dict[str, Any],
+    output_dir: Path,
+    *,
+    max_attempts: int = 2,
+) -> tuple[dict[str, Any], list[str]]:
+    errors: list[dict[str, Any]] = []
+    raw_paths: list[str] = []
+    prompt = REPORT_MAIN_AGENT_PROMPT
+    for attempt in range(1, max_attempts + 1):
+        raw = ""
+        try:
+            raw = invoker.invoke(
+                prompt, summary_input, attempt=attempt, label="report-main-agent"
+            )
+        except Exception as exc:  # noqa: BLE001 - provider retry boundary
+            error = str(exc)
+        else:
+            raw_path = (
+                output_dir / "raw-report-main-agent-output" / f"attempt-{attempt}.txt"
+            )
+            write_text(raw_path, raw)
+            raw_paths.append(str(raw_path))
+            try:
+                payload = parse_strict_json_object(raw)
+                validate_report_summary(payload)
+                if payload["status"] != "success":
+                    raise ValidationError("report summary status must be success")
+                if payload["generation_errors"]:
+                    raise ValidationError(
+                        "report summary generation_errors must be empty"
+                    )
+                payload["generation_errors"] = list(errors)
+            except ValidationError as exc:
+                error = str(exc)
+            else:
+                return payload, raw_paths
+            if raw and attempt < max_attempts:
+                prompt = build_validation_retry_prompt(
+                    base_prompt=REPORT_MAIN_AGENT_PROMPT,
+                    previous_output=raw,
+                    validation_error=error,
+                )
+        errors.append(
+            {"stage": "report_main_agent", "attempt": attempt, "error": error}
+        )
+        if attempt < max_attempts:
+            sleep_before_retry(attempt)
+    return _fallback_summary(summary_input, errors), raw_paths

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -64,6 +64,7 @@ INCONCLUSIVE_VERIFICATION_REASONS = {
     "monitor_unavailable",
     "rerun_failed",
 }
+REPORT_SUMMARY_STATUSES = {"success", "failed"}
 
 
 def json_sha256(value: Any) -> str:
@@ -942,3 +943,39 @@ def validate_verification_result(payload: dict[str, Any]) -> None:
             require_dict(record, f"unexpected_run_task_results[{index}]"),
             f"unexpected_run_task_results[{index}]",
         )
+
+
+def validate_report_summary(payload: dict[str, Any]) -> None:
+    _require_exact_fields(
+        payload,
+        "report summary",
+        {
+            "schema_version",
+            "kind",
+            "status",
+            "text",
+            "highlights",
+            "caveats",
+            "generation_errors",
+        },
+    )
+    _check_kind(
+        payload, version=1, kind="harbor_fixer_report_summary", name="report summary"
+    )
+    status = require_enum(
+        payload.get("status"), "report summary status", REPORT_SUMMARY_STATUSES
+    )
+    text = require_string(
+        payload.get("text"), "report summary text", allow_empty=status == "failed"
+    )
+    if status == "success" and not text.strip():
+        raise ValidationError("report summary text must contain non-whitespace text")
+    for index, highlight in enumerate(
+        require_list(payload.get("highlights"), "report summary highlights")
+    ):
+        require_string(highlight, f"report summary highlights[{index}]")
+    for index, caveat in enumerate(
+        require_list(payload.get("caveats"), "report summary caveats")
+    ):
+        require_string(caveat, f"report summary caveats[{index}]")
+    require_list(payload.get("generation_errors"), "report summary generation_errors")

--- a/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/__init__.py
@@ -1,5 +1,6 @@
 """Small shared helper for isolated Harbor Pi subprocesses."""
 
+from .backoff import retry_delay_seconds, sleep_before_retry
 from .process import (
     PiProcessResult,
     load_final_json_from_event_stream,
@@ -10,6 +11,8 @@ from .process import (
 __all__ = [
     "PiProcessResult",
     "load_final_json_from_event_stream",
+    "retry_delay_seconds",
     "run_pi_json_process",
+    "sleep_before_retry",
     "write_text_atomic",
 ]

--- a/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/backoff.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/backoff.py
@@ -1,0 +1,46 @@
+"""Shared exponential backoff for Harbor Pi agent retries."""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from collections.abc import Callable
+
+DEFAULT_INITIAL_SECONDS = 1.0
+DEFAULT_MAX_SECONDS = 30.0
+
+
+def _non_negative_finite_env(name: str, default: float) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return value if math.isfinite(value) and value >= 0 else default
+
+
+def retry_delay_seconds(completed_attempt: int) -> float:
+    """Return the delay before the attempt following ``completed_attempt``."""
+
+    if completed_attempt < 1:
+        raise ValueError("completed_attempt must be positive")
+    initial = _non_negative_finite_env(
+        "HARBOR_AGENT_RETRY_INITIAL_SECONDS", DEFAULT_INITIAL_SECONDS
+    )
+    maximum = _non_negative_finite_env(
+        "HARBOR_AGENT_RETRY_MAX_SECONDS", DEFAULT_MAX_SECONDS
+    )
+    return min(initial * (2 ** (completed_attempt - 1)), maximum)
+
+
+def sleep_before_retry(
+    completed_attempt: int,
+    *,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> float:
+    """Sleep with bounded exponential backoff and return the chosen delay."""
+
+    delay = retry_delay_seconds(completed_attempt)
+    if delay > 0:
+        sleeper(delay)
+    return delay

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
@@ -1,9 +1,13 @@
-"""Tests for the deterministic human-readable Fixer report."""
+"""Tests for deterministic and agent-generated Harbor Fixer reports."""
 
 from __future__ import annotations
 
+import json
+import os
 import sys
+import tempfile
 from pathlib import Path
+from unittest import mock
 
 TEST_DIR = Path(__file__).resolve().parent
 SCRIPT_DIR = TEST_DIR.parent / "scripts"
@@ -12,7 +16,12 @@ for path in (TEST_DIR, SCRIPT_DIR):
         sys.path.insert(0, str(path))
 
 from fixer_test_support import FixerTestCase, make_exec_result, make_fix_plan
-from harbor_fixer.report import render_fix_report, write_fix_report
+from harbor_fixer.report import (
+    generate_report_summary,
+    render_fix_report,
+    write_fix_report,
+)
+from harbor_fixer.validation import ValidationError, validate_report_summary
 
 
 def _verification_result() -> dict:
@@ -48,6 +57,25 @@ def _verification_result() -> dict:
         ],
         "unexpected_run_task_results": [],
     }
+
+
+class _SequenceInvoker:
+    def __init__(self, outputs: list[str]) -> None:
+        self.outputs = outputs
+        self.prompts: list[str] = []
+
+    def invoke(
+        self, prompt: str, payload: dict, *, attempt: int, label: str
+    ) -> str:
+        self.prompts.append(prompt)
+        return self.outputs[attempt - 1]
+
+
+class _FailingInvoker:
+    def invoke(
+        self, prompt: str, payload: dict, *, attempt: int, label: str
+    ) -> str:
+        raise TimeoutError("provider timed out")
 
 
 class HarborFixerReportTest(FixerTestCase):
@@ -88,3 +116,76 @@ class HarborFixerReportTest(FixerTestCase):
                 _verification_result(),
             ),
         )
+
+    def test_runtime_retries_invalid_summary_and_has_factual_fallback(self) -> None:
+        valid = {
+            "schema_version": 1,
+            "kind": "harbor_fixer_report_summary",
+            "status": "success",
+            "text": "One sampled task was fixed.",
+            "highlights": [],
+            "caveats": [],
+            "generation_errors": [],
+        }
+        summary_input = {
+            "schema_version": 1,
+            "kind": "harbor_fixer_report_summary_input",
+            "old_run": {"monitor_available": False},
+            "new_run": {
+                "verification_mode": "smoke_test",
+                "sampling": {
+                    "plan_task_count": 2,
+                    "sampled_task_count": 1,
+                    "unsampled_task_count": 1,
+                },
+            },
+            "task_results": [
+                {"sampled": True, "verification_status": "fixed"},
+                {"sampled": False, "verification_status": "exec_failed"},
+            ],
+            "caveats": [],
+        }
+        with self.assertRaises(ValidationError):
+            validate_report_summary(
+                {**valid, "highlights": [{"task": "task-1"}]}
+            )
+        with self.assertRaises(ValidationError):
+            validate_report_summary({**valid, "detail": {"task": "task-1"}})
+        for invalid_text in ("", " \n\t "):
+            with self.subTest(invalid_text=invalid_text), self.assertRaises(
+                ValidationError
+            ):
+                validate_report_summary({**valid, "text": invalid_text})
+        with tempfile.TemporaryDirectory() as root, mock.patch.dict(
+            os.environ, {"HARBOR_AGENT_RETRY_INITIAL_SECONDS": "0"}
+        ):
+            invoker = _SequenceInvoker(
+                [
+                    json.dumps({**valid, "status": "failed", "text": ""}),
+                    json.dumps(valid),
+                ]
+            )
+            summary, _ = generate_report_summary(
+                invoker, summary_input, Path(root) / "valid"
+            )
+            fallback, _ = generate_report_summary(
+                _FailingInvoker(), summary_input, Path(root) / "fallback"
+            )
+            blocked_output = Path(root) / "blocked"
+            blocked_output.write_text("not a directory", encoding="utf-8")
+            write_invoker = _SequenceInvoker([json.dumps(valid)])
+            with self.assertRaises(OSError):
+                generate_report_summary(
+                    write_invoker, summary_input, blocked_output, max_attempts=2
+                )
+
+        self.assertEqual(summary["status"], "success")
+        self.assertEqual(len(summary["generation_errors"]), 1)
+        self.assertIn("status must be success", summary["generation_errors"][0]["error"])
+        self.assertIn("Validation retry", invoker.prompts[1])
+        self.assertEqual(fallback["status"], "failed")
+        self.assertIn("1 of 2 planned task(s)", fallback["text"])
+        self.assertIn("1 task(s) were not sampled", fallback["text"])
+        self.assertIn("1 unsampled task(s) labeled exec_failed", fallback["text"])
+        self.assertIn("Baseline monitor data was unavailable", fallback["text"])
+        self.assertEqual(len(write_invoker.prompts), 1)


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer report generation needs a bounded summary-agent runtime that can tolerate provider and validation failures without aborting report production. It also needs a deterministic fallback that reports only observed task outcomes and clearly identifies unavailable monitor evidence.

## 2. Summary of the change

- Add the report summary prompt and an `AgentInvoker`-based runtime.
- Validate the exact summary schema, including string-only highlights and caveats.
- Retry invocation and validation failures with exponential backoff while preserving raw agent outputs and generation errors.
- Produce a factual deterministic fallback that distinguishes sampled and unsampled tasks and does not overstate missing baseline evidence.
- Add shared Harbor Pi retry-backoff utilities and the minimal runtime test.

## 3. Other details

This PR contains only the report runtime foundation. Machine-readable report generation, Markdown rendering, and CLI integration will be submitted as separate follow-up PRs.

Validation:

- `/home/yicheng/.local/share/agent-fleet/harbor-runner/bin/python -m unittest Agents.utils.common.Harbor.tests.test_harbor_fixer_report`
- `uvx --from ruff==0.16.0 ruff check --config .github/ruff.toml`