### PR TITLE
docs: align structure maps with Python helpers

### DIFF
--- a/Agents/AGENTS.md
+++ b/Agents/AGENTS.md
@@ -67,9 +67,12 @@ additionally stops a worker's current task when a matching
 | `env.sh` | Path resolution and runtime defaults (sources repo `config.env` / `config.local.env`) |
 | `gen_harbor_zellij_layout.sh` | Writes the zellij layout (monitor + worker panes) |
 | `run_harbor_worker.sh` | Worker loop for one pane: claims tasks, calls `harboropik.sh` |
-| `harboropik.sh` | Harbor CLI wrapper with Opik/tracing setup |
-| `monitor_harbor.sh` | Run monitor pane |
-| `prepare_local_deps.sh` | Local package/cache preparation |
+| `harboropik.sh` | Harbor CLI orchestration wrapper with Opik/tracing setup |
+| `harbor_shell_utils.py` | Structured event, JSON, URL, and mount helpers called by Harbor shell wrappers |
+| `monitor_harbor.sh` | Run monitor pane and delegate summary calculations |
+| `harbor_monitor_utils.py` | Reward, success, exception, and environment summary calculations |
+| `prepare_local_deps.sh` | Thin interpreter-selection wrapper for local dependency preparation |
+| `prepare_local_deps.py` | Local package downloads, runtime archives, caches, and manifest generation |
 
 Full variable table: [utils/common/Harbor/STRUCT.md](utils/common/Harbor/STRUCT.md).
 Agent integration internals: [Harbor-claude-code/STRUCT.md](Harbor-claude-code/STRUCT.md),

--- a/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
+++ b/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
@@ -30,7 +30,7 @@ graph TD
 ```
 
 The integration entry point is
-[`prepare_opensandbox_image_ref`](harboropik.sh#L256-L307). The main workflow
+[`prepare_opensandbox_image_ref`](harboropik.sh). The main workflow
 is implemented by [`prepare`](opensandbox_image_manager.py#L664-L780).
 
 The OCI export explicitly disables Buildx provenance attestations. The

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -12,15 +12,20 @@ Agents/utils/common/Harbor/
 ├── env.sh                      # Path resolution and runtime defaults
 ├── env.py                      # JSON and data/cache helpers invoked by env.sh
 ├── gen_harbor_zellij_layout.sh # zellij layout generator
-├── monitor_harbor.sh           # Run monitor pane
+├── monitor_harbor.sh           # Monitor pane orchestration
+├── harbor_monitor_utils.py     # Monitor summary calculations
 ├── run_harbor_worker.sh        # Worker loop for one zellij pane
 ├── run_harbor_registry.sh      # Registry runner with optional final-pane hold
-├── harboropik.sh               # Harbor CLI wrapper with Opik setup
-├── prepare_local_deps.sh       # Local package/cache preparation
+├── harboropik.sh               # Harbor CLI orchestration with Opik setup
+├── harbor_shell_utils.py       # Event, JSON, URL, and mount helpers
+├── prepare_local_deps.sh       # Thin Python launcher
+├── prepare_local_deps.py       # Package/cache preparation implementation
 ├── runner-requirements.txt     # Exact direct dependencies for the runner image
 ├── setup_runner_env.sh         # Explicit host setup / image validation
 ├── harbor_prepare_runner_cli.py # Startup validation for the configured CLI
 ├── harbor_worker_utils.py
+├── model-fusion/
+│   └── router_cli_utils.py     # Shared Router build/config/launcher helpers
 ├── OPENSANDBOX_IMAGE_MANAGER.md # OpenSandbox task image build/cache/publish flow
 ├── prebuild_opensandbox_dataset.sh # Batch prebuild/publish local dataset images
 └── scripts/
@@ -67,6 +72,23 @@ in the environment as `HARBOR_ANALYZER_*` variables.
 JSON-event validation, final JSON extraction, and provenance shared by Harbor
 Pi callers. Analyzer-specific tool access, path gating, prompts, artifact
 locations, and error compatibility remain in `harbor_analyzer/pi.py`.
+
+## Shell and Python Boundaries
+
+Shell entry points own environment composition, process lifecycle, and calls
+to external tools. Their Python helpers own structured parsing and data
+transformation:
+
+| Shell caller | Python helper | Delegated responsibility |
+| --- | --- | --- |
+| `prepare_local_deps.sh` | `prepare_local_deps.py` | Downloads, runtime archives, npm caches, and manifest generation |
+| `harboropik.sh` and model-fusion wrappers | `harbor_shell_utils.py` | Structured events, JSON normalization, URL parsing, and read-only mount JSON |
+| `monitor_harbor.sh` | `harbor_monitor_utils.py` | Reward, success, exception, and environment statistics |
+| `Agents/utils/rl/run_rl_rollout_server.sh`, `run_rl_rollout_worker.sh`, `monitor_rl_rollout.sh` | `Agents/utils/rl/rollout_worker_utils.py` | Request headers/JSON, LLM kwargs, result assembly, and monitor rendering |
+| Mimo/OpenRouter `run_tb21.sh` | `model-fusion/router_cli_utils.py` | Wheel metadata/extraction, doctor validation, and task-list conversion |
+
+The Python command surfaces are internal implementation boundaries; operators
+continue to use the shell entry points documented in the README files.
 
 ## Path Resolution
 
@@ -180,6 +202,7 @@ Agents/utils/rl/
 ├── gen_rl_rollout_zellij_layout.sh   # Per-submission zellij layout generator
 ├── monitor_rl_rollout.sh             # RL job monitor pane
 ├── run_rl_rollout_worker.sh          # Queue worker that reuses harboropik.sh
+├── rollout_worker_utils.py            # Request/result and monitor helpers
 └── rl_dataset_worklist.py            # Dataset-to-task-list helper
 ```
 
@@ -266,8 +289,14 @@ OpenCode:
 2. `gen_harbor_zellij_layout.sh` writes a zellij layout with monitor and worker panes.
 3. Each worker pane runs `run_harbor_worker.sh`.
 4. Workers claim tasks from the shared queue and call `harboropik.sh`.
-5. `harboropik.sh` prepares Opik/tracing settings and invokes Harbor with either Claude Code or OpenCode.
-6. When every task is done or failed, `monitor_harbor.sh` writes `$OUTPUT_PATH/summary.txt`, stops the online analyzer, and exits when `HARBOR_ZELLIJ_CLOSE_ON_COMPLETE=1` (the default). With `0`, the final monitor pane remains open for inspection.
+5. `harboropik.sh` composes the runtime and delegates structured event, JSON,
+   URL, and mount rendering to `harbor_shell_utils.py` before invoking Harbor
+   with either Claude Code or OpenCode.
+6. When every task is done or failed, `monitor_harbor.sh` uses
+   `harbor_monitor_utils.py` to render summary statistics, writes
+   `$OUTPUT_PATH/summary.txt`, stops the online analyzer, and exits when
+   `HARBOR_ZELLIJ_CLOSE_ON_COMPLETE=1` (the default). With `0`, the final
+   monitor pane remains open for inspection.
 
 Native registry runs use the single-pane layout; `run_harbor_registry.sh`
 wraps `harboropik.sh`, which writes the same summary path from Harbor's job
@@ -288,10 +317,12 @@ RL rollout flow:
 3. `ensure_rl_job_zellij.sh` creates a
    `harbor-rollout-<agent>-<dataset>-<ray_submission_id>` zellij session for
    that submission if one is not already running.
-4. `run_rl_rollout_worker.sh` claims queued requests and calls
+4. `run_rl_rollout_worker.sh` claims queued requests, uses
+   `rollout_worker_utils.py` for request parsing and LLM arguments, and calls
    `Agents/utils/common/Harbor/harboropik.sh`, preserving normal agent logs,
    local dependency cache behavior, Opik tracing, and timeout finalization.
-5. The worker writes the result JSON; the HTTP request returns that result.
+5. The worker uses `rollout_worker_utils.py` to assemble the result JSON; the
+   HTTP request returns that result.
 
 RL rollout sessions are not governed by `HARBOR_ZELLIJ_CLOSE_ON_COMPLETE`.
 Their monitor and worker panes are long-running because requests are queued

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -75,9 +75,9 @@ locations, and error compatibility remain in `harbor_analyzer/pi.py`.
 
 ## Shell and Python Boundaries
 
-Shell entry points own environment composition, process lifecycle, and calls
-to external tools. Their Python helpers own structured parsing and data
-transformation:
+Shell entry points own environment composition and top-level process
+lifecycle. Their Python helpers own delegated parsing and data workflows,
+including external commands required to complete them:
 
 | Shell caller | Python helper | Delegated responsibility |
 | --- | --- | --- |

--- a/Agents/utils/common/Harbor/model-fusion/README.md
+++ b/Agents/utils/common/Harbor/model-fusion/README.md
@@ -65,3 +65,8 @@ Harbor home, but it does not reuse or alter this mid-turn execution path.
 The `openrouter/` subdirectory contains the original `openrouter_fusion`
 pipeline using the same isolation rule. It is selected only through its own
 `run_tb21.sh` entry point and does not modify Mimo Max or mid-turn runs.
+
+The Mimo and OpenRouter launchers share `router_cli_utils.py` for Router source
+fingerprinting, wheel build/metadata/extraction, derived config publication,
+doctor validation, and task-list conversion. Their shell entry points still
+own environment selection and Harbor process orchestration.

--- a/STRUCT.md
+++ b/STRUCT.md
@@ -32,10 +32,11 @@ agent-fleet/
 
 `Tasks/` owns benchmark and task inputs. Harbor and OpenClaw runners read task lists from here instead of duplicating task files inside agent directories.
 
-Shell files remain the operator entry points and own process orchestration,
-environment setup, and external command execution. Focused Python modules own
-structured parsing, file updates, archive handling, and summary rendering;
-shell entry points invoke those modules rather than embedding Python programs.
+Shell files remain the operator entry points and own top-level workflow
+orchestration and environment setup. Focused Python modules own delegated
+workflows such as structured parsing, file updates, archive handling, summary
+rendering, and any commands those workflows require; shell entry points invoke
+those modules rather than embedding Python programs.
 
 ## Cross-Directory Calls
 

--- a/STRUCT.md
+++ b/STRUCT.md
@@ -10,7 +10,13 @@ agent-fleet/
 │   ├── Harbor-claude-code/    # Claude Code tracing/integration code
 │   ├── Harbor-opencode/       # OpenCode tracing/integration code
 │   └── utils/
-│       └── common/Harbor/     # Shared Harbor runner, zellij layout, workers
+│       ├── common/Harbor/     # Shared Harbor runner, zellij layout, workers
+│       └── rl/                # Remote rollout listener, workers, and helpers
+├── scripts/
+│   ├── setup.sh               # Host setup orchestration entry point
+│   ├── setup_config.py        # Setup config parsing and managed-file updates
+│   ├── prerequisites.sh       # Shared managed-tool discovery/bootstrap
+│   └── script_utils.py        # URL and checksum helpers for shell callers
 ├── Tasks/
 │   ├── Pinchbench/            # PinchBench runner for OpenClaw
 │   ├── clawBio/               # ClawBio runner for OpenClaw
@@ -25,6 +31,11 @@ agent-fleet/
 `Agents/` owns execution. Agent-specific code stays under its own directory, while shared Harbor orchestration lives under `Agents/utils/common/Harbor/`.
 
 `Tasks/` owns benchmark and task inputs. Harbor and OpenClaw runners read task lists from here instead of duplicating task files inside agent directories.
+
+Shell files remain the operator entry points and own process orchestration,
+environment setup, and external command execution. Focused Python modules own
+structured parsing, file updates, archive handling, and summary rendering;
+shell entry points invoke those modules rather than embedding Python programs.
 
 ## Cross-Directory Calls
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,11 +3,22 @@
 | Script | Purpose |
 | --- | --- |
 | `setup.sh` | One-shot control-plane bootstrap: installs Node, Pi, and the pinned host Harbor runner; writes config, installs Git hooks, and installs the Pi skills |
+| `prerequisites.sh` | Shared managed-tool discovery and bootstrap sourced by setup and launch scripts |
 | `install-git-hooks.sh` | Enable the repository's advisory Ruff pre-commit hook for an existing checkout |
 | `run_fleet.sh` | Routes tasksets to the existing Harbor or OpenClaw runner |
 | `fleet_spec.sh` | Internal dispatcher for validated single- and multi-run spec inputs |
 | `fleet_batch.sh` | Internal concurrent launcher for normalized multi-run inputs |
 | `dind-run.sh` | Start/reuse a Docker-in-Docker runner, bootstrap it, then invoke `run_fleet.sh` |
+
+Internal Python helpers keep structured data and file mutation out of the
+shell entry points:
+
+| Helper | Called by | Owns |
+| --- | --- | --- |
+| `setup_config.py` | `setup.sh` | Legacy config migration, Pi JSON merges, managed bashrc updates, and `config.local.env` updates |
+| `script_utils.py` | `dind-run.sh`, `prerequisites.sh` | URL hostname parsing and streaming SHA-256 verification |
+
+These helpers are implementation boundaries, not separate operator workflows.
 
 For the end-to-end quick start, see the [root README](../README.md#quick-start).
 

--- a/skills/harbor-benchmark-runner/SKILL.md
+++ b/skills/harbor-benchmark-runner/SKILL.md
@@ -81,6 +81,7 @@ orchestration ownership in `Agents/utils/common/Harbor/`.
 - For worker failures, inspect the worker console log and the corresponding
   Harbor job log before changing scripts.
 - For dependency-cache problems, inspect `prepare_local_deps.sh`,
+  `prepare_local_deps.py`,
   `LOCAL_WHEEL_DIR`, `LOCAL_WHEEL_PORT`, and
   `HARBOR_REMOTE_WHEEL_SERVER_URLS`.
 - For mounted Claude Code tgz problems, inspect `HARBOR_CC_CLAUDE_TGZ_SOURCE`,


### PR DESCRIPTION
## 1. Why the change?

The shell-to-Python refactors in #112–#117 changed implementation ownership, but the repository structure maps and operator guidance still described the shell wrappers as owning all of that logic.

## 2. Summary of the change

- Document the setup and shared script helper boundaries in the root structure map and scripts guide.
- Add the Harbor cache, runtime, monitor, RL, and model-fusion Python helpers to the relevant structure and agent maps.
- Clarify that shell files remain operator entry points while Python modules own structured parsing and transformation.
- Remove a stale line-specific `harboropik.sh` link and update dependency-cache debugging guidance.

## 3. Other details

Documentation-only change.

Verification:
- `python3 -m unittest tests.test_skills -v`
- Relative Markdown link target validation
- `git diff --check`