### PR TITLE
refactor: extract RL rollout shell helpers

### DIFF
--- a/Agents/utils/rl/monitor_rl_rollout.sh
+++ b/Agents/utils/rl/monitor_rl_rollout.sh
@@ -25,67 +25,8 @@ dataset_task_count() {
 }
 
 result_stats() {
-  python3 - "$RL_QUEUE_DIR/results" <<'PY'
-import json
-import sys
-from collections import Counter
-from pathlib import Path
-
-results_dir = Path(sys.argv[1])
-finished = gen_trace_success = task_success = 0
-exceptions: Counter[str] = Counter()
-rewards: Counter[str] = Counter()
-
-
-def is_task_success(reward: object) -> bool:
-    value = str(reward or "").strip().lower()
-    return value in {"1", "1.0", "true", "success", "resolved", "pass", "passed"}
-
-
-if results_dir.exists():
-    for path in sorted(results_dir.glob("*.json")):
-        try:
-            item = json.loads(path.read_text(errors="ignore"))
-        except json.JSONDecodeError:
-            continue
-        finished += 1
-        status = str(item.get("status") or "").lower()
-        ok = bool(item.get("ok"))
-        if ok:
-            gen_trace_success += 1
-        reward = item.get("reward")
-        if is_task_success(reward):
-            task_success += 1
-        rewards["none" if reward is None else str(reward)] += 1
-        exception = item.get("exception_info") or {}
-        if isinstance(exception, dict):
-            name = exception.get("exception_type") or ""
-        else:
-            name = str(exception or "")
-        if name:
-            exceptions[name] += 1
-
-gen_trace_fail = finished - gen_trace_success
-task_success_rate = (task_success / finished * 100.0) if finished else 0.0
-print(f"finished:     {finished}")
-print(f"gen_trace_success: {gen_trace_success}")
-print(f"gen_trace_fail:    {gen_trace_fail}")
-print()
-print("reward stats:")
-print(f"task_success_rate: {task_success_rate:.2f}%")
-if rewards:
-    for reward, count in sorted(rewards.items(), key=lambda item: (item[0] != "1.0", item[0])):
-        print(f"reward={reward}: {count}")
-else:
-    print("(none)")
-print()
-print("exception stats:")
-if exceptions:
-    for name, count in exceptions.most_common(10):
-        print(f"{name}: {count}")
-else:
-    print("(none)")
-PY
+  python3 "$RL_SCRIPT_DIR/rollout_worker_utils.py" result-stats \
+    "$RL_QUEUE_DIR/results"
 }
 
 active_workers() {
@@ -122,36 +63,8 @@ active_workers() {
 }
 
 recent_results() {
-  python3 - "$RL_QUEUE_DIR/results" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-results_dir = Path(sys.argv[1])
-items = []
-if results_dir.exists():
-    for path in sorted(results_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)[-8:]:
-        try:
-            item = json.loads(path.read_text(errors="ignore"))
-        except json.JSONDecodeError:
-            continue
-        display = item.get("display_name") or item.get("task_id") or path.stem
-        status = item.get("status") or ("completed" if item.get("ok") else "failed")
-        reward = item.get("reward")
-        exception = item.get("exception_info") or {}
-        if isinstance(exception, dict):
-            exc = exception.get("exception_type") or "none"
-        else:
-            exc = str(exception or "none")
-        items.append((display, status, reward, exc))
-
-if not items:
-    print("(none)")
-else:
-    for display, status, reward, exc in items:
-        reward_text = "none" if reward is None else reward
-        print(f"- {display} status={status} reward={reward_text} exception={exc}")
-PY
+  python3 "$RL_SCRIPT_DIR/rollout_worker_utils.py" recent-results \
+    "$RL_QUEUE_DIR/results"
 }
 
 while true; do

--- a/Agents/utils/rl/rollout_worker_utils.py
+++ b/Agents/utils/rl/rollout_worker_utils.py
@@ -8,10 +8,185 @@ import json
 import os
 import re
 import shutil
+from collections import Counter
 from pathlib import Path
 
 HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
 RESERVED_HEADERS = {"x-session-id", "proxy-x-session-id"}
+SUCCESS_VALUES = {"1", "1.0", "true", "success", "resolved", "pass", "passed"}
+
+
+def _format_json_value(value: object) -> str:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, separators=(",", ":"))
+    return str(value)
+
+
+def _json_path_value(payload: object, path: str) -> object:
+    value = payload
+    for part in path.split("."):
+        if part:
+            if not isinstance(value, dict):
+                return None
+            value = value.get(part)
+    return value
+
+
+def json_path(payload: object, path: str) -> str:
+    return _format_json_value(_json_path_value(payload, path))
+
+
+def first_json_path(payload: object, paths: list[str]) -> str:
+    for path in paths:
+        value = json_path(payload, path)
+        if value:
+            return value
+    return ""
+
+
+def build_llm_kwargs(values: list[str], headers_json: str) -> str:
+    names = ("temperature", "top_p", "top_k", "min_p", "timeout", "max_retries")
+    integer_names = {"top_k", "max_retries"}
+    payload: dict[str, object] = {}
+    if len(values) != len(names):
+        raise ValueError(f"expected {len(names)} LLM values, received {len(values)}")
+    for name, raw in zip(names, values):
+        raw = str(raw).strip()
+        if not raw:
+            continue
+        try:
+            payload[name] = int(raw) if name in integer_names else float(raw)
+        except ValueError:
+            payload[name] = raw
+    headers = json.loads(headers_json)
+    if headers:
+        payload["extra_headers"] = headers
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def build_result(
+    request_file: Path,
+    result_file: Path | None,
+    console_log: str,
+    reward: str,
+    exception_type: str,
+    exit_code: int,
+    result_out: Path,
+    status: str,
+) -> None:
+    request = json.loads(request_file.read_text(encoding="utf-8"))
+    result_data: object = {}
+    if result_file:
+        try:
+            result_data = json.loads(result_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            result_data = {}
+    agent_result = result_data.get("agent_result") if isinstance(result_data, dict) else None
+    verifier_result = result_data.get("verifier_result") if isinstance(result_data, dict) else None
+    exception_info = result_data.get("exception_info") if isinstance(result_data, dict) else None
+    if not isinstance(exception_info, dict) and exception_type:
+        exception_info = {"exception_type": exception_type}
+    payload = {
+        "ok": status == "completed" and not exception_type,
+        "task_id": request.get("task_id"),
+        "task_path": request.get("task_path"),
+        "ray_submission_id": request.get("ray_submission_id"),
+        "polar_task_id": request.get("polar_task_id"),
+        "display_name": request.get("display_name"),
+        "environment_type": request.get("environment_type"),
+        "trial_name": result_file.parent.name if result_file else "",
+        "trial_uri": str(result_file.parent) if result_file else "",
+        "reward": float(reward) if reward.strip() not in {"", "None"} else None,
+        "rollout_details": agent_result.get("rollout_details") if isinstance(agent_result, dict) else None,
+        "num_turns": (agent_result.get("metadata") or {}).get("n_episodes") if isinstance(agent_result, dict) else None,
+        "agent_result": agent_result,
+        "verifier_result": verifier_result,
+        "exception_info": exception_info,
+        "metadata": {
+            "request_id": request.get("request_id"),
+            "session_id": request.get("session_id"),
+            "ray_submission_id": request.get("ray_submission_id"),
+            "polar_task_id": request.get("polar_task_id"),
+            "display_name": request.get("display_name"),
+            "console_log": console_log,
+            "exit_code": exit_code,
+        },
+    }
+    temporary = result_out.with_name(f".{result_out.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    temporary.replace(result_out)
+
+
+def render_result_stats(results_dir: Path) -> str:
+    finished = trace_success = task_success = 0
+    exceptions: Counter[str] = Counter()
+    rewards: Counter[str] = Counter()
+    if results_dir.exists():
+        for path in sorted(results_dir.glob("*.json")):
+            try:
+                item = json.loads(path.read_text(errors="ignore"))
+            except json.JSONDecodeError:
+                continue
+            finished += 1
+            trace_success += bool(item.get("ok"))
+            reward = item.get("reward")
+            task_success += str(reward or "").strip().lower() in SUCCESS_VALUES
+            rewards["none" if reward is None else str(reward)] += 1
+            exception = item.get("exception_info") or {}
+            name = exception.get("exception_type") if isinstance(exception, dict) else str(exception)
+            if name:
+                exceptions[str(name)] += 1
+    lines = [
+        f"finished:     {finished}",
+        f"gen_trace_success: {trace_success}",
+        f"gen_trace_fail:    {finished - trace_success}",
+        "",
+        "reward stats:",
+        f"task_success_rate: {(task_success / finished * 100.0) if finished else 0.0:.2f}%",
+    ]
+    lines.extend(
+        [f"reward={reward}: {count}" for reward, count in sorted(rewards.items(), key=lambda item: (item[0] != "1.0", item[0]))]
+        or ["(none)"]
+    )
+    lines.extend(["", "exception stats:"])
+    lines.extend([f"{name}: {count}" for name, count in exceptions.most_common(10)] or ["(none)"])
+    return "\n".join(lines)
+
+
+def render_recent_results(results_dir: Path) -> str:
+    items: list[tuple[object, object, object, object]] = []
+    if results_dir.exists():
+        for path in sorted(results_dir.glob("*.json"), key=lambda item: item.stat().st_mtime)[-8:]:
+            try:
+                item = json.loads(path.read_text(errors="ignore"))
+            except json.JSONDecodeError:
+                continue
+            exception = item.get("exception_info") or {}
+            if isinstance(exception, dict):
+                exc = exception.get("exception_type") or "none"
+            else:
+                exc = str(exception or "none")
+            items.append(
+                (
+                    item.get("display_name") or item.get("task_id") or path.stem,
+                    item.get("status") or ("completed" if item.get("ok") else "failed"),
+                    "none" if item.get("reward") is None else item.get("reward"),
+                    exc,
+                )
+            )
+    if not items:
+        return "(none)"
+    return "\n".join(
+        f"- {display} status={status} reward={reward} exception={exc}"
+        for display, status, reward, exc in items
+    )
 
 
 def build_request_headers(raw: str, session_id: str = "") -> dict[str, str]:
@@ -94,9 +269,19 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "command",
-        choices=("prune-trials", "request-headers", "render-header-lines"),
+        choices=(
+            "prune-trials",
+            "request-headers",
+            "render-header-lines",
+            "json-get",
+            "json-get-first",
+            "build-result",
+            "build-llm-kwargs",
+            "result-stats",
+            "recent-results",
+        ),
     )
-    parser.add_argument("path", nargs="?")
+    parser.add_argument("arguments", nargs="*")
     parser.add_argument("--keep", type=int, default=20)
     args = parser.parse_args()
 
@@ -115,9 +300,45 @@ def main() -> int:
             )
         )
         return 0
-    if not args.path:
+    if args.command == "json-get":
+        payload = json.loads(Path(args.arguments[0]).read_text(encoding="utf-8"))
+        value = _json_path_value(payload, args.arguments[1])
+        print("" if value is None else value)
+        return 0
+    if args.command == "json-get-first":
+        payload = json.loads(Path(args.arguments[0]).read_text(encoding="utf-8"))
+        print(first_json_path(payload, args.arguments[1:]))
+        return 0
+    if args.command == "build-result":
+        result_file = Path(args.arguments[1]) if args.arguments[1] else None
+        build_result(
+            Path(args.arguments[0]),
+            result_file,
+            args.arguments[2],
+            args.arguments[3],
+            args.arguments[4],
+            int(args.arguments[5]),
+            Path(args.arguments[6]),
+            args.arguments[7],
+        )
+        return 0
+    if args.command == "build-llm-kwargs":
+        print(
+            build_llm_kwargs(
+                args.arguments,
+                os.environ.get("MODEL_REQUEST_HEADERS_JSON", "{}"),
+            )
+        )
+        return 0
+    if args.command == "result-stats":
+        print(render_result_stats(Path(args.arguments[0])))
+        return 0
+    if args.command == "recent-results":
+        print(render_recent_results(Path(args.arguments[0])))
+        return 0
+    if not args.arguments:
         parser.error("prune-trials requires path")
-    prune_trial_artifacts(Path(args.path), args.keep)
+    prune_trial_artifacts(Path(args.arguments[0]), args.keep)
     return 0
 
 

--- a/Agents/utils/rl/run_rl_rollout_worker.sh
+++ b/Agents/utils/rl/run_rl_rollout_worker.sh
@@ -39,119 +39,15 @@ rename_pane() {
 }
 
 json_get() {
-  python3 - "$1" "$2" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-value = data
-for part in sys.argv[2].split("."):
-    if not part:
-        continue
-    if not isinstance(value, dict):
-        value = ""
-        break
-    value = value.get(part, "")
-print("" if value is None else value)
-PY
+  python3 "$RL_SCRIPT_DIR/rollout_worker_utils.py" json-get "$1" "$2"
 }
 
 json_get_first() {
-  python3 - "$@" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-
-def get_path(obj, path):
-    value = obj
-    for part in path.split("."):
-        if not part:
-            continue
-        if not isinstance(value, dict):
-            return None
-        value = value.get(part)
-    return value
-
-def format_value(value):
-    if value is None or value == "":
-        return ""
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, separators=(",", ":"))
-    return str(value)
-
-for path in sys.argv[2:]:
-    formatted = format_value(get_path(data, path))
-    if formatted:
-        print(formatted)
-        break
-PY
+  python3 "$RL_SCRIPT_DIR/rollout_worker_utils.py" json-get-first "$@"
 }
 
 json_build_result() {
-  python3 - "$@" <<'PY'
-import json
-import os
-import sys
-from pathlib import Path
-
-(
-    request_file,
-    result_file,
-    console_log,
-    reward,
-    exception_type,
-    exit_code,
-    result_out,
-    status,
-) = sys.argv[1:9]
-request = json.loads(Path(request_file).read_text(encoding="utf-8"))
-result_data = {}
-if result_file:
-    try:
-        result_data = json.loads(Path(result_file).read_text(encoding="utf-8"))
-    except Exception:
-        result_data = {}
-agent_result = result_data.get("agent_result") if isinstance(result_data, dict) else None
-verifier_result = result_data.get("verifier_result") if isinstance(result_data, dict) else None
-exception_info = result_data.get("exception_info") if isinstance(result_data, dict) else None
-if not isinstance(exception_info, dict) and exception_type:
-    exception_info = {"exception_type": exception_type}
-payload = {
-    "ok": status == "completed" and not exception_type,
-    "task_id": request.get("task_id"),
-    "task_path": request.get("task_path"),
-    "ray_submission_id": request.get("ray_submission_id"),
-    "polar_task_id": request.get("polar_task_id"),
-    "display_name": request.get("display_name"),
-    "environment_type": request.get("environment_type"),
-    "trial_name": Path(result_file).parent.name if result_file else "",
-    "trial_uri": str(Path(result_file).parent) if result_file else "",
-    "reward": float(reward) if str(reward).strip() not in {"", "None"} else None,
-    "rollout_details": agent_result.get("rollout_details") if isinstance(agent_result, dict) else None,
-    "num_turns": (agent_result.get("metadata") or {}).get("n_episodes") if isinstance(agent_result, dict) else None,
-    "agent_result": agent_result,
-    "verifier_result": verifier_result,
-    "exception_info": exception_info,
-    "metadata": {
-        "request_id": request.get("request_id"),
-        "session_id": request.get("session_id"),
-        "ray_submission_id": request.get("ray_submission_id"),
-        "polar_task_id": request.get("polar_task_id"),
-        "display_name": request.get("display_name"),
-        "console_log": console_log,
-        "exit_code": int(exit_code),
-    },
-}
-result_path = Path(result_out)
-tmp_path = result_path.with_name(f".{result_path.name}.{os.getpid()}.tmp")
-tmp_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True), encoding="utf-8")
-tmp_path.replace(result_path)
-PY
+  python3 "$RL_SCRIPT_DIR/rollout_worker_utils.py" build-result "$@"
 }
 
 find_latest_trial_result() {
@@ -405,39 +301,13 @@ while true; do
     fi
     export HARBOR_LLM_KWARGS="$(
       MODEL_REQUEST_HEADERS_JSON="$request_headers_json" \
-        python3 - "${temperature:-${RL_TEMPERATURE:-}}" \
+        python3 "$RL_SCRIPT_DIR/rollout_worker_utils.py" build-llm-kwargs \
+        "${temperature:-${RL_TEMPERATURE:-}}" \
         "${top_p:-${RL_TOP_P:-}}" \
         "${top_k:-${RL_TOP_K:-}}" \
         "${min_p:-${RL_MIN_P:-}}" \
         "${llm_timeout:-${RL_LLM_TIMEOUT:-}}" \
-        "${llm_max_retries:-${RL_LLM_MAX_RETRIES:-}}" <<'PY'
-import json
-import os
-import sys
-
-temperature, top_p, top_k, min_p, timeout, max_retries = sys.argv[1:7]
-payload = {}
-
-def add_number(name, value, cast=float):
-    value = str(value).strip()
-    if value == "":
-        return
-    try:
-        payload[name] = cast(value)
-    except ValueError:
-        payload[name] = value
-
-add_number("temperature", temperature)
-add_number("top_p", top_p)
-add_number("top_k", top_k, int)
-add_number("min_p", min_p)
-add_number("timeout", timeout)
-add_number("max_retries", max_retries, int)
-headers = json.loads(os.environ["MODEL_REQUEST_HEADERS_JSON"])
-if headers:
-    payload["extra_headers"] = headers
-print(json.dumps(payload, separators=(",", ":")))
-PY
+        "${llm_max_retries:-${RL_LLM_MAX_RETRIES:-}}"
     )"
     export HARBOR_TASK_ID="$task_name"
     export HARBOR_INCLUDE_TASKS="$task_name"

--- a/Agents/utils/rl/tests/test_rollout_worker_utils.py
+++ b/Agents/utils/rl/tests/test_rollout_worker_utils.py
@@ -18,6 +18,62 @@ SPEC.loader.exec_module(MODULE)
 
 
 class RolloutWorkerUtilsTest(unittest.TestCase):
+    def test_json_path_helpers(self) -> None:
+        payload = {"task": {"id": "task-a"}, "enabled": False, "items": [1, 2]}
+        self.assertEqual(MODULE.json_path(payload, "task.id"), "task-a")
+        self.assertEqual(MODULE.first_json_path(payload, ["missing", "enabled", "items"]), "false")
+
+    def test_build_llm_kwargs_preserves_numeric_and_header_values(self) -> None:
+        rendered = MODULE.build_llm_kwargs(
+            ["0.5", "", "12", "0.1", "30", "2"],
+            '{"X-Route-Key":"deployment-a"}',
+        )
+
+        self.assertEqual(
+            json.loads(rendered),
+            {
+                "temperature": 0.5,
+                "top_k": 12,
+                "min_p": 0.1,
+                "timeout": 30.0,
+                "max_retries": 2,
+                "extra_headers": {"X-Route-Key": "deployment-a"},
+            },
+        )
+
+    def test_build_result_merges_harbor_result_atomically(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            directory = Path(root)
+            request = directory / "request.json"
+            result = directory / "result.json"
+            output = directory / "output.json"
+            request.write_text(
+                '{"request_id":"request-1","task_id":"task-a"}',
+                encoding="utf-8",
+            )
+            result.write_text(
+                '{"agent_result":{"metadata":{"n_episodes":3}},'
+                '"verifier_result":{"reward":1}}',
+                encoding="utf-8",
+            )
+
+            MODULE.build_result(
+                request,
+                result,
+                "/tmp/console.log",
+                "1.0",
+                "",
+                0,
+                output,
+                "completed",
+            )
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["reward"], 1.0)
+            self.assertEqual(payload["num_turns"], 3)
+            self.assertEqual(payload["metadata"]["request_id"], "request-1")
+
     def test_build_request_headers_merges_deployment_and_session_headers(self) -> None:
         headers = MODULE.build_request_headers(
             '{"version":1,"headers":{"set":{"X-Route-Key":"deployment-a"}}}',


### PR DESCRIPTION
## 1. Why the change?

The RL rollout worker and monitor scripts embed Python for JSON access, request construction, result assembly, and status rendering.

## 2. Summary of the change

- Extend `rollout_worker_utils.py` with focused CLI commands for those operations.
- Replace embedded Python in the worker and monitor scripts with helper invocations.
- Add behavior-level regression coverage for the extracted boundaries.

## 3. Other details

Verification:
- `python3 -m unittest Agents.utils.rl.tests.test_rollout_worker_utils -v`
- `bash Agents/utils/rl/tests/test_rollout_timeout_trace_gate.sh`
- Shell syntax, Ruff, and `git diff --check`