### PR TITLE
refactor: extract shared script Python helpers

### DIFF
--- a/scripts/dind-run.sh
+++ b/scripts/dind-run.sh
@@ -121,12 +121,7 @@ DIND_MOUNTS="${DIND_MOUNTS:-}"
 DIND_DEFAULT_ADDRESS_POOLS="${DIND_DEFAULT_ADDRESS_POOLS:-}"
 
 url_hostname() {
-  python3 - "$1" <<'PY'
-from urllib.parse import urlparse
-import sys
-
-print(urlparse(sys.argv[1]).hostname or "")
-PY
+  python3 "$SCRIPT_DIR/script_utils.py" url-hostname "$1"
 }
 
 append_csv_unique() {

--- a/scripts/prerequisites.sh
+++ b/scripts/prerequisites.sh
@@ -2,6 +2,8 @@
 # Shared prerequisite discovery and managed-tool bootstrap.
 set -euo pipefail
 
+AGENT_FLEET_PREREQ_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 AGENT_FLEET_PATHS_FILE="${AGENT_FLEET_PATHS_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/agent-fleet/paths.env}"
 __agent_fleet_caller_env="$(export -p)"
 if [[ -f "$AGENT_FLEET_PATHS_FILE" ]]; then
@@ -182,13 +184,7 @@ agent_fleet_platform_asset() {
 }
 
 agent_fleet_verify_sha256() {
-  python3 - "$1" "$2" <<'PY'
-import hashlib, pathlib, sys
-source = pathlib.Path(sys.argv[1])
-expected = pathlib.Path(sys.argv[2]).read_text().split()[0].lower()
-actual = hashlib.sha256(source.read_bytes()).hexdigest()
-raise SystemExit(0 if actual == expected else 1)
-PY
+  python3 "$AGENT_FLEET_PREREQ_SCRIPT_DIR/script_utils.py" verify-sha256 "$1" "$2"
 }
 
 agent_fleet_download() {

--- a/scripts/script_utils.py
+++ b/scripts/script_utils.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def url_hostname(value: str) -> str:
+    return urlparse(value).hostname or ""
+
+
+def verify_sha256(source: Path, checksum: Path) -> bool:
+    expected = checksum.read_text(encoding="utf-8").split()[0].lower()
+    digest = hashlib.sha256()
+    with source.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest() == expected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Helpers for Agent Fleet shell scripts")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    hostname = subparsers.add_parser("url-hostname")
+    hostname.add_argument("url")
+    checksum = subparsers.add_parser("verify-sha256")
+    checksum.add_argument("source", type=Path)
+    checksum.add_argument("checksum", type=Path)
+    args = parser.parse_args()
+
+    if args.command == "url-hostname":
+        print(url_hostname(args.url))
+        return 0
+    return 0 if verify_sha256(args.source, args.checksum) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_dind_run.sh
+++ b/scripts/tests/test_dind_run.sh
@@ -11,6 +11,7 @@ mkdir -p \
   "$PROJECT_DIR/Agents/utils/common/Harbor" \
   "$TMP_DIR/bin"
 cp "$REPO_ROOT/scripts/dind-run.sh" "$PROJECT_DIR/scripts/dind-run.sh"
+cp "$REPO_ROOT/scripts/script_utils.py" "$PROJECT_DIR/scripts/script_utils.py"
 if grep -q -- 'docker_exec_root_env' "$PROJECT_DIR/scripts/dind-run.sh"; then
   echo "dind-run.sh still defines or uses the root setup helper" >&2
   exit 1

--- a/scripts/tests/test_script_utils.py
+++ b/scripts/tests/test_script_utils.py
@@ -1,0 +1,46 @@
+import hashlib
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import script_utils
+
+
+class ScriptUtilsTest(unittest.TestCase):
+    def test_owned_shell_scripts_do_not_embed_python_heredocs(self):
+        root = Path(__file__).resolve().parents[2]
+        offenders = []
+        pattern = re.compile(r"(?:python(?:3)?|\$PYTHON_BIN)[^\n]*<<")
+        for relative_path in ("scripts/dind-run.sh", "scripts/prerequisites.sh"):
+            path = root / relative_path
+            if pattern.search(path.read_text(encoding="utf-8")):
+                offenders.append(str(path.relative_to(root)))
+
+        self.assertEqual(offenders, [])
+
+    def test_url_hostname(self):
+        self.assertEqual(
+            script_utils.url_hostname("https://gateway.example.invalid:8443/v1"),
+            "gateway.example.invalid",
+        )
+        self.assertEqual(script_utils.url_hostname(""), "")
+
+    def test_verify_sha256(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "archive"
+            checksum = root / "archive.sha256"
+            source.write_bytes(b"fixture")
+            checksum.write_text(
+                f"{hashlib.sha256(b'fixture').hexdigest()}  archive\n",
+                encoding="utf-8",
+            )
+
+            self.assertTrue(script_utils.verify_sha256(source, checksum))
+            source.write_bytes(b"changed")
+            self.assertFalse(script_utils.verify_sha256(source, checksum))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

The DinD and prerequisite scripts contain inline Python for URL parsing and checksum verification.

## 2. Summary of the change

- Add `scripts/script_utils.py` with focused hostname and SHA-256 commands.
- Delegate `dind-run.sh` and `prerequisites.sh` to the helper.
- Update the DinD fixture and add helper regression coverage.

## 3. Other details

Verification:
- `python3 -m unittest scripts.tests.test_script_utils -v`
- `bash scripts/tests/test_prerequisites.sh`
- Shell syntax, Ruff, and `git diff --check`