### PR TITLE
refactor: extract setup configuration helpers

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -107,7 +107,8 @@ info "Prerequisite downloads: $AGENT_FLEET_CACHE_DIR/downloads"
 # ---- 2. Gather config (caller env, existing local config, then prompts) ----
 
 normalize_trace_to_opik() {
-  local value="${1,,}"
+  local value
+  value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
   case "$value" in
     1|true|yes|y|on)
       TRACE_TO_OPIK=true
@@ -227,42 +228,7 @@ load_legacy_managed_claude_package_config() {
         fi
         ;;
     esac
-  done < <(python3 - "$bashrc" <<'PY'
-import shlex
-import sys
-from pathlib import Path
-
-begin = "# >>> agent-fleet env >>>"
-end = "# <<< agent-fleet env <<<"
-legacy_prefix = "T" + "B_CC_"
-names = {
-    legacy_prefix + "OPIK_ENABLE_HOOK": "HARBOR_CC_OPIK_ENABLE_HOOK",
-    legacy_prefix + "CLAUDE_TGZ_SOURCE": "HARBOR_CC_CLAUDE_TGZ_SOURCE",
-    legacy_prefix + "PY_WHEEL_DIR_SOURCE": "HARBOR_CC_PY_WHEEL_DIR_SOURCE",
-}
-in_block = False
-for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
-    stripped = line.strip()
-    if stripped == begin:
-        in_block = True
-        continue
-    if stripped == end:
-        in_block = False
-        continue
-    if not in_block:
-        continue
-    try:
-        fields = shlex.split(stripped, comments=True, posix=True)
-    except ValueError:
-        continue
-    if len(fields) != 2 or fields[0] != "export" or "=" not in fields[1]:
-        continue
-    key, value = fields[1].split("=", 1)
-    replacement = names.get(key)
-    if replacement:
-        print(f"{replacement}\t{value}")
-PY
-)
+  done < <(python3 "$SCRIPT_DIR/setup_config.py" legacy-claude-config "$bashrc")
 
   if (( found )); then
     warn "Migrating legacy TerminalBench Claude package settings from ~/.bashrc."
@@ -399,58 +365,11 @@ PI_SETTINGS="$PI_AGENT_DIR/settings.json"
 PI_MODELS="$PI_AGENT_DIR/models.json"
 cp -f "$PI_SETTINGS" "$PI_SETTINGS.bak.agent-fleet" 2>/dev/null || true
 cp -f "$PI_MODELS" "$PI_MODELS.bak.agent-fleet" 2>/dev/null || true
-python3 - "$PI_SETTINGS" "$PI_MODELS" "$BASE_URL" "$MODEL" "$SCRIPT_DIR" <<'PY'
-import json, sys
-settings_path, models_path, base_url, model, script_dir = sys.argv[1:]
-sys.path.insert(0, script_dir)
-from pi_prompt import PromptFailure, models_config, normalized_base_url
-
-def load_object(path):
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            value = json.load(f)
-        if isinstance(value, dict):
-            return value
-    except FileNotFoundError:
-        pass
-    except json.JSONDecodeError:
-        print(
-            f"\033[1;33m[WARN]\033[0m existing {path} could not be parsed; "
-            f"backed up at {path}.bak.agent-fleet, writing fresh",
-            file=sys.stderr,
-        )
-    return {}
-
-settings = load_object(settings_path)
-settings["defaultProvider"] = "sii-gateway"
-settings["defaultModel"] = model
-settings.setdefault("defaultThinkingLevel", "high")
-settings.setdefault("theme", "dark")
-settings.setdefault("enableInstallTelemetry", False)
-
-models = load_object(models_path)
-providers = models.get("providers")
-if not isinstance(providers, dict):
-    providers = {}
-    models["providers"] = providers
-try:
-    normalized_url = normalized_base_url(base_url)
-except PromptFailure as exc:
-    print(f"\033[1;31m[FAIL]\033[0m {exc}", file=sys.stderr)
-    raise SystemExit(1) from exc
-providers["sii-gateway"] = models_config(
-    normalized_url, model, display_name="Agent Fleet"
-)["providers"]["sii-gateway"]
-
-for path, value in ((settings_path, settings), (models_path, models)):
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(value, f, indent=2)
-        f.write("\n")
-PY
+python3 "$SCRIPT_DIR/setup_config.py" merge-pi-config \
+  "$PI_SETTINGS" "$PI_MODELS" "$BASE_URL" "$MODEL"
 ok "Pi configuration merged (provider=sii-gateway, model=${MODEL})"
 
 # ---- 6. Write env vars + nvm init to ~/.bashrc (idempotent) ----
-# Uses Python to replace the managed block portably (GNU/BSD sed differ).
 info "Writing env vars to ~/.bashrc..."
 BASHRC="$HOME/.bashrc"
 cp -f "$BASHRC" "$BASHRC.bak.agent-fleet" 2>/dev/null || true
@@ -459,59 +378,7 @@ CLAUDE_TGZ_SOURCE="$CLAUDE_TGZ_SOURCE" \
 CLAUDE_WHEEL_DIR_SOURCE="$CLAUDE_WHEEL_DIR_SOURCE" \
 AGENT_FLEET_PATHS_FILE="$AGENT_FLEET_PATHS_FILE" \
 BASHRC="$BASHRC" \
-  python3 - <<'PY'
-import os, shlex
-from pathlib import Path
-
-bashrc = Path(os.environ["BASHRC"])
-auth_token = os.environ["AUTH_TOKEN"]
-tgz = os.environ.get("CLAUDE_TGZ_SOURCE", "").strip()
-wheel = os.environ.get("CLAUDE_WHEEL_DIR_SOURCE", "").strip()
-paths_file = os.environ["AGENT_FLEET_PATHS_FILE"]
-
-BEGIN = "# >>> agent-fleet env >>>"
-END   = "# <<< agent-fleet env <<<"
-
-lines = []
-if bashrc.exists():
-    lines = bashrc.read_text(encoding="utf-8").splitlines()
-
-# Drop any existing managed block (idempotent).
-out = []
-in_block = False
-for ln in lines:
-    if ln.strip() == BEGIN:
-        in_block = True
-        continue
-    if ln.strip() == END:
-        in_block = False
-        continue
-    if not in_block:
-        out.append(ln)
-
-# Build new managed block with shell-escaped values.
-q = shlex.quote
-block = [
-    "",
-    BEGIN,
-    f"export AGENT_FLEET_PATHS_FILE={q(paths_file)}",
-    '[ -f "$AGENT_FLEET_PATHS_FILE" ] && . "$AGENT_FLEET_PATHS_FILE"',
-    'export NVM_DIR="$HOME/.nvm"',
-    '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
-    "export PI_OFFLINE=1",
-    f"export AGENT_FLEET_API_KEY={q(auth_token)}",
-]
-if tgz and wheel:
-    block += [
-        "export HARBOR_CC_OPIK_ENABLE_HOOK=1",
-        f"export HARBOR_CC_CLAUDE_TGZ_SOURCE={q(tgz)}",
-        f"export HARBOR_CC_PY_WHEEL_DIR_SOURCE={q(wheel)}",
-    ]
-block.append(END)
-
-out.extend(block)
-bashrc.write_text("\n".join(out) + "\n", encoding="utf-8")
-PY
+  python3 "$SCRIPT_DIR/setup_config.py" update-bashrc "$BASHRC"
 ok "Env vars written to ~/.bashrc (idempotent); backup at ${BASHRC}.bak.agent-fleet"
 
 export PI_OFFLINE=1
@@ -637,72 +504,7 @@ OPIK_API_KEY="${OPIK_API_KEY:-}" \
 OPIK_WORKSPACE="${OPIK_WORKSPACE:-}" \
 OPIK_PROJECT_NAME="${OPIK_PROJECT_NAME:-}" \
 CONFIG_LOCAL="$CONFIG_LOCAL" \
-  python3 - <<'PY'
-import os
-from pathlib import Path
-
-path = Path(os.environ["CONFIG_LOCAL"])
-base = os.environ["BASE_URL"].rstrip("/")
-token = os.environ["AUTH_TOKEN"]
-model = os.environ["MODEL"]
-
-# Managed keys: BASE_URL stored without /v1 (repo convention; runners append it).
-managed = {
-    "BASE_URL": base,
-    "API_KEY": token,
-    "MODEL": model,
-}
-trace_to_opik = os.environ.get("TRACE_TO_OPIK", "").strip()
-if trace_to_opik:
-    managed["TRACE_TO_OPIK"] = trace_to_opik
-opik_url = os.environ.get("OPIK_URL", "").strip()
-if opik_url:
-    managed["OPIK_URL"] = opik_url
-    managed["OPIK_API_KEY"] = os.environ.get("OPIK_API_KEY", "")
-    managed["OPIK_WORKSPACE"] = os.environ.get("OPIK_WORKSPACE") or "default"
-    managed["OPIK_PROJECT_NAME"] = os.environ.get("OPIK_PROJECT_NAME", "")
-
-# Read existing lines, keep non-managed keys as-is.
-existing = {}
-order = []
-if path.exists():
-    for line in path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            order.append(("comment", line.rstrip("\n")))
-            continue
-        if "=" in stripped:
-            k, _, v = stripped.partition("=")
-            existing[k] = v
-            order.append(("kv", k))
-        else:
-            order.append(("raw", line.rstrip("\n")))
-
-existing.update(managed)
-
-# Emit: existing structure (comments/order preserved) + any new managed keys.
-# Values are plain (unquoted) to match config.env convention; the repo's
-# env-file readers (load_env_file) use partition("=") + strip() without
-# shell unquoting, so quoted values would be read back with the quotes
-# still embedded.
-def emit(k):
-    return f"{k}={existing[k]}"
-
-seen = set()
-out = []
-for kind, val in order:
-    if kind == "kv":
-        if val in existing and val not in seen:
-            out.append(emit(val))
-            seen.add(val)
-    else:
-        out.append(val)
-for k in managed:
-    if k not in seen:
-        out.append(emit(k))
-
-path.write_text("\n".join(out) + "\n", encoding="utf-8")
-PY
+  python3 "$SCRIPT_DIR/setup_config.py" merge-local-config "$CONFIG_LOCAL"
 chmod 0600 "$CONFIG_LOCAL"
 if [[ -n "$CONFIG_LOCAL_BACKUP" ]]; then
   ok "config.local.env merged; private backup at $CONFIG_LOCAL_BACKUP"

--- a/scripts/setup_config.py
+++ b/scripts/setup_config.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+try:
+    from .pi_prompt import PromptFailure, models_config, normalized_base_url
+except ImportError:
+    from pi_prompt import PromptFailure, models_config, normalized_base_url
+
+
+BEGIN = "# >>> agent-fleet env >>>"
+END = "# <<< agent-fleet env <<<"
+
+
+def legacy_claude_config(path: Path) -> list[tuple[str, str]]:
+    legacy_prefix = "T" + "B_CC_"
+    names = {
+        legacy_prefix + "OPIK_ENABLE_HOOK": "HARBOR_CC_OPIK_ENABLE_HOOK",
+        legacy_prefix + "CLAUDE_TGZ_SOURCE": "HARBOR_CC_CLAUDE_TGZ_SOURCE",
+        legacy_prefix + "PY_WHEEL_DIR_SOURCE": "HARBOR_CC_PY_WHEEL_DIR_SOURCE",
+    }
+    values: list[tuple[str, str]] = []
+    in_block = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped == BEGIN:
+            in_block = True
+            continue
+        if stripped == END:
+            in_block = False
+            continue
+        if not in_block:
+            continue
+        try:
+            fields = shlex.split(stripped, comments=True, posix=True)
+        except ValueError:
+            continue
+        if len(fields) != 2 or fields[0] != "export" or "=" not in fields[1]:
+            continue
+        key, value = fields[1].split("=", 1)
+        replacement = names.get(key)
+        if replacement:
+            values.append((replacement, value))
+    return values
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(value, dict):
+            return value
+    except FileNotFoundError:
+        pass
+    except json.JSONDecodeError:
+        print(
+            f"\033[1;33m[WARN]\033[0m existing {path} could not be parsed; "
+            f"backed up at {path}.bak.agent-fleet, writing fresh",
+            file=sys.stderr,
+        )
+    return {}
+
+
+def merge_pi_config(
+    settings_path: Path,
+    models_path: Path,
+    base_url: str,
+    model: str,
+) -> None:
+    settings = _load_object(settings_path)
+    settings["defaultProvider"] = "sii-gateway"
+    settings["defaultModel"] = model
+    settings.setdefault("defaultThinkingLevel", "high")
+    settings.setdefault("theme", "dark")
+    settings.setdefault("enableInstallTelemetry", False)
+
+    models = _load_object(models_path)
+    providers = models.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+        models["providers"] = providers
+    normalized_url = normalized_base_url(base_url)
+    providers["sii-gateway"] = models_config(
+        normalized_url, model, display_name="Agent Fleet"
+    )["providers"]["sii-gateway"]
+
+    for path, value in ((settings_path, settings), (models_path, models)):
+        path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def update_bashrc(path: Path, environ: Mapping[str, str]) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    output: list[str] = []
+    in_block = False
+    for line in lines:
+        if line.strip() == BEGIN:
+            in_block = True
+            continue
+        if line.strip() == END:
+            in_block = False
+            continue
+        if not in_block:
+            output.append(line)
+
+    quote = shlex.quote
+    block = [
+        "",
+        BEGIN,
+        f"export AGENT_FLEET_PATHS_FILE={quote(environ['AGENT_FLEET_PATHS_FILE'])}",
+        '[ -f "$AGENT_FLEET_PATHS_FILE" ] && . "$AGENT_FLEET_PATHS_FILE"',
+        'export NVM_DIR="$HOME/.nvm"',
+        '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
+        "export PI_OFFLINE=1",
+        f"export AGENT_FLEET_API_KEY={quote(environ['AUTH_TOKEN'])}",
+    ]
+    tgz = environ.get("CLAUDE_TGZ_SOURCE", "").strip()
+    wheel = environ.get("CLAUDE_WHEEL_DIR_SOURCE", "").strip()
+    if tgz and wheel:
+        block.extend(
+            [
+                "export HARBOR_CC_OPIK_ENABLE_HOOK=1",
+                f"export HARBOR_CC_CLAUDE_TGZ_SOURCE={quote(tgz)}",
+                f"export HARBOR_CC_PY_WHEEL_DIR_SOURCE={quote(wheel)}",
+            ]
+        )
+    block.append(END)
+    output.extend(block)
+    path.write_text("\n".join(output) + "\n", encoding="utf-8")
+
+
+def merge_local_config(path: Path, environ: Mapping[str, str]) -> None:
+    managed = {
+        "BASE_URL": environ["BASE_URL"].rstrip("/"),
+        "API_KEY": environ["AUTH_TOKEN"],
+        "MODEL": environ["MODEL"],
+    }
+    trace_to_opik = environ.get("TRACE_TO_OPIK", "").strip()
+    if trace_to_opik:
+        managed["TRACE_TO_OPIK"] = trace_to_opik
+    opik_url = environ.get("OPIK_URL", "").strip()
+    if opik_url:
+        managed.update(
+            {
+                "OPIK_URL": opik_url,
+                "OPIK_API_KEY": environ.get("OPIK_API_KEY", ""),
+                "OPIK_WORKSPACE": environ.get("OPIK_WORKSPACE") or "default",
+                "OPIK_PROJECT_NAME": environ.get("OPIK_PROJECT_NAME", ""),
+            }
+        )
+
+    existing: dict[str, str] = {}
+    order: list[tuple[str, str]] = []
+    if path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                order.append(("comment", line))
+            elif "=" in stripped:
+                key, _, value = stripped.partition("=")
+                existing[key] = value
+                order.append(("kv", key))
+            else:
+                order.append(("raw", line))
+    existing.update(managed)
+
+    seen: set[str] = set()
+    output: list[str] = []
+    for kind, value in order:
+        if kind == "kv":
+            if value in existing and value not in seen:
+                output.append(f"{value}={existing[value]}")
+                seen.add(value)
+        else:
+            output.append(value)
+    for key in managed:
+        if key not in seen:
+            output.append(f"{key}={existing[key]}")
+    path.write_text("\n".join(output) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage Agent Fleet setup files")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    legacy = subparsers.add_parser("legacy-claude-config")
+    legacy.add_argument("path", type=Path)
+
+    merge_pi = subparsers.add_parser("merge-pi-config")
+    merge_pi.add_argument("settings_path", type=Path)
+    merge_pi.add_argument("models_path", type=Path)
+    merge_pi.add_argument("base_url")
+    merge_pi.add_argument("model")
+
+    update_shell = subparsers.add_parser("update-bashrc")
+    update_shell.add_argument("path", type=Path)
+
+    merge_local = subparsers.add_parser("merge-local-config")
+    merge_local.add_argument("path", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "legacy-claude-config":
+        for key, value in legacy_claude_config(args.path):
+            print(f"{key}\t{value}")
+    elif args.command == "merge-pi-config":
+        try:
+            merge_pi_config(
+                args.settings_path,
+                args.models_path,
+                args.base_url,
+                args.model,
+            )
+        except PromptFailure as exc:
+            print(f"\033[1;31m[FAIL]\033[0m {exc}", file=sys.stderr)
+            return 1
+    elif args.command == "update-bashrc":
+        update_bashrc(args.path, os.environ)
+    elif args.command == "merge-local-config":
+        merge_local_config(args.path, os.environ)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_setup_config.py
+++ b/scripts/tests/test_setup_config.py
@@ -1,0 +1,132 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import setup_config
+
+
+class SetupConfigTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_legacy_claude_config_reads_only_managed_legacy_exports(self):
+        bashrc = self.root / ".bashrc"
+        legacy_prefix = "T" + "B_CC_"
+        bashrc.write_text(
+            "export OUTSIDE=ignored\n"
+            "# >>> agent-fleet env >>>\n"
+            f"export {legacy_prefix}OPIK_ENABLE_HOOK=1\n"
+            f"export {legacy_prefix}CLAUDE_TGZ_SOURCE='/tmp/claude code.tgz'\n"
+            "export KEEP_ME=yes\n"
+            "# <<< agent-fleet env <<<\n",
+            encoding="utf-8",
+        )
+
+        values = setup_config.legacy_claude_config(bashrc)
+
+        self.assertEqual(
+            values,
+            [
+                ("HARBOR_CC_OPIK_ENABLE_HOOK", "1"),
+                ("HARBOR_CC_CLAUDE_TGZ_SOURCE", "/tmp/claude code.tgz"),
+            ],
+        )
+
+    def test_merge_pi_config_preserves_custom_values(self):
+        settings_path = self.root / "settings.json"
+        models_path = self.root / "models.json"
+        settings_path.write_text(
+            json.dumps({"theme": "light", "custom": True}), encoding="utf-8"
+        )
+        models_path.write_text(
+            json.dumps({"providers": {"other": {"models": []}}}),
+            encoding="utf-8",
+        )
+
+        setup_config.merge_pi_config(
+            settings_path,
+            models_path,
+            "https://gateway.example.invalid",
+            "test-model",
+        )
+
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertEqual(settings["theme"], "light")
+        self.assertTrue(settings["custom"])
+        self.assertEqual(settings["defaultProvider"], "sii-gateway")
+        models = json.loads(models_path.read_text(encoding="utf-8"))
+        self.assertIn("other", models["providers"])
+        provider = models["providers"]["sii-gateway"]
+        self.assertEqual(provider["baseUrl"], "https://gateway.example.invalid/v1")
+        self.assertEqual(provider["models"][0]["id"], "test-model")
+
+    def test_update_bashrc_replaces_managed_block_and_shell_quotes_values(self):
+        bashrc = self.root / ".bashrc"
+        bashrc.write_text(
+            "export KEEP_ME=yes\n"
+            "# >>> agent-fleet env >>>\n"
+            "export OLD_VALUE=remove-me\n"
+            "# <<< agent-fleet env <<<\n",
+            encoding="utf-8",
+        )
+        environ = {
+            "AUTH_TOKEN": "fake token with spaces",
+            "AGENT_FLEET_PATHS_FILE": "/tmp/agent fleet/paths.env",
+            "CLAUDE_TGZ_SOURCE": "/tmp/claude code.tgz",
+            "CLAUDE_WHEEL_DIR_SOURCE": "/tmp/wheel dir",
+        }
+
+        setup_config.update_bashrc(bashrc, environ)
+
+        content = bashrc.read_text(encoding="utf-8")
+        self.assertIn("export KEEP_ME=yes", content)
+        self.assertNotIn("OLD_VALUE", content)
+        self.assertIn("export AGENT_FLEET_PATHS_FILE='/tmp/agent fleet/paths.env'", content)
+        self.assertIn("export AGENT_FLEET_API_KEY='fake token with spaces'", content)
+        self.assertIn("export HARBOR_CC_CLAUDE_TGZ_SOURCE='/tmp/claude code.tgz'", content)
+        self.assertEqual(content.count("# >>> agent-fleet env >>>"), 1)
+
+    def test_merge_local_config_preserves_structure_and_updates_managed_keys(self):
+        path = self.root / "config.local.env"
+        path.write_text(
+            "# keep comment\n"
+            "KEEP_SETTING=yes\n"
+            "BASE_URL=https://old.invalid\n"
+            "API_KEY=old-secret\n",
+            encoding="utf-8",
+        )
+        environ = {
+            "BASE_URL": "https://gateway.example.invalid/",
+            "AUTH_TOKEN": "fake-new-secret",
+            "MODEL": "test-model",
+            "TRACE_TO_OPIK": "false",
+            "OPIK_URL": "",
+        }
+
+        setup_config.merge_local_config(path, environ)
+
+        self.assertEqual(
+            path.read_text(encoding="utf-8"),
+            "# keep comment\n"
+            "KEEP_SETTING=yes\n"
+            "BASE_URL=https://gateway.example.invalid\n"
+            "API_KEY=fake-new-secret\n"
+            "MODEL=test-model\n"
+            "TRACE_TO_OPIK=false\n",
+        )
+
+    def test_setup_shell_contains_no_embedded_python_programs(self):
+        setup_shell = Path(__file__).resolve().parents[1] / "setup.sh"
+        content = setup_shell.read_text(encoding="utf-8")
+
+        self.assertNotIn("python3 - <<", content)
+        self.assertNotIn("python3 - \"$bashrc\" <<", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

`scripts/setup.sh` embeds substantial Python configuration logic, which makes the setup entry point harder to review and maintain.

## 2. Summary of the change

- Add `scripts/setup_config.py` for legacy Claude config migration, Pi config merging, managed bashrc updates, and local config updates.
- Replace embedded Python programs in `setup.sh` with thin helper invocations.
- Preserve the existing shell interface and configuration precedence.

## 3. Other details

Verification:
- `python3 -m unittest scripts.tests.test_setup_config -v`
- `bash -n scripts/setup.sh`
- Ruff and `git diff --check`