### PR TITLE
gitignore: exclude local agent review artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,13 @@ scripts/logs/
 
 # Local assistant artifacts
 .claude/
+.pi-subagents/
+
+# Local agent review and planning artifacts
+review-outputs/
+docs/superpowers/
+docs/CODE_REVIEW_*.md
+/*-review.md
 
 # Local analyzer validation artifacts
 .tmp-*/


### PR DESCRIPTION
## 1. Why the change?

Local coding-agent runs leave artifact trees in the working tree that show up as untracked noise in `git status`, so real changes are easy to miss and easy to stage by accident:

- `.pi-subagents/` — Pi subagent transcripts, per-run `*_meta.json`, and progress files (69 files in one review session)
- `review-outputs/` — agent review output directories, including stray editor artifacts such as `model_fusion.md-e`
- `docs/CODE_REVIEW_*.md` — generated code-review reports
- `docs/superpowers/` — superpowers planning docs
- root `*-review.md` — per-subsystem review files

None of these are build outputs already covered by the existing rules, and none belong in the repository.

## 2. Summary of the change

Adds five patterns to `.gitignore`, grouped alongside the existing `.claude/` entry:

```
# Local assistant artifacts
.claude/
.pi-subagents/

# Local agent review and planning artifacts
review-outputs/
docs/superpowers/
docs/CODE_REVIEW_*.md
/*-review.md
```

`docs/` is deliberately **not** ignored wholesale — it holds committed design specs, and a blanket rule would block future project documentation. Only the generated subpaths are excluded.

`/*-review.md` is root-anchored so a nested `Tasks/pinch-review.md` or `docs/code-review.md` stays committable.

Commit c446914 ("Remove superpowers planning docs") already removed these planning docs from tracking; this records that intent as an ignore rule instead of relying on manual cleanup.

## 3. Other details

**Test plan / Verification**

- `git ls-files | git check-ignore --stdin` → no output. No tracked file becomes ignored, so no existing file is silently shadowed.
- `git check-ignore -v` confirms each of the five patterns matches its intended path via the expected rule: `.pi-subagents/artifacts/…`, `scripts/review-outputs/tracing.md`, `Agents/review-outputs/b.md`, `docs/superpowers/plans/…`, `docs/CODE_REVIEW_REFACTOR_REDESIGN.md`, `harbor-review.md`, `skills-review.md`.
- Negative check — these remain committable: `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/design/foo.md`, `Tasks/pinch-review.md`, `Agents/harbor-review.md`, `.github/scripts/pi_review_prompt.md`, `README.md`.
- `python3 -m unittest discover -s tests` → 5 tests, OK.
- `python3 -m unittest discover -s .github/scripts/tests` → 184 tests, OK.
- `git ls-files -z '*.sh' | xargs -0 -n1 bash -n` → all 68 shell scripts pass, confirming the ignore change does not affect CI's tracked-file shell discovery.

Documentation-only change to `.gitignore`; no runtime or script behavior is affected.
