### PR TITLE
refactor: extract model fusion launcher helpers

### DIFF
--- a/Agents/utils/common/Harbor/model-fusion/mimo-code/run_tb21.sh
+++ b/Agents/utils/common/Harbor/model-fusion/mimo-code/run_tb21.sh
@@ -67,14 +67,8 @@ wheel_metadata="$(
     --version "$router_version"
 )"
 mapfile -t wheel_values < <(
-  python3 - "$wheel_metadata" <<'PY'
-import json
-import sys
-
-payload = json.loads(sys.argv[1])
-for key in ("cache_dir", "source_hash", "wheel", "wheel_sha256"):
-    print(payload[key])
-PY
+  python3 "$MIMO_CODE_DIR/../router_cli_utils.py" \
+    wheel-metadata-values "$wheel_metadata"
 )
 [[ "${#wheel_values[@]}" -eq 4 ]] || die "invalid Router wheel metadata"
 dist_dir="${wheel_values[0]}"
@@ -90,7 +84,7 @@ cleanup() {
   [[ -z "$task_file" || ! -f "$task_file" ]] || rm -f -- "$task_file"
 }
 trap cleanup EXIT INT TERM
-python3 -c 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])' \
+python3 "$MIMO_CODE_DIR/../router_cli_utils.py" extract-wheel \
   "$MIMO_ROUTER_WHEEL" "$runtime_dir"
 actual_version="$(PYTHONPATH="$runtime_dir" python3 -m sii_fusion_router.cli --version)"
 [[ "$actual_version" == "$router_version" ]] \
@@ -114,14 +108,8 @@ doctor_json="$(
       --config "$MIMO_ROUTER_CONFIG" \
       --claude-bin true
 )"
-python3 - "$doctor_json" <<'PY'
-import json
-import sys
-
-payload = json.loads(sys.argv[1])
-if payload.get("status") != "ok" or payload.get("pipeline") != "mimo_max":
-    raise SystemExit(f"Router doctor failed: {payload}")
-PY
+python3 "$MIMO_CODE_DIR/../router_cli_utils.py" validate-doctor \
+  "$doctor_json" mimo_max
 
 printf '[mimo-code] wheel=%s\n' "$MIMO_ROUTER_WHEEL"
 printf '[mimo-code] config=%s\n' "$MIMO_ROUTER_CONFIG"
@@ -183,17 +171,9 @@ if [[ "$MODE" == "smoke" ]]; then
 else
   TASK_SOURCE_FILE="${TASK_SOURCE_FILE:-$REPO_ROOT/Tasks/Terminal-bench-2/harbor_terminalbench21_tasks.txt}"
   [[ -s "$TASK_SOURCE_FILE" ]] || die "task list not found or empty: $TASK_SOURCE_FILE"
-  INCLUDE_TASKS="$(python3 - "$TASK_SOURCE_FILE" <<'PY'
-import sys
-from pathlib import Path
-
-tasks = [line.strip() for line in Path(sys.argv[1]).read_text().splitlines()]
-tasks = [task for task in tasks if task and not task.startswith("#")]
-if not tasks or any("," in task for task in tasks):
-    raise SystemExit("task list must contain nonempty task IDs without commas")
-print(",".join(tasks))
-PY
-)"
+  INCLUDE_TASKS="$(
+    python3 "$MIMO_CODE_DIR/../router_cli_utils.py" task-list-csv "$TASK_SOURCE_FILE"
+  )"
   export TASK_SOURCE_FILE INCLUDE_TASKS HARBOR_INCLUDE_TASKS="$INCLUDE_TASKS"
   export HARBOR_RUNS="${HARBOR_RUNS:-${N_ATTEMPTS:-1}}"
   export HARBOR_MAX_RETRIES="${HARBOR_MAX_RETRIES:-${MAX_RETRIES:-0}}"

--- a/Agents/utils/common/Harbor/model-fusion/openrouter/run_tb21.sh
+++ b/Agents/utils/common/Harbor/model-fusion/openrouter/run_tb21.sh
@@ -55,14 +55,8 @@ wheel_metadata="$(
     --version "$router_version"
 )"
 mapfile -t wheel_values < <(
-  python3 - "$wheel_metadata" <<'PY'
-import json
-import sys
-
-payload = json.loads(sys.argv[1])
-for key in ("cache_dir", "source_hash", "wheel", "wheel_sha256"):
-    print(payload[key])
-PY
+  python3 "$OPENROUTER_DIR/../router_cli_utils.py" \
+    wheel-metadata-values "$wheel_metadata"
 )
 [[ "${#wheel_values[@]}" -eq 4 ]] || die "invalid Router wheel metadata"
 dist_dir="${wheel_values[0]}"
@@ -78,7 +72,7 @@ cleanup() {
   [[ -z "$task_file" || ! -f "$task_file" ]] || rm -f -- "$task_file"
 }
 trap cleanup EXIT INT TERM
-python3 -c 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])' \
+python3 "$OPENROUTER_DIR/../router_cli_utils.py" extract-wheel \
   "$OPENROUTER_WHEEL" "$runtime_dir"
 actual_version="$(PYTHONPATH="$runtime_dir" python3 -m sii_fusion_router.cli --version)"
 [[ "$actual_version" == "$router_version" ]] || die "wheel/source version mismatch"
@@ -98,12 +92,8 @@ doctor_json="$(
     PYTHONPATH="$runtime_dir" python3 -m sii_fusion_router.cli doctor \
       --pipeline openrouter_fusion --config "$OPENROUTER_CONFIG" --claude-bin true
 )"
-python3 - "$doctor_json" <<'PY'
-import json, sys
-d = json.loads(sys.argv[1])
-if d.get("status") != "ok" or d.get("pipeline") != "openrouter_fusion":
-    raise SystemExit(f"Router doctor failed: {d}")
-PY
+python3 "$OPENROUTER_DIR/../router_cli_utils.py" validate-doctor \
+  "$doctor_json" openrouter_fusion
 
 printf '[openrouter] wheel=%s\n' "$OPENROUTER_WHEEL"
 printf '[openrouter] config=%s\n' "$OPENROUTER_CONFIG"
@@ -159,17 +149,9 @@ if [[ "$MODE" == "smoke" ]]; then
 else
   TASK_SOURCE_FILE="${TASK_SOURCE_FILE:-$REPO_ROOT/Tasks/Terminal-bench-2/harbor_terminalbench21_tasks.txt}"
   [[ -s "$TASK_SOURCE_FILE" ]] || die "task list not found or empty: $TASK_SOURCE_FILE"
-  INCLUDE_TASKS="$(python3 - "$TASK_SOURCE_FILE" <<'PY'
-import sys
-from pathlib import Path
-
-tasks = [line.strip() for line in Path(sys.argv[1]).read_text().splitlines()]
-tasks = [task for task in tasks if task and not task.startswith("#")]
-if not tasks or any("," in task for task in tasks):
-    raise SystemExit("task list must contain nonempty task IDs without commas")
-print(",".join(tasks))
-PY
-)"
+  INCLUDE_TASKS="$(
+    python3 "$OPENROUTER_DIR/../router_cli_utils.py" task-list-csv "$TASK_SOURCE_FILE"
+  )"
   export TASK_SOURCE_FILE INCLUDE_TASKS HARBOR_INCLUDE_TASKS="$INCLUDE_TASKS"
   export HARBOR_RUNS="${HARBOR_RUNS:-${N_ATTEMPTS:-1}}"
   export HARBOR_MAX_RETRIES="${HARBOR_MAX_RETRIES:-${MAX_RETRIES:-0}}"

--- a/Agents/utils/common/Harbor/model-fusion/router_cli_utils.py
+++ b/Agents/utils/common/Harbor/model-fusion/router_cli_utils.py
@@ -11,8 +11,35 @@ import stat
 import subprocess
 import sys
 import tempfile
+import zipfile
 from pathlib import Path
 from typing import Protocol
+
+WHEEL_METADATA_KEYS = ("cache_dir", "source_hash", "wheel", "wheel_sha256")
+
+
+def wheel_metadata_values(raw: str) -> list[str]:
+    payload = json.loads(raw)
+    return [str(payload[key]) for key in WHEEL_METADATA_KEYS]
+
+
+def extract_wheel(wheel: Path, destination: Path) -> None:
+    with zipfile.ZipFile(wheel) as archive:
+        archive.extractall(destination)
+
+
+def validate_doctor(raw: str, pipeline: str) -> None:
+    payload = json.loads(raw)
+    if payload.get("status") != "ok" or payload.get("pipeline") != pipeline:
+        raise RuntimeError(f"Router doctor failed: {payload}")
+
+
+def task_list_csv(path: Path) -> str:
+    tasks = [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    tasks = [task for task in tasks if task and not task.startswith("#")]
+    if not tasks or any("," in task for task in tasks):
+        raise ValueError("task list must contain nonempty task IDs without commas")
+    return ",".join(tasks)
 
 
 class _Digest(Protocol):
@@ -275,17 +302,35 @@ def main() -> int:
         "--pipeline", required=True, choices=("mimo_max", "openrouter_fusion")
     )
     config_parser.add_argument("--max-fusions", required=True, type=int)
+    metadata_parser = subparsers.add_parser("wheel-metadata-values")
+    metadata_parser.add_argument("metadata")
+    extract_parser = subparsers.add_parser("extract-wheel")
+    extract_parser.add_argument("wheel", type=Path)
+    extract_parser.add_argument("destination", type=Path)
+    doctor_parser = subparsers.add_parser("validate-doctor")
+    doctor_parser.add_argument("payload")
+    doctor_parser.add_argument("pipeline")
+    tasks_parser = subparsers.add_parser("task-list-csv")
+    tasks_parser.add_argument("path", type=Path)
     args = parser.parse_args()
     if args.command == "source-fingerprint":
         print(source_fingerprint(args.repo))
     elif args.command == "build-wheel":
         print(json.dumps(build_wheel(args.repo, args.cache_root, args.version)))
-    else:
+    elif args.command == "derive-config":
         print(
             derive_config(
                 args.source, args.output_dir, args.pipeline, args.max_fusions
             )
         )
+    elif args.command == "wheel-metadata-values":
+        print("\n".join(wheel_metadata_values(args.metadata)))
+    elif args.command == "extract-wheel":
+        extract_wheel(args.wheel, args.destination)
+    elif args.command == "validate-doctor":
+        validate_doctor(args.payload, args.pipeline)
+    else:
+        print(task_list_csv(args.path))
     return 0
 
 

--- a/Agents/utils/common/Harbor/tests/test_router_cli_utils.py
+++ b/Agents/utils/common/Harbor/tests/test_router_cli_utils.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import tempfile
 import unittest
+import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
@@ -22,6 +23,29 @@ spec.loader.exec_module(utils)
 
 
 class RouterSourceFingerprintTest(unittest.TestCase):
+    def test_shell_boundary_helpers(self) -> None:
+        metadata = '{"cache_dir":"/cache","source_hash":"abc","wheel":"/cache/router.whl","wheel_sha256":"def"}'
+        self.assertEqual(
+            utils.wheel_metadata_values(metadata),
+            ["/cache", "abc", "/cache/router.whl", "def"],
+        )
+        utils.validate_doctor('{"status":"ok","pipeline":"mimo_max"}', "mimo_max")
+        with self.assertRaisesRegex(RuntimeError, "Router doctor failed"):
+            utils.validate_doctor('{"status":"error"}', "mimo_max")
+
+    def test_extract_wheel_and_task_list(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            wheel = root / "router.whl"
+            with zipfile.ZipFile(wheel, "w") as archive:
+                archive.writestr("router/module.py", "value = 1\n")
+            target = root / "runtime"
+            utils.extract_wheel(wheel, target)
+            self.assertTrue((target / "router/module.py").is_file())
+            tasks = root / "tasks.txt"
+            tasks.write_text("# comment\ntask-a\ntask-b\n", encoding="utf-8")
+            self.assertEqual(utils.task_list_csv(tasks), "task-a,task-b")
+
     def test_fingerprint_tracks_dirty_and_untracked_source_content(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)


### PR DESCRIPTION
## 1. Why the change?

The Mimo and OpenRouter launchers embed Python for wheel metadata, extraction, doctor validation, and task-list conversion.

## 2. Summary of the change

- Extend `router_cli_utils.py` with focused commands for launcher operations.
- Replace the embedded Python blocks in both `run_tb21.sh` launchers.
- Add regression coverage for the new shell boundary helpers.

## 3. Other details

Verification:
- `PYTHONPATH=Agents/utils/common/Harbor python3 -m unittest Agents.utils.common.Harbor.tests.test_router_cli_utils -v`
- Shell syntax, Ruff, and `git diff --check`