### PR TITLE
feat(harbor): generate machine-readable fixer reports

### DIFF
--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/agent_invocation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/agent_invocation.py
@@ -124,8 +124,6 @@ class PiAgentInvoker:
             json.dumps(result.provenance, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         )
         if result.block_reason or result.output_json is None:
-            error = result.block_reason or "pi_final_json_missing"
-            if result.stderr_tail:
-                error = f"{error}: {result.stderr_tail}"
+            error = (result.block_reason or "pi_final_json_missing").split(":", 1)[0]
             raise RuntimeError(f"pi agent failed for {label} attempt {attempt}: {error}")
         return json.dumps(result.output_json, ensure_ascii=False)

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/__init__.py
@@ -1,6 +1,12 @@
 """Harbor Fixer report generation and summary runtime."""
 
 from .deterministic import render_fix_report, write_fix_report
+from .generation import generate_report_from_paths
 from .runtime import generate_report_summary
 
-__all__ = ["generate_report_summary", "render_fix_report", "write_fix_report"]
+__all__ = [
+    "generate_report_from_paths",
+    "generate_report_summary",
+    "render_fix_report",
+    "write_fix_report",
+]

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/generation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/generation.py
@@ -1,0 +1,549 @@
+"""Machine-readable Harbor Fixer report generation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..agent_invocation import AgentInvoker
+from ..analyzer_inputs import resolve_analyzer_paths
+from ..artifact_io import read_json, write_json_atomic
+from ..validation import (
+    TASK_COMPLETE_STATUSES,
+    ValidationError,
+    json_sha256,
+    report_rerun_facts,
+    task_key,
+    validate_env_infra_tasks,
+    validate_exec_result,
+    validate_fix_plan_set,
+    validate_fix_report,
+    validate_verification_result,
+)
+from ..verification.run_state import (
+    collect_task_results,
+    generate_monitor_snapshot,
+    read_monitor_snapshot,
+)
+from .runtime import generate_report_summary
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _prepare_report_output(output_dir: Path) -> None:
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "fix-report-latest.json").unlink(missing_ok=True)
+    except OSError as exc:
+        raise ValidationError(f"cannot prepare report output: {exc}") from None
+
+
+def _task_identity(task: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task_index": str(task.get("task_index") or ""),
+        "task_name": str(task.get("task_name") or ""),
+        "attempt_id": task.get("attempt_id"),
+    }
+
+
+def _explicit_status(env_task: dict[str, Any]) -> tuple[str, str]:
+    for source, value in (
+        ("env_infra_task.task_complete_status", env_task.get("task_complete_status")),
+        ("env_infra_task.complete_status", env_task.get("complete_status")),
+        ("env_infra_task.status", env_task.get("status")),
+    ):
+        if isinstance(value, str) and value in TASK_COMPLETE_STATUSES:
+            return value, source
+    return "", "unavailable"
+
+
+def _monitor_snapshot_summary(snapshot: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(snapshot, dict):
+        return {}
+    return {
+        "benchmark_status": str(snapshot.get("benchmark_status") or ""),
+        "status_reason": str(snapshot.get("status_reason") or ""),
+        "task_summary": snapshot.get("task_summary")
+        if isinstance(snapshot.get("task_summary"), dict)
+        else {},
+    }
+
+
+def _old_run_monitor_fields(record: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        "old_run_monitor_status": str(record.get("task_complete_status") or "")
+        if record
+        else "",
+        "old_run_monitor": record or {},
+    }
+
+
+def _old_run_status_fields(old_task: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "old_run_status": str(old_task.get("old_run_status") or ""),
+        "old_run_status_source": str(old_task.get("old_run_status_source") or ""),
+        "old_run_monitor_status": str(old_task.get("old_run_monitor_status") or ""),
+        "old_run_monitor": old_task.get("old_run_monitor")
+        if isinstance(old_task.get("old_run_monitor"), dict)
+        else {},
+    }
+
+
+def _analyzer_facts(env_task: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: str(env_task.get(key) or "")
+        for key in (
+            "final_class",
+            "failure_stage",
+            "scope",
+            "root_cause_code",
+            "root_cause_summary",
+        )
+    } | {"confidence": env_task.get("confidence")}
+
+
+def _summary_task_result(item: dict[str, Any]) -> dict[str, Any]:
+    new_run = item.get("new_run") if isinstance(item.get("new_run"), dict) else {}
+    return {
+        "task": item.get("task", {}),
+        "plan_id": item.get("plan_id", ""),
+        "sampled": item.get("sampled"),
+        "old_run_status": item.get("old_run_status", ""),
+        "old_run_monitor_status": item.get("old_run_monitor_status", ""),
+        "exec_status": item.get("exec_status", ""),
+        "exec_failure_reason": item.get("exec_failure_reason"),
+        "new_run_status": new_run.get("task_complete_status", ""),
+        "verification_status": item.get("verification_status", ""),
+    }
+
+
+def _summary_caveats(
+    verification_result: dict[str, Any],
+    *,
+    baseline_monitor_required: bool,
+    baseline_monitor_available: bool,
+) -> list[str]:
+    caveats: list[str] = []
+    if not baseline_monitor_available:
+        caveats.append(
+            "baseline monitor data unavailable; before/after comparison omitted"
+        )
+        if baseline_monitor_required:
+            caveats.append("baseline monitor data was required by policy")
+    if verification_result.get("status") in {"inconclusive", "exec_failed"}:
+        caveats.append(f"verification status is {verification_result.get('status')}")
+    if verification_result.get("verification_mode") == "smoke_test":
+        sampling = verification_result.get("sampling", {})
+        caveats.append(
+            "verification used smoke sampling: "
+            f"{sampling.get('sampled_task_count', 0)} sampled task(s), "
+            f"{sampling.get('unsampled_task_count', 0)} unsampled task(s)"
+        )
+    return caveats
+
+
+def _collect_baseline_monitor(
+    baseline_run_dir: Path | None,
+    output_dir: Path,
+    baseline_monitor_policy: str,
+    agent: str,
+) -> tuple[
+    dict[str, Any] | None, str, dict[str, dict[str, Any]], dict[str, Any] | None
+]:
+    if baseline_run_dir is None:
+        return None, "", {}, None
+    if baseline_monitor_policy == "off":
+        return None, "", {}, None
+    snapshot = None
+    output_path = ""
+    snapshot, output_path = read_monitor_snapshot(baseline_run_dir)
+    if snapshot is None:
+        snapshot, output_path = generate_monitor_snapshot(
+            baseline_run_dir,
+            output_dir / "baseline-monitor",
+            agent,
+        )
+    records, summary = collect_task_results(baseline_run_dir, agent)
+    return snapshot, output_path, records, summary
+
+
+def _build_old_run(
+    analyzer_paths: dict[str, Any],
+    output_dir: Path,
+    *,
+    baseline_run_dir: Path | None,
+    baseline_monitor_policy: str,
+    agent: str,
+) -> tuple[dict[str, Any], dict[tuple[str, str, str], dict[str, Any]], str]:
+    snapshot, monitor_output_path, monitor_records, monitor_summary = (
+        _collect_baseline_monitor(
+            baseline_run_dir,
+            output_dir,
+            baseline_monitor_policy,
+            agent,
+        )
+    )
+    if snapshot is not None:
+        handover = snapshot.get("analyzer_handover")
+        if not isinstance(handover, dict) or (
+            handover.get("run_id") != analyzer_paths["run_id"]
+            or handover.get("agent") != agent
+        ):
+            raise ValidationError("baseline monitor does not match analyzer run")
+    by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    monitor_task_keys: dict[tuple[str, str], set[tuple[str, str, str]]] = {}
+    handover_ids: list[str] = []
+    for publication in analyzer_paths["publications"]:
+        env_infra = read_json(Path(publication["env_infra_tasks_path"]))
+        validate_env_infra_tasks(env_infra)
+        if env_infra.get("handover_id") != publication["handover_id"]:
+            raise ValidationError("env/infra handover_id does not match analyzer manifest")
+        handover_ids.append(str(env_infra.get("handover_id") or ""))
+        for item in env_infra.get("tasks", []):
+            if not isinstance(item, dict) or not isinstance(item.get("task"), dict):
+                continue
+            task = item["task"]
+            task_index = str(task.get("task_index") or "")
+            task_name = str(task.get("task_name") or "")
+            key = task_key(task)
+            monitor_task_keys.setdefault((task_index, task_name), set()).add(key)
+            status, source = _explicit_status(item)
+            by_key[key] = {
+                "task": _task_identity(task),
+                "old_run_status": status,
+                "old_run_status_source": source,
+                **_old_run_monitor_fields(None),
+                "analyzer": _analyzer_facts(item),
+            }
+    for (task_index, task_name), keys in monitor_task_keys.items():
+        monitor_record = monitor_records.get(task_index)
+        if (
+            len(keys) == 1
+            and monitor_record
+            and monitor_record.get("task_name") == task_name
+        ):
+            by_key[next(iter(keys))].update(_old_run_monitor_fields(monitor_record))
+    old_tasks = list(by_key.values())
+
+    old_run = {
+        "run_id": str(analyzer_paths.get("run_id") or ""),
+        "handover_id": handover_ids[-1] if handover_ids else "",
+        "handover_ids": handover_ids,
+        "analyzer_summary": {
+            "task_count": len(old_tasks),
+            "publication_count": len(analyzer_paths["publications"]),
+        },
+        "env_infra_task_count": len(old_tasks),
+        "tasks": old_tasks,
+        "monitor_available": snapshot is not None and bool(monitor_records),
+        "monitor_summary": monitor_summary or {},
+        "monitor_snapshot": _monitor_snapshot_summary(snapshot),
+    }
+    return old_run, by_key, monitor_output_path
+
+
+def _with_old_status(
+    record: dict[str, Any],
+    old_task_by_key: dict[tuple[str, str, str], dict[str, Any]],
+) -> dict[str, Any]:
+    task = record.get("task") if isinstance(record.get("task"), dict) else {}
+    return {**record, **_old_run_status_fields(old_task_by_key.get(task_key(task), {}))}
+
+
+def _summary_input(
+    status: str,
+    old_run: dict[str, Any],
+    verification_result: dict[str, Any],
+    task_results: list[dict[str, Any]],
+    *,
+    baseline_monitor_required: bool,
+    baseline_monitor_available: bool,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "kind": "harbor_fixer_report_summary_input",
+        "status": status,
+        "agent": verification_result.get("agent", ""),
+        "execution": verification_result.get("execution", {}),
+        "reason_codes": verification_result.get("reason_codes", []),
+        "old_run": {
+            "run_id": old_run.get("run_id", ""),
+            "handover_id": old_run.get("handover_id", ""),
+            "analyzer_summary": old_run.get("analyzer_summary", {}),
+            "env_infra_task_count": old_run.get("env_infra_task_count", 0),
+            "monitor_available": old_run.get("monitor_available", False),
+            "monitor_summary": old_run.get("monitor_summary", {}),
+        },
+        "new_run": {
+            "summary": verification_result.get("new_run_summary", {}),
+            "rerun": report_rerun_facts(verification_result.get("rerun")),
+            "verification_mode": verification_result.get(
+                "verification_mode", "full_run"
+            ),
+            "sampling": verification_result.get("sampling", {}),
+        },
+        "plan_results": verification_result.get("plan_results", []),
+        "task_results": [_summary_task_result(item) for item in task_results],
+        "caveats": _summary_caveats(
+            verification_result,
+            baseline_monitor_required=baseline_monitor_required,
+            baseline_monitor_available=baseline_monitor_available,
+        ),
+    }
+
+
+def _report_source(
+    verification_result_path: Path,
+    analyzer_paths: dict[str, Any],
+    baseline_run_dir: Path | None,
+    baseline_monitor_output_path: str,
+) -> dict[str, Any]:
+    return {
+        "verification_result_path": str(verification_result_path),
+        "analyzer_output_path": str(analyzer_paths["analyzer_root"]),
+        "analyzer_manifest_path": str(analyzer_paths["manifest_path"]),
+        "env_infra_tasks_paths": [
+            str(item["env_infra_tasks_path"]) for item in analyzer_paths["publications"]
+        ],
+        "baseline_run_dir": str(baseline_run_dir)
+        if baseline_run_dir is not None
+        else "",
+        "baseline_monitor_output_path": baseline_monitor_output_path,
+    }
+
+
+def _source_artifact_path(
+    verification_result: dict[str, Any], field: str
+) -> Path:
+    source = verification_result.get("source")
+    value = source.get(field) if isinstance(source, dict) else None
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(
+            f"verification source.{field} must be a non-empty string"
+        )
+    path = Path(value).expanduser()
+    return path if path.is_absolute() else path.resolve()
+
+
+def _fix_plan_path(verification_result: dict[str, Any]) -> Path:
+    return _source_artifact_path(verification_result, "fix_plan_path")
+
+
+def _validate_analyzer_provenance(
+    verification_result: dict[str, Any],
+    analyzer_paths: dict[str, Any],
+) -> None:
+    fix_plan = read_json(_fix_plan_path(verification_result))
+    validate_fix_plan_set(fix_plan)
+    exec_result = read_json(
+        _source_artifact_path(verification_result, "exec_result_path")
+    )
+    validate_exec_result(exec_result)
+    if exec_result["source"].get("fix_plan_sha256") != json_sha256(fix_plan):
+        raise ValidationError("fix plan does not match executed plan")
+    verification_source = verification_result["source"]
+    if verification_source.get("exec_result_sha256") != json_sha256(exec_result):
+        raise ValidationError("exec result does not match verification result")
+    fix_plan_source = fix_plan["source"]
+    expected = {
+        "analyzer_root": str(analyzer_paths["analyzer_root"]),
+        "manifest_path": str(analyzer_paths["manifest_path"]),
+        "run_id": analyzer_paths["run_id"],
+        "publications": analyzer_paths["publications"],
+    }
+    if any(fix_plan_source.get(key) != value for key, value in expected.items()):
+        raise ValidationError("analyzer output does not match fix plan source")
+
+
+def _build_report_input(
+    verification_result_path: Path,
+    analyzer_output_path: Path,
+    output_dir: Path,
+    *,
+    baseline_run_dir: Path | None,
+    baseline_monitor_policy: str,
+) -> dict[str, Any]:
+    verification_result = read_json(verification_result_path)
+    validate_verification_result(verification_result)
+    analyzer_paths = resolve_analyzer_paths(analyzer_output_path)
+    _validate_analyzer_provenance(verification_result, analyzer_paths)
+    old_run, old_task_by_key, monitor_path = _build_old_run(
+        analyzer_paths,
+        output_dir,
+        baseline_run_dir=baseline_run_dir,
+        baseline_monitor_policy=baseline_monitor_policy,
+        agent=str(verification_result["agent"]),
+    )
+    task_results = [
+        _with_old_status(item, old_task_by_key)
+        for item in verification_result.get("task_results", [])
+        if isinstance(item, dict)
+    ]
+    unexpected_run_task_results = [
+        item
+        for item in verification_result.get("unexpected_run_task_results", [])
+        if isinstance(item, dict)
+    ]
+    safe_verification_result = {
+        **verification_result,
+        "rerun": report_rerun_facts(verification_result.get("rerun")),
+    }
+    payload = {
+        "schema_version": 1,
+        "kind": "harbor_fixer_report_input",
+        "source": _report_source(
+            verification_result_path,
+            analyzer_paths,
+            baseline_run_dir,
+            monitor_path,
+        )
+        | {
+            "verification_rerun_stdout_path": str(
+                verification_result["rerun"].get("stdout_path") or ""
+            ),
+            "verification_rerun_stderr_path": str(
+                verification_result["rerun"].get("stderr_path") or ""
+            ),
+        },
+        "baseline_monitor_policy": baseline_monitor_policy,
+        "verification_result": safe_verification_result,
+        "old_run": old_run,
+        "task_results": task_results,
+        "unexpected_run_task_results": unexpected_run_task_results,
+        "summary_input": _summary_input(
+            str(verification_result.get("status") or "inconclusive"),
+            old_run,
+            verification_result,
+            task_results,
+            baseline_monitor_required=baseline_monitor_policy == "on",
+            baseline_monitor_available=bool(old_run.get("monitor_available")),
+        ),
+    }
+    return payload
+
+
+def _apply_summary_caveats(
+    summary: dict[str, Any], report_input: dict[str, Any]
+) -> dict[str, Any]:
+    caveats = report_input["summary_input"].get("caveats") or []
+    if caveats:
+        summary = {
+            **summary,
+            "caveats": list(dict.fromkeys([*summary.get("caveats", []), *caveats])),
+        }
+    if report_input["baseline_monitor_policy"] == "on" and not report_input[
+        "old_run"
+    ].get("monitor_available"):
+        summary = {
+            **summary,
+            "status": "failed",
+            "generation_errors": [
+                *summary.get("generation_errors", []),
+                {
+                    "stage": "baseline_monitor",
+                    "error": "baseline monitor data required by policy but unavailable",
+                },
+            ],
+        }
+    return summary
+
+
+def _generate_report(
+    report_input: dict[str, Any], output_dir: Path, invoker: AgentInvoker
+) -> dict[str, Any]:
+    write_json_atomic(output_dir / "report-input.json", report_input)
+
+    verification_result = report_input["verification_result"]
+    fix_plan_path = _fix_plan_path(verification_result)
+    summary, raw_paths = generate_report_summary(
+        invoker, report_input["summary_input"], output_dir
+    )
+    target_environment_path = fix_plan_path.parent / "target-environment.json"
+    target_context_path = fix_plan_path.parent / "target-context.json"
+    result_payload = {
+        "summary": _apply_summary_caveats(summary, report_input),
+        "schema_version": 1,
+        "kind": "harbor_fixer_report",
+        "generated_at": _utc_now(),
+        "agent": verification_result["agent"],
+        "status": verification_result["status"],
+        "execution": verification_result["execution"],
+        "reason_codes": verification_result["reason_codes"],
+        "source": report_input["source"],
+        "old_run": report_input["old_run"],
+        "new_run": {
+            "summary": verification_result["new_run_summary"],
+            "rerun": report_rerun_facts(verification_result.get("rerun")),
+            "monitor_output_path": verification_result["source"].get(
+                "monitor_output_path", ""
+            ),
+            "verification_mode": verification_result.get(
+                "verification_mode", "full_run"
+            ),
+            "sampling": verification_result.get("sampling", {}),
+        },
+        "plan_results": verification_result["plan_results"],
+        "task_results": report_input["task_results"],
+        "unexpected_run_task_results": report_input.get(
+            "unexpected_run_task_results", []
+        ),
+        "artifacts": {
+            "fix_plan_path": verification_result["source"].get("fix_plan_path", ""),
+            "exec_result_path": verification_result["source"].get(
+                "exec_result_path", ""
+            ),
+            "verification_result_path": report_input["source"][
+                "verification_result_path"
+            ],
+            "report_input_path": str(output_dir / "report-input.json"),
+            "target_environment_path": (
+                str(target_environment_path)
+                if target_environment_path.is_file()
+                else ""
+            ),
+            "target_context_path": (
+                str(target_context_path) if target_context_path.is_file() else ""
+            ),
+            "human_report_path": "",
+            "verification_rerun_stdout_path": report_input["source"].get(
+                "verification_rerun_stdout_path", ""
+            ),
+            "verification_rerun_stderr_path": report_input["source"].get(
+                "verification_rerun_stderr_path", ""
+            ),
+            "raw_summary_output_paths": raw_paths,
+        },
+    }
+    validate_fix_report(result_payload, verification_result=verification_result)
+    write_json_atomic(output_dir / "fix-report-latest.json", result_payload)
+    return result_payload
+
+
+def generate_report_from_paths(
+    verification_result_path: Path,
+    analyzer_output_path: Path,
+    output_dir: Path,
+    invoker: AgentInvoker,
+    *,
+    baseline_run_dir: Path | None = None,
+    baseline_monitor_policy: str = "auto",
+) -> dict[str, Any]:
+    verification_result_path = verification_result_path.expanduser().resolve()
+    analyzer_output_path = analyzer_output_path.expanduser().resolve()
+    output_dir = output_dir.expanduser().resolve()
+    if baseline_run_dir is not None:
+        baseline_run_dir = baseline_run_dir.expanduser().resolve()
+    _prepare_report_output(output_dir)
+    if baseline_monitor_policy not in {"auto", "on", "off"}:
+        raise ValidationError("baseline_monitor_policy must be one of: auto, off, on")
+    report_input = _build_report_input(
+        verification_result_path,
+        analyzer_output_path,
+        output_dir,
+        baseline_run_dir=baseline_run_dir,
+        baseline_monitor_policy=baseline_monitor_policy,
+    )
+    return _generate_report(report_input, output_dir, invoker)

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/runtime.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/runtime.py
@@ -99,7 +99,7 @@ def generate_report_summary(
                 prompt, summary_input, attempt=attempt, label="report-main-agent"
             )
         except Exception as exc:  # noqa: BLE001 - provider retry boundary
-            error = str(exc)
+            error = f"{type(exc).__name__}: report summary invocation failed"
         else:
             raw_path = (
                 output_dir / "raw-report-main-agent-output" / f"attempt-{attempt}.txt"

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -65,6 +65,17 @@ INCONCLUSIVE_VERIFICATION_REASONS = {
     "rerun_failed",
 }
 REPORT_SUMMARY_STATUSES = {"success", "failed"}
+REPORT_RERUN_FIELDS = (
+    "exit_code",
+    "started_at",
+    "finished_at",
+    "duration_ms",
+    "skipped_reason",
+    "agent",
+    "monitor_policy",
+    "monitor_available",
+    "monitor_timed_out",
+)
 
 
 def json_sha256(value: Any) -> str:
@@ -102,6 +113,14 @@ def require_enum(value: Any, name: str, allowed: set[str]) -> str:
     if text not in allowed:
         raise ValidationError(f"{name} must be one of: {', '.join(sorted(allowed))}")
     return text
+
+
+def report_rerun_facts(rerun: Any) -> dict[str, Any]:
+    if not isinstance(rerun, dict):
+        return {}
+    return {
+        key: rerun[key] for key in REPORT_RERUN_FIELDS if key in rerun
+    }
 
 
 def _require_exact_fields(value: dict[str, Any], name: str, fields: set[str]) -> None:
@@ -979,3 +998,144 @@ def validate_report_summary(payload: dict[str, Any]) -> None:
     ):
         require_string(caveat, f"report summary caveats[{index}]")
     require_list(payload.get("generation_errors"), "report summary generation_errors")
+
+
+def _core_task_result(task_result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task": task_result.get("task"),
+        "plan_id": task_result.get("plan_id"),
+        "sampled": task_result.get("sampled"),
+        "smoke_task_index": task_result.get("smoke_task_index"),
+        "exec_status": task_result.get("exec_status"),
+        "exec_failure_reason": task_result.get("exec_failure_reason"),
+        "new_run": task_result.get("new_run"),
+        "verification_status": task_result.get("verification_status"),
+    }
+
+
+def _core_run_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task_index": record.get("task_index"),
+        "task_name": record.get("task_name"),
+        "task_complete_status": record.get("task_complete_status"),
+        "task_result_signals": record.get("task_result_signals"),
+        "evidence": record.get("evidence"),
+        "result_path": record.get("result_path"),
+    }
+
+
+def _require_equal(actual: Any, expected: Any, name: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{name} must match verification result")
+
+
+def _validate_report_matches_verification(
+    payload: dict[str, Any], verification_result: dict[str, Any]
+) -> None:
+    validate_verification_result(verification_result)
+    _require_equal(payload.get("agent"), verification_result.get("agent"), "agent")
+    _require_equal(payload.get("status"), verification_result.get("status"), "status")
+    _require_equal(
+        payload.get("execution"), verification_result.get("execution"), "execution"
+    )
+    _require_equal(
+        payload.get("reason_codes"),
+        verification_result.get("reason_codes"),
+        "reason_codes",
+    )
+    new_run = require_dict(payload.get("new_run"), "new_run")
+    _require_equal(
+        new_run.get("summary"),
+        verification_result.get("new_run_summary"),
+        "new_run.summary",
+    )
+    _require_equal(
+        new_run.get("rerun"),
+        report_rerun_facts(verification_result.get("rerun")),
+        "new_run.rerun",
+    )
+    _require_equal(
+        new_run.get("verification_mode"),
+        verification_result.get("verification_mode"),
+        "new_run.verification_mode",
+    )
+    if "sampling" in verification_result:
+        _require_equal(
+            new_run.get("sampling"),
+            verification_result.get("sampling"),
+            "new_run.sampling",
+        )
+    _require_equal(
+        payload.get("plan_results"),
+        verification_result.get("plan_results"),
+        "plan_results",
+    )
+    _require_equal(
+        [
+            _core_task_result(require_dict(item, "task_result"))
+            for item in require_list(payload.get("task_results"), "task_results")
+        ],
+        [
+            _core_task_result(require_dict(item, "verification_task_result"))
+            for item in require_list(
+                verification_result.get("task_results"), "verification task_results"
+            )
+        ],
+        "task_results",
+    )
+    _require_equal(
+        [
+            _core_run_record(require_dict(item, "unexpected_result"))
+            for item in require_list(
+                payload.get("unexpected_run_task_results", []),
+                "unexpected_run_task_results",
+            )
+        ],
+        [
+            _core_run_record(require_dict(item, "verification_unexpected_result"))
+            for item in require_list(
+                verification_result.get("unexpected_run_task_results", []),
+                "verification unexpected_run_task_results",
+            )
+        ],
+        "unexpected_run_task_results",
+    )
+
+
+def validate_fix_report(
+    payload: dict[str, Any], verification_result: dict[str, Any] | None = None
+) -> None:
+    _check_kind(payload, version=1, kind="harbor_fixer_report", name="fix report")
+    validate_report_summary(require_dict(payload.get("summary"), "summary"))
+    for key in ("source", "old_run", "new_run", "execution", "artifacts"):
+        require_dict(payload.get(key), key)
+    for key in (
+        "reason_codes",
+        "plan_results",
+        "task_results",
+        "unexpected_run_task_results",
+    ):
+        require_list(payload.get(key), key)
+    new_run = payload["new_run"]
+    validate_verification_result(
+        {
+            "schema_version": 2,
+            "kind": "harbor_fixer_verification_result",
+            "agent": payload.get("agent"),
+            "verification_mode": new_run.get("verification_mode"),
+            "source": {},
+            "execution": payload["execution"],
+            "status": payload.get("status"),
+            "reason_codes": payload["reason_codes"],
+            "rerun": new_run.get("rerun"),
+            "sampling": new_run.get("sampling"),
+            "new_run_summary": new_run.get("summary"),
+            "plan_results": payload["plan_results"],
+            "task_results": payload["task_results"],
+            "unexpected_run_task_results": payload[
+                "unexpected_run_task_results"
+            ],
+        }
+    )
+    if verification_result is not None:
+        _validate_report_matches_verification(payload, verification_result)

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/workflow.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/workflow.py
@@ -12,6 +12,7 @@ from ..validation import (
     HARBOR_AGENTS,
     TASK_VERIFICATION_STATUSES,
     ValidationError,
+    json_sha256,
     task_key,
     validate_fix_plan_set,
     validate_verification_input,
@@ -60,6 +61,9 @@ def build_verification_input(
     dataset_path: str = "",
     model: str = "",
 ) -> dict[str, Any]:
+    fix_plan_path = fix_plan_path.expanduser().resolve()
+    exec_result_path = exec_result_path.expanduser().resolve()
+    verification_run_dir = verification_run_dir.expanduser().resolve()
     fix_plan = read_json(fix_plan_path)
     exec_result = read_json(exec_result_path)
     validate_fix_plan_set(fix_plan)
@@ -289,6 +293,7 @@ def run_verification(
         "source": {
             "fix_plan_path": verification_input["fix_plan_path"],
             "exec_result_path": verification_input["exec_result_path"],
+            "exec_result_sha256": json_sha256(exec_result),
             "verification_run_dir": verification_input["verification_run_dir"],
             "analyzer_monitor_path": str(fix_plan["source"].get("monitor_path") or ""),
             "monitor_output_path": monitor_path,

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
@@ -15,13 +15,26 @@ for path in (TEST_DIR, SCRIPT_DIR):
     if str(path) not in sys.path:
         sys.path.insert(0, str(path))
 
-from fixer_test_support import FixerTestCase, make_exec_result, make_fix_plan
+from fixer_test_support import (
+    FixerTestCase,
+    make_exec_result,
+    make_fix_plan,
+    write_analyzer_fixture,
+    write_json,
+)
+from harbor_fixer.analyzer_inputs import resolve_analyzer_paths
 from harbor_fixer.report import (
+    generate_report_from_paths,
     generate_report_summary,
     render_fix_report,
     write_fix_report,
 )
-from harbor_fixer.validation import ValidationError, validate_report_summary
+from harbor_fixer.validation import (
+    ValidationError,
+    validate_fix_report,
+    validate_report_summary,
+)
+from harbor_fixer.verifier import run_verification_from_paths
 
 
 def _verification_result() -> dict:
@@ -62,20 +75,56 @@ def _verification_result() -> dict:
 class _SequenceInvoker:
     def __init__(self, outputs: list[str]) -> None:
         self.outputs = outputs
+        self.payloads: list[dict] = []
         self.prompts: list[str] = []
 
-    def invoke(
-        self, prompt: str, payload: dict, *, attempt: int, label: str
-    ) -> str:
+    def invoke(self, prompt: str, payload: dict, *, attempt: int, label: str) -> str:
+        self.payloads.append(payload)
         self.prompts.append(prompt)
         return self.outputs[attempt - 1]
 
 
 class _FailingInvoker:
-    def invoke(
-        self, prompt: str, payload: dict, *, attempt: int, label: str
-    ) -> str:
-        raise TimeoutError("provider timed out")
+    def invoke(self, prompt: str, payload: dict, *, attempt: int, label: str) -> str:
+        raise TimeoutError("provider API_KEY=fake-secret timed out")
+
+
+def _write_generation_fixture(root: Path) -> tuple[Path, Path, Path]:
+    analyzer_dir = write_analyzer_fixture(root, count=2)
+    analyzer_paths = resolve_analyzer_paths(analyzer_dir)
+    output_dir = root / "fixer"
+    plan_path = root / "fix-plan-latest.json"
+    exec_path = root / "exec-result-latest.json"
+    plan = make_fix_plan()
+    plan["source"].update(
+        {
+            "agent": "claude-code",
+            "monitor_path": str(root / "monitor" / "monitor-latest.json"),
+            "analyzer_root": str(analyzer_paths["analyzer_root"]),
+            "manifest_path": str(analyzer_paths["manifest_path"]),
+            "run_id": analyzer_paths["run_id"],
+            "publications": analyzer_paths["publications"],
+        }
+    )
+    write_json(plan_path, plan)
+    write_json(exec_path, make_exec_result(fix_plan=plan))
+    run_dir = root / "verification-run"
+    queue_dir = run_dir / "queue" / "claude-code"
+    queue_dir.mkdir(parents=True)
+    (run_dir / "tasks.txt").write_text("task-1\n", encoding="utf-8")
+    (queue_dir / "done.txt").write_text(
+        "1\ttask-1\t1.0\t\t\n", encoding="utf-8"
+    )
+    (queue_dir / "failed.txt").write_text("", encoding="utf-8")
+    run_verification_from_paths(
+        Path(os.path.relpath(plan_path)),
+        Path(os.path.relpath(exec_path)),
+        run_dir,
+        output_dir,
+        agent="claude-code",
+        monitor_policy="off",
+    )
+    return analyzer_dir, output_dir, exec_path
 
 
 class HarborFixerReportTest(FixerTestCase):
@@ -146,9 +195,7 @@ class HarborFixerReportTest(FixerTestCase):
             "caveats": [],
         }
         with self.assertRaises(ValidationError):
-            validate_report_summary(
-                {**valid, "highlights": [{"task": "task-1"}]}
-            )
+            validate_report_summary({**valid, "highlights": [{"task": "task-1"}]})
         with self.assertRaises(ValidationError):
             validate_report_summary({**valid, "detail": {"task": "task-1"}})
         for invalid_text in ("", " \n\t "):
@@ -156,6 +203,8 @@ class HarborFixerReportTest(FixerTestCase):
                 ValidationError
             ):
                 validate_report_summary({**valid, "text": invalid_text})
+        with self.assertRaises(ValidationError):
+            validate_report_summary({**valid, "caveats": [{}]})
         with tempfile.TemporaryDirectory() as root, mock.patch.dict(
             os.environ, {"HARBOR_AGENT_RETRY_INITIAL_SECONDS": "0"}
         ):
@@ -188,4 +237,103 @@ class HarborFixerReportTest(FixerTestCase):
         self.assertIn("1 task(s) were not sampled", fallback["text"])
         self.assertIn("1 unsampled task(s) labeled exec_failed", fallback["text"])
         self.assertIn("Baseline monitor data was unavailable", fallback["text"])
+        self.assertNotIn("fake-secret", json.dumps(fallback))
         self.assertEqual(len(write_invoker.prompts), 1)
+
+    def test_generation_redacts_rerun_secrets(self) -> None:
+        analyzer_dir, output_dir, _ = _write_generation_fixture(self.root)
+        verification_path = output_dir / "verification-result-latest.json"
+        verification = json.loads(verification_path.read_text(encoding="utf-8"))
+        verification["rerun"].update(
+            {
+                "command": "runner --api-key=fake-secret",
+                "stdout_summary": "API_KEY=fake-secret",
+                "stderr_summary": "token=fake-secret",
+            }
+        )
+        write_json(verification_path, verification)
+        invoker = _SequenceInvoker(
+            [
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "kind": "harbor_fixer_report_summary",
+                        "status": "success",
+                        "text": "Fixture report.",
+                        "highlights": [],
+                        "caveats": [],
+                        "generation_errors": [],
+                    }
+                )
+            ]
+        )
+
+        with mock.patch(
+            "harbor_fixer.report.generation.resolve_analyzer_paths",
+            wraps=resolve_analyzer_paths,
+        ) as resolve:
+            result = generate_report_from_paths(
+                verification_path,
+                analyzer_dir,
+                output_dir,
+                invoker,
+                baseline_run_dir=self.root / "renamed-baseline",
+                baseline_monitor_policy="off",
+            )
+
+        validate_fix_report(result, verification_result=verification)
+        report_input_path = output_dir / "report-input.json"
+        report_input = report_input_path.read_text(encoding="utf-8")
+        self.assertNotIn("fake-secret", json.dumps(result))
+        self.assertNotIn("fake-secret", json.dumps(invoker.payloads))
+        self.assertNotIn("fake-secret", report_input)
+        self.assertEqual(resolve.call_count, 1)
+        self.assertTrue(Path(verification["source"]["fix_plan_path"]).is_absolute())
+        self.assertTrue(Path(verification["source"]["exec_result_path"]).is_absolute())
+        self.assertEqual(os.stat(report_input_path).st_mode & 0o777, 0o600)
+        self.assertEqual(
+            os.stat(output_dir / "fix-report-latest.json").st_mode & 0o777,
+            0o600,
+        )
+        invalid = {**result, "task_results": ["invalid"]}
+        with self.assertRaisesRegex(ValidationError, "task_results"):
+            validate_fix_report(invalid)
+
+    def test_generation_rejects_mismatched_runtime_sources(self) -> None:
+        analyzer_dir, output_dir, exec_path = _write_generation_fixture(self.root)
+        verification_path = output_dir / "verification-result-latest.json"
+        exec_result = json.loads(exec_path.read_text(encoding="utf-8"))
+        exec_result["plans"][0]["actions"][0]["later_execution"] = True
+        write_json(exec_path, exec_result)
+        with self.assertRaisesRegex(ValidationError, "verification result"):
+            generate_report_from_paths(
+                verification_path,
+                analyzer_dir,
+                output_dir,
+                _FailingInvoker(),
+                baseline_monitor_policy="off",
+            )
+
+        write_json(
+            exec_path,
+            make_exec_result(
+                fix_plan=json.loads(
+                    (self.root / "fix-plan-latest.json").read_text(encoding="utf-8")
+                )
+            ),
+        )
+        wrong_snapshot = {
+            "analyzer_handover": {"run_id": "other-run", "agent": "claude-code"}
+        }
+        with mock.patch(
+            "harbor_fixer.report.generation.read_monitor_snapshot",
+            return_value=(wrong_snapshot, "snapshot.json"),
+        ), self.assertRaisesRegex(ValidationError, "baseline monitor"):
+            generate_report_from_paths(
+                verification_path,
+                analyzer_dir,
+                output_dir,
+                _FailingInvoker(),
+                baseline_run_dir=self.root / "baseline",
+                baseline_monitor_policy="on",
+            )


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer has a report-summary runtime, but it does not yet publish a validated machine-readable report that connects the original Analyzer findings, Fixer execution, and smoke-verification results. Without that artifact, downstream consumers cannot reliably inspect before/after task outcomes, verification caveats, or report-generation failures.

## 2. Summary of the change

- Add report-input construction from Analyzer and verification artifacts, with optional baseline-monitor collection and per-task before/after facts.
- Bind reports to the executed fix plan and Analyzer publications through plan digests, source metadata, task identities, and handover validation.
- Send a bounded, credential-safe fact projection to the report summary agent and validate it against the underlying verification and baseline data.
- Publish `report-input.json`, raw summary-agent outputs, and an atomic `fix-report-latest.json` artifact.
- Extend report contracts and focused tests for provenance, monitor policy, smoke-sampling caveats, fallback summaries, and stale-output handling.

## 3. Other details

Validation performed:

- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_harbor_fixer*.py'` (70 tests)
- `uvx ruff@0.16.0 check --config .github/ruff.toml`

This PR produces the machine-readable JSON report only; human-readable report rendering remains outside this change.
