### PR TITLE
refactor: extract Harbor shell runtime helpers

### DIFF
--- a/Agents/utils/common/Harbor/harbor_monitor_utils.py
+++ b/Agents/utils/common/Harbor/harbor_monitor_utils.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+SUCCESS_VALUES = {"1", "1.0", "true", "success", "resolved", "pass", "passed"}
+
+
+def _rows(path: Path) -> list[list[str]]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            return [line.rstrip("\n").split("\t") for line in handle]
+    except FileNotFoundError:
+        return []
+
+
+def reward_stats(done_path: Path) -> list[str]:
+    counter = Counter(
+        parts[2] or "none" for parts in _rows(done_path) if len(parts) >= 3
+    )
+    if not counter:
+        return ["(none)"]
+    return [
+        f"reward={reward}: {count}"
+        for reward, count in sorted(counter.items(), key=lambda item: (item[0] != "1.0", item[0]))
+    ]
+
+
+def success_stats(done_path: Path, failed_path: Path) -> list[str]:
+    done_rows = [parts for parts in _rows(done_path) if len(parts) >= 3]
+    success = sum(parts[2].strip().lower() in SUCCESS_VALUES for parts in done_rows)
+    failed = sum(bool(parts and any(part.strip() for part in parts)) for parts in _rows(failed_path))
+    finished = len(done_rows) + failed
+    failure = finished - success
+    rate = success / finished * 100.0 if finished else 0.0
+    return [
+        f"success:      {success}",
+        f"fail:         {failure}",
+        f"success_rate: {rate:.2f}%",
+    ]
+
+
+def exception_stats(done_path: Path, failed_path: Path) -> list[str]:
+    counter: Counter[str] = Counter()
+    for path in (done_path, failed_path):
+        for parts in _rows(path):
+            if len(parts) >= 4 and parts[3]:
+                counter[parts[3]] += 1
+            elif path == failed_path:
+                counter["missing_result"] += 1
+    if not counter:
+        return ["(none)"]
+    return [f"{name}: {count}" for name, count in counter.most_common(10)]
+
+
+def environment_signal_stats(path: Path) -> list[str]:
+    try:
+        summary = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return ["(none)"]
+    counter = summary.get("monitor_environment_events_by_type") or {}
+    if not counter:
+        return ["(none)"]
+    return [
+        f"{name}: {count}"
+        for name, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:10]
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render Harbor monitor statistics")
+    parser.add_argument(
+        "command",
+        choices=("rewards", "success", "exceptions", "environment-signals"),
+    )
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args()
+    if args.command == "rewards":
+        lines = reward_stats(args.paths[0])
+    elif args.command == "success":
+        lines = success_stats(args.paths[0], args.paths[1])
+    elif args.command == "exceptions":
+        lines = exception_stats(args.paths[0], args.paths[1])
+    else:
+        lines = environment_signal_stats(args.paths[0])
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/utils/common/Harbor/harbor_shell_utils.py
+++ b/Agents/utils/common/Harbor/harbor_shell_utils.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def online_event(
+    phase: str,
+    component: str,
+    event: str,
+    severity: str,
+    fatal: bool,
+    message: str,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    values = os.environ if environ is None else environ
+    task_index = values.get("HARBOR_TASK_INDEX", "")
+    payload = {
+        "schema": 1,
+        "task_id": int(task_index) if task_index.isdigit() else None,
+        "task_name": values.get("HARBOR_TASK_ID", ""),
+        "phase": phase,
+        "component": component,
+        "event": event,
+        "severity": severity,
+        "fatal": fatal,
+        "scope": "task",
+        "message": message,
+    }
+    return "[ONLINE_ENV] " + json.dumps(payload, separators=(",", ":"))
+
+
+def normalize_json(raw: str) -> str:
+    return json.dumps(json.loads(raw), separators=(",", ":"))
+
+
+def json_string_field(raw: str, field: str) -> str:
+    value = json.loads(raw).get(field, "")
+    return value if isinstance(value, str) else ""
+
+
+def url_hostname(value: str) -> str:
+    return urlparse(value).hostname or ""
+
+
+def readonly_mounts(
+    specifications: Sequence[tuple[Path, str, str]],
+) -> list[dict[str, object]]:
+    mounts: list[dict[str, object]] = []
+    for source, target, policy in specifications:
+        if policy == "exists" and not source.exists():
+            continue
+        if policy == "uv-bin" and not (
+            source.is_dir() and (source / "uv").exists() and (source / "uvx").exists()
+        ):
+            continue
+        if policy not in {"always", "exists", "uv-bin"}:
+            raise ValueError(f"unsupported mount policy: {policy}")
+        mounts.append(
+            {
+                "type": "bind",
+                "source": str(source),
+                "target": target,
+                "read_only": True,
+            }
+        )
+    return mounts
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Python helpers for Harbor shell entrypoints")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    event_parser = subparsers.add_parser("online-event")
+    event_parser.add_argument("phase")
+    event_parser.add_argument("component")
+    event_parser.add_argument("event")
+    event_parser.add_argument("severity")
+    event_parser.add_argument("fatal", choices=("true", "false"))
+    event_parser.add_argument("message")
+    normalize = subparsers.add_parser("normalize-json")
+    normalize.add_argument("raw")
+    field = subparsers.add_parser("json-string-field")
+    field.add_argument("raw")
+    field.add_argument("field")
+    hostname = subparsers.add_parser("url-hostname")
+    hostname.add_argument("url")
+    mounts = subparsers.add_parser("readonly-mounts")
+    mounts.add_argument("--mount", nargs=3, action="append", default=[])
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.command == "online-event":
+        print(
+            online_event(
+                args.phase,
+                args.component,
+                args.event,
+                args.severity,
+                args.fatal == "true",
+                args.message,
+            )
+        )
+    elif args.command == "normalize-json":
+        try:
+            print(normalize_json(args.raw))
+        except (json.JSONDecodeError, TypeError) as exc:
+            print(f"INVALID_JSON::{exc}", file=sys.stderr)
+            return 1
+    elif args.command == "json-string-field":
+        print(json_string_field(args.raw, args.field))
+    elif args.command == "url-hostname":
+        print(url_hostname(args.url))
+    else:
+        specifications = [
+            (Path(source), target, policy) for source, target, policy in args.mount
+        ]
+        print(json.dumps(readonly_mounts(specifications), ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -121,25 +121,8 @@ online_env_event() {
     printf '%s\n' '[ONLINE_ENV] {"schema":1,"task_id":null,"task_name":"","phase":"preflight","component":"host_prerequisite","event":"command_unavailable","severity":"critical","fatal":true,"scope":"task","message":"python3 is unavailable; structured event details could not be serialized"}'
     return 0
   fi
-  python3 - "$phase" "$component" "$event" "$severity" "$fatal" "$message" <<'PY'
-import json
-import os
-import sys
-
-phase, component, event, severity, fatal, message = sys.argv[1:]
-print("[ONLINE_ENV] " + json.dumps({
-    "schema": 1,
-    "task_id": int(os.environ["HARBOR_TASK_INDEX"]) if os.environ.get("HARBOR_TASK_INDEX", "").isdigit() else None,
-    "task_name": os.environ.get("HARBOR_TASK_ID", ""),
-    "phase": phase,
-    "component": component,
-    "event": event,
-    "severity": severity,
-    "fatal": fatal == "true",
-    "scope": "task",
-    "message": message,
-}, separators=(",", ":")))
-PY
+  python3 "$SCRIPT_DIR/harbor_shell_utils.py" online-event \
+    "$phase" "$component" "$event" "$severity" "$fatal" "$message"
 }
 
 # harbor_trace_to_opik_enabled comes from env.sh so the worker shares it.
@@ -710,19 +693,7 @@ docker_hub_preflight_check() {
 
 normalize_json_or_fail() {
   local raw="$1"
-  python3 - "$raw" <<'PY'
-import json
-import os
-import sys
-
-raw = sys.argv[1]
-try:
-    obj = json.loads(raw)
-except Exception as exc:
-    print(f"INVALID_JSON::{exc}", file=sys.stderr)
-    sys.exit(1)
-print(json.dumps(obj, separators=(",", ":")))
-PY
+  python3 "$SCRIPT_DIR/harbor_shell_utils.py" normalize-json "$raw"
 }
 
 apply_min_test_defaults() {
@@ -795,17 +766,9 @@ run_oracle_task() {
     && verifier_uv_bin_ready; then
     local verifier_mounts_json verifier_uv_path_prefix
     verifier_mounts_json="$(
-      python3 - "$VERIFIER_UV_BIN_DIR_SOURCE" "$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH" <<'PY'
-import json
-import sys
-
-print(json.dumps([{
-    "type": "bind",
-    "source": sys.argv[1],
-    "target": sys.argv[2],
-    "read_only": True,
-}]))
-PY
+      python3 "$SCRIPT_DIR/harbor_shell_utils.py" readonly-mounts \
+        --mount "$VERIFIER_UV_BIN_DIR_SOURCE" \
+        "$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH" always
     )"
     verifier_uv_path_prefix="/root/.local/bin:/home/oai/.local/bin:/home/agent/.local/bin:/home/ubuntu/.local/bin"
     if [[ -n "${HARBOR_VERIFIER_UV_HOME:-}" ]]; then
@@ -964,16 +927,8 @@ run_harbor() {
   if [[ -z "$HARBOR_ANTHROPIC_AUTH_TOKEN" ]]; then
     local inferred_api_key
     inferred_api_key="$(
-      python3 - "$normalized_llm_kwargs" <<'PY'
-import json
-import os
-import sys
-
-obj = json.loads(sys.argv[1])
-api_key = obj.get("api_key", "")
-if isinstance(api_key, str):
-    print(api_key)
-PY
+      python3 "$SCRIPT_DIR/harbor_shell_utils.py" json-string-field \
+        "$normalized_llm_kwargs" api_key
     )"
     if [[ -n "$inferred_api_key" ]]; then
       HARBOR_ANTHROPIC_AUTH_TOKEN="$inferred_api_key"
@@ -1075,22 +1030,11 @@ PY
 
   local opik_host wheel_host no_proxy_value
   opik_host="$(
-    python3 - "$OPIK_URL_OVERRIDE" <<'PY'
-from urllib.parse import urlparse
-import sys
-
-u = urlparse(sys.argv[1])
-print(u.hostname or "")
-PY
+    python3 "$SCRIPT_DIR/harbor_shell_utils.py" url-hostname "$OPIK_URL_OVERRIDE"
   )"
   wheel_host="$(
-    python3 - "${HARBOR_LOCAL_WHEEL_SERVER_URL:-}" <<'PY'
-from urllib.parse import urlparse
-import sys
-
-u = urlparse(sys.argv[1] if len(sys.argv) > 1 else "")
-print(u.hostname or "")
-PY
+    python3 "$SCRIPT_DIR/harbor_shell_utils.py" url-hostname \
+      "${HARBOR_LOCAL_WHEEL_SERVER_URL:-}"
   )"
   no_proxy_value="127.0.0.1,localhost,host.docker.internal"
   if [[ -n "$opik_host" ]]; then
@@ -1123,44 +1067,22 @@ PY
 
   local mounts_json="[]"
   if [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" || "$HARBOR_ENVIRONMENT_TYPE" == "opensandbox" ]]; then
+    local -a mount_args=()
+    if [[ "$hook_mount_enabled" == "1" ]]; then
+      mount_args+=( --mount "$HARBOR_CC_HOOK_SOURCE" "$HARBOR_CC_HOOK_MOUNT_PATH" always )
+    fi
+    if [[ -n "$HARBOR_CC_CLAUDE_TGZ_SOURCE" ]]; then
+      mount_args+=( --mount "$HARBOR_CC_CLAUDE_TGZ_SOURCE" "$HARBOR_CC_CLAUDE_TGZ_MOUNT_PATH" exists )
+    fi
+    if [[ -n "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" ]]; then
+      mount_args+=( --mount "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" "$HARBOR_CC_PY_WHEEL_DIR_MOUNT_PATH" exists )
+    fi
+    if [[ -n "$VERIFIER_UV_BIN_DIR_SOURCE" ]]; then
+      mount_args+=( --mount "$VERIFIER_UV_BIN_DIR_SOURCE" "$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH" uv-bin )
+    fi
     mounts_json="$(
-    python3 - "$hook_mount_enabled" "$HARBOR_CC_HOOK_SOURCE" "$HARBOR_CC_HOOK_MOUNT_PATH" "$HARBOR_CC_CLAUDE_TGZ_SOURCE" "$HARBOR_CC_CLAUDE_TGZ_MOUNT_PATH" "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" "$HARBOR_CC_PY_WHEEL_DIR_MOUNT_PATH" "$VERIFIER_UV_BIN_DIR_SOURCE" "$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH" <<'PY'
-import json
-import os
-import sys
-
-hook_enabled = sys.argv[1] == "1"
-src = sys.argv[2]
-dst = sys.argv[3]
-claude_src = sys.argv[4]
-claude_dst = sys.argv[5]
-wheel_src = sys.argv[6]
-wheel_dst = sys.argv[7]
-uv_src = sys.argv[8]
-uv_dst = sys.argv[9]
-mounts = []
-def bind_mount(src, dst):
-    return {"type": "bind", "source": src, "target": dst, "read_only": True}
-# Only the hook source follows the hook switch. The Claude package and
-# wheel/runtime caches serve the offline agent install and must stay
-# mounted with tracing disabled, for benchmark and rollout workers alike.
-# NOTE: no single quotes in this heredoc; bash 3.2 mis-parses them inside
-# command substitution.
-if hook_enabled:
-    mounts.append(bind_mount(src, dst))
-if claude_src and os.path.exists(claude_src):
-    mounts.append(bind_mount(claude_src, claude_dst))
-if wheel_src and os.path.exists(wheel_src):
-    mounts.append(bind_mount(wheel_src, wheel_dst))
-if (
-    uv_src
-    and os.path.isdir(uv_src)
-    and os.path.exists(os.path.join(uv_src, "uv"))
-    and os.path.exists(os.path.join(uv_src, "uvx"))
-):
-    mounts.append(bind_mount(uv_src, uv_dst))
-print(json.dumps(mounts, ensure_ascii=True))
-PY
+      python3 "$SCRIPT_DIR/harbor_shell_utils.py" readonly-mounts \
+        "${mount_args[@]}"
     )"
   elif [[ "$HARBOR_ENVIRONMENT_TYPE" == "e2b" ]]; then
     echo "[INFO] E2B environment does not support host bind mounts; skip hook, dependency, and verifier uv mounts"
@@ -1372,11 +1294,7 @@ run_opencode_task() {
 
   local opik_host no_proxy_value
   opik_host="$(
-    python3 - "$OPIK_URL_OVERRIDE" <<'PY'
-from urllib.parse import urlparse
-import sys
-print(urlparse(sys.argv[1]).hostname or "")
-PY
+    python3 "$SCRIPT_DIR/harbor_shell_utils.py" url-hostname "$OPIK_URL_OVERRIDE"
   )"
   no_proxy_value="127.0.0.1,localhost,host.docker.internal"
   if [[ -n "$opik_host" ]]; then
@@ -1466,38 +1384,16 @@ PY
 
     local mounts_json="[]"
     if [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" || "$HARBOR_ENVIRONMENT_TYPE" == "opensandbox" ]]; then
+      local -a mount_args=()
+      if [[ -n "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" ]]; then
+        mount_args+=( --mount "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" "$HARBOR_CC_PY_WHEEL_DIR_MOUNT_PATH" exists )
+      fi
+      if [[ -n "$VERIFIER_UV_BIN_DIR_SOURCE" ]]; then
+        mount_args+=( --mount "$VERIFIER_UV_BIN_DIR_SOURCE" "$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH" uv-bin )
+      fi
       mounts_json="$(
-      python3 - "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" "$HARBOR_CC_PY_WHEEL_DIR_MOUNT_PATH" "$VERIFIER_UV_BIN_DIR_SOURCE" "$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH" <<'PY'
-import json
-import os
-import sys
-
-src = sys.argv[1]
-dst = sys.argv[2]
-uv_src = sys.argv[3]
-uv_dst = sys.argv[4]
-mounts = []
-if src and os.path.exists(src):
-    mounts.append({
-        "type": "bind",
-        "source": src,
-        "target": dst,
-        "read_only": True,
-    })
-if (
-    uv_src
-    and os.path.isdir(uv_src)
-    and os.path.exists(os.path.join(uv_src, "uv"))
-    and os.path.exists(os.path.join(uv_src, "uvx"))
-):
-    mounts.append({
-        "type": "bind",
-        "source": uv_src,
-        "target": uv_dst,
-        "read_only": True,
-    })
-print(json.dumps(mounts, ensure_ascii=True))
-PY
+        python3 "$SCRIPT_DIR/harbor_shell_utils.py" readonly-mounts \
+          "${mount_args[@]}"
       )"
     fi
     if [[ "$mounts_json" != "[]" ]]; then

--- a/Agents/utils/common/Harbor/model-fusion/harboropik.sh
+++ b/Agents/utils/common/Harbor/model-fusion/harboropik.sh
@@ -49,12 +49,8 @@ args=("$@")
 # command already carries NO_PROXY for Opik and wheel hosts; retain that value
 # and add the model gateway host for this scoped integration.
 gateway_host="$(
-  python3 - "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}" <<'PY'
-from urllib.parse import urlparse
-import sys
-
-print(urlparse(sys.argv[1]).hostname or "")
-PY
+  python3 "$MODEL_FUSION_DIR/../harbor_shell_utils.py" url-hostname \
+    "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
 )"
 if [[ -n "$gateway_host" ]]; then
   found_upper=0

--- a/Agents/utils/common/Harbor/model-fusion/mimo-code/harboropik.sh
+++ b/Agents/utils/common/Harbor/model-fusion/mimo-code/harboropik.sh
@@ -38,12 +38,8 @@ fi
 args=("$@")
 
 gateway_host="$(
-  python3 - "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}" <<'PY'
-from urllib.parse import urlparse
-import sys
-
-print(urlparse(sys.argv[1]).hostname or "")
-PY
+  python3 "$MIMO_CODE_DIR/../../harbor_shell_utils.py" url-hostname \
+    "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
 )"
 if [[ -n "$gateway_host" ]]; then
   found_upper=0

--- a/Agents/utils/common/Harbor/model-fusion/openrouter/harboropik.sh
+++ b/Agents/utils/common/Harbor/model-fusion/openrouter/harboropik.sh
@@ -26,11 +26,8 @@ fi
 
 args=("$@")
 gateway_host="$(
-  python3 - "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}" <<'PY'
-from urllib.parse import urlparse
-import sys
-print(urlparse(sys.argv[1]).hostname or "")
-PY
+  python3 "$OPENROUTER_DIR/../../harbor_shell_utils.py" url-hostname \
+    "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
 )"
 if [[ -n "$gateway_host" ]]; then
   found_upper=0

--- a/Agents/utils/common/Harbor/monitor_harbor.sh
+++ b/Agents/utils/common/Harbor/monitor_harbor.sh
@@ -32,114 +32,22 @@ next_index() {
 }
 
 reward_stats() {
-  python3 - "$QUEUE_DIR/done.txt" <<'PY'
-import collections
-import sys
-
-path = sys.argv[1]
-counter = collections.Counter()
-total = 0
-try:
-    with open(path, encoding="utf-8") as handle:
-        for line in handle:
-            parts = line.rstrip("\n").split("\t")
-            if len(parts) < 3:
-                continue
-            reward = parts[2] if parts[2] else "none"
-            counter[reward] += 1
-            total += 1
-except FileNotFoundError:
-    pass
-
-if not total:
-    print("(none)")
-else:
-    for reward, count in sorted(counter.items(), key=lambda item: (item[0] != "1.0", item[0])):
-        print(f"reward={reward}: {count}")
-PY
+  python3 "$SCRIPT_DIR/harbor_monitor_utils.py" rewards "$QUEUE_DIR/done.txt"
 }
 
 success_stats() {
-  python3 - "$QUEUE_DIR/done.txt" "$QUEUE_DIR/failed.txt" <<'PY'
-import sys
-
-done_path, failed_path = sys.argv[1:3]
-done = 0
-success = 0
-try:
-    with open(done_path, encoding="utf-8") as handle:
-        for line in handle:
-            parts = line.rstrip("\n").split("\t")
-            if len(parts) < 3:
-                continue
-            done += 1
-            value = (parts[2] or "").strip().lower()
-            if value in {"1", "1.0", "true", "success", "resolved", "pass", "passed"}:
-                success += 1
-except FileNotFoundError:
-    pass
-
-failed = 0
-try:
-    with open(failed_path, encoding="utf-8") as handle:
-        failed = sum(1 for line in handle if line.strip())
-except FileNotFoundError:
-    pass
-
-finished = done + failed
-fail = finished - success
-rate = (success / finished * 100.0) if finished else 0.0
-print(f"success:      {success}")
-print(f"fail:         {fail}")
-print(f"success_rate: {rate:.2f}%")
-PY
+  python3 "$SCRIPT_DIR/harbor_monitor_utils.py" success \
+    "$QUEUE_DIR/done.txt" "$QUEUE_DIR/failed.txt"
 }
 
 exception_stats() {
-  python3 - "$QUEUE_DIR/done.txt" "$QUEUE_DIR/failed.txt" <<'PY'
-import collections
-import sys
-
-counter = collections.Counter()
-for path in sys.argv[1:]:
-    try:
-        with open(path, encoding="utf-8") as handle:
-            for line in handle:
-                parts = line.rstrip("\n").split("\t")
-                if len(parts) >= 4 and parts[3]:
-                    counter[parts[3]] += 1
-                elif path.endswith("failed.txt"):
-                    counter["missing_result"] += 1
-    except FileNotFoundError:
-        pass
-
-if not counter:
-    print("(none)")
-else:
-    for name, count in counter.most_common(10):
-        print(f"{name}: {count}")
-PY
+  python3 "$SCRIPT_DIR/harbor_monitor_utils.py" exceptions \
+    "$QUEUE_DIR/done.txt" "$QUEUE_DIR/failed.txt"
 }
 
 environment_signal_stats() {
-  python3 - "$HARBOR_ONLINE_ANALYSIS_DIR/environment-summary.json" <<'PY'
-import json
-import sys
-
-try:
-    with open(sys.argv[1], encoding="utf-8") as handle:
-        summary = json.load(handle)
-except (FileNotFoundError, json.JSONDecodeError):
-    print("(none)")
-    raise SystemExit(0)
-
-counter = summary.get("monitor_environment_events_by_type") or {}
-if not counter:
-    print("(none)")
-else:
-    for name, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:10]:
-        print(f"{name}: {count}")
-PY
+  python3 "$SCRIPT_DIR/harbor_monitor_utils.py" environment-signals \
+    "$HARBOR_ONLINE_ANALYSIS_DIR/environment-summary.json"
 }
 
 SUMMARY_FILE="$OUTPUT_PATH/summary.txt"

--- a/Agents/utils/common/Harbor/tests/test_harbor_monitor_utils.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_monitor_utils.py
@@ -1,0 +1,39 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from Agents.utils.common.Harbor import harbor_monitor_utils
+
+
+class HarborMonitorUtilsTest(unittest.TestCase):
+    def test_queue_stats(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            done = root / "done.txt"
+            failed = root / "failed.txt"
+            done.write_text("1\ttask-a\t1.0\n2\ttask-b\t0.0\n", encoding="utf-8")
+            failed.write_text("3\ttask-c\t\tTimeoutError\n", encoding="utf-8")
+
+            self.assertEqual(harbor_monitor_utils.reward_stats(done), ["reward=1.0: 1", "reward=0.0: 1"])
+            self.assertEqual(
+                harbor_monitor_utils.success_stats(done, failed),
+                ["success:      1", "fail:         2", "success_rate: 33.33%"],
+            )
+            self.assertEqual(harbor_monitor_utils.exception_stats(done, failed), ["TimeoutError: 1"])
+
+    def test_environment_signal_stats(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "summary.json"
+            path.write_text(
+                json.dumps({"monitor_environment_events_by_type": {"network": 2, "auth": 3}}),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                harbor_monitor_utils.environment_signal_stats(path),
+                ["auth: 3", "network: 2"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_harbor_shell_utils.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_shell_utils.py
@@ -1,0 +1,61 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from Agents.utils.common.Harbor import harbor_shell_utils
+
+
+class HarborShellUtilsTest(unittest.TestCase):
+    def test_online_event_uses_task_environment(self):
+        rendered = harbor_shell_utils.online_event(
+            "preflight",
+            "docker_registry",
+            "connectivity_degraded",
+            "warning",
+            False,
+            "continuing",
+            {"HARBOR_TASK_INDEX": "7", "HARBOR_TASK_ID": "task-a"},
+        )
+
+        payload = json.loads(rendered.removeprefix("[ONLINE_ENV] "))
+        self.assertEqual(payload["task_id"], 7)
+        self.assertEqual(payload["task_name"], "task-a")
+        self.assertFalse(payload["fatal"])
+
+    def test_json_and_url_helpers(self):
+        self.assertEqual(harbor_shell_utils.normalize_json('{"b": 2, "a": 1}'), '{"b":2,"a":1}')
+        self.assertEqual(
+            harbor_shell_utils.json_string_field('{"api_key":"secret"}', "api_key"),
+            "secret",
+        )
+        self.assertEqual(
+            harbor_shell_utils.url_hostname("https://opik.example.invalid/api"),
+            "opik.example.invalid",
+        )
+
+    def test_readonly_mounts_include_only_ready_sources(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cache = root / "cache"
+            cache.mkdir()
+            (cache / "uv").touch()
+            (cache / "uvx").touch()
+            package = root / "package.tgz"
+            package.touch()
+
+            mounts = harbor_shell_utils.readonly_mounts(
+                [(package, "/opt/package.tgz", "exists"), (cache, "/opt/bin", "uv-bin")]
+            )
+
+            self.assertEqual(
+                mounts,
+                [
+                    {"type": "bind", "source": str(package), "target": "/opt/package.tgz", "read_only": True},
+                    {"type": "bind", "source": str(cache), "target": "/opt/bin", "read_only": True},
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor launch and monitoring scripts embed repeated Python for JSON handling, mount rendering, URL parsing, and run statistics.

## 2. Summary of the change

- Add `harbor_shell_utils.py` for launch-time JSON, URL, event, and mount operations.
- Add `harbor_monitor_utils.py` for reward, success, exception, and environment statistics.
- Replace embedded Python in Harbor and related model-fusion wrappers with helper commands.

## 3. Other details

Verification:
- Harbor shell and monitor helper unit tests
- `bash Agents/utils/common/Harbor/tests/test_monitor_summary.sh`
- Shell syntax, Ruff, and `git diff --check`