### PR TITLE
feat(harbor): materialize QZ templates in batches

### DIFF
--- a/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
+++ b/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
@@ -103,12 +103,34 @@ python qz_template_resolver.py materialize \
   --task adaptive-rejection-sampler
 ```
 
+## Materialize an explicit task batch
+
+Use the batch tool only during Template preparation. It requires an explicit
+task list and intentionally has no `--all` mode:
+
+```bash
+python qz_template_batch_materialize.py \
+  --mapping /path/to/terminalbench21-qz-templates.json \
+  --task-list /path/to/selected-tasks.txt \
+  --workers 4
+```
+
+The tool resolves the selected tasks before making QZ API calls, groups them by
+`template_key`, and runs at most `--workers` unique Template operations at once.
+Mapping writes stay serialized in the main process, so successful IDs are saved
+atomically without concurrent workers overwriting each other.
+
+Failures are isolated per unique Template. The command writes a JSON result to
+stdout and exits non-zero if any Template failed. Rerunning the same command
+reuses IDs already saved in the mapping and ready deterministic aliases.
+
 The write commands record `template_id` only after live status, deterministic
 alias, and QZ spec validation succeed. QZ's read API does not expose the source
 image, so the server-returned alias is the live content-identity commitment: it
 is derived from the exact image reference, image source, and spec in the
 mapping. A legacy Template without that alias must be materialized under the
 deterministic name instead of being bound by ID.
+
 Enable per-task selection in the runner with:
 
 ```bash

--- a/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
+++ b/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
@@ -112,7 +112,7 @@ task list and intentionally has no `--all` mode:
 python qz_template_batch_materialize.py \
   --mapping /path/to/terminalbench21-qz-templates.json \
   --task-list /path/to/selected-tasks.txt \
-  --workers 4
+  --workers 8
 ```
 
 The tool resolves the selected tasks before making QZ API calls, groups them by

--- a/Agents/utils/common/Harbor/qz_template_batch_materialize.py
+++ b/Agents/utils/common/Harbor/qz_template_batch_materialize.py
@@ -14,7 +14,7 @@ from typing import Any, TextIO
 import qz_template_manager as manager
 import qz_template_resolver as resolver
 
-DEFAULT_WORKERS = 4
+DEFAULT_WORKERS = 8
 
 
 class QzTemplateBatchError(RuntimeError):

--- a/Agents/utils/common/Harbor/qz_template_batch_materialize.py
+++ b/Agents/utils/common/Harbor/qz_template_batch_materialize.py
@@ -1,0 +1,222 @@
+"""Explicitly materialize selected QZ Templates with bounded concurrency."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+import qz_template_manager as manager
+import qz_template_resolver as resolver
+
+DEFAULT_WORKERS = 4
+
+
+class QzTemplateBatchError(RuntimeError):
+    """Raised when a batch cannot be prepared."""
+
+
+@dataclass(frozen=True)
+class MaterializeJob:
+    template_key: str
+    entry: Mapping[str, Any]
+    tasks: tuple[str, ...]
+
+
+def _positive_workers(value: str) -> int:
+    try:
+        workers = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("workers must be an integer") from exc
+    if workers <= 0:
+        raise argparse.ArgumentTypeError("workers must be greater than zero")
+    return workers
+
+
+def load_task_names(path: Path) -> list[str]:
+    """Load an explicit, non-empty task selection file."""
+    path = path.expanduser()
+    if not path.is_file():
+        raise QzTemplateBatchError(f"task list not found: {path}")
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise QzTemplateBatchError(f"task list is not valid UTF-8: {path}") from exc
+    task_names = []
+    for raw_line in contents.splitlines():
+        value = raw_line.strip()
+        if value and not value.startswith("#"):
+            task_names.append(value)
+    if not task_names:
+        raise QzTemplateBatchError(f"task list is empty: {path}")
+    return task_names
+
+
+def plan_jobs(
+    payload: Mapping[str, Any],
+    task_names: Sequence[str],
+) -> list[MaterializeJob]:
+    """Validate all selected tasks and deduplicate their Template entries."""
+    grouped: dict[str, dict[str, Any]] = {}
+    seen_tasks: set[str] = set()
+    for task_name in task_names:
+        canonical_task = resolver.resolve_task_key(payload, task_name)
+        if canonical_task in seen_tasks:
+            continue
+        seen_tasks.add(canonical_task)
+        template_key, entry = resolver.task_template_entry(payload, canonical_task)
+        group = grouped.setdefault(
+            template_key,
+            {"entry": entry, "tasks": []},
+        )
+        group["tasks"].append(canonical_task)
+
+    return [
+        MaterializeJob(
+            template_key=template_key,
+            entry=group["entry"],
+            tasks=tuple(sorted(group["tasks"])),
+        )
+        for template_key, group in sorted(grouped.items())
+    ]
+
+
+def _run_job(
+    job: MaterializeJob,
+    client: manager.QzTemplateClient,
+    timeout: float,
+    stderr: TextIO,
+) -> tuple[str | None, str | None]:
+    try:
+        template_id = resolver.materialize_template_entry(
+            job.template_key,
+            job.entry,
+            client,
+            timeout=timeout,
+            stderr=stderr,
+        )
+        return template_id, None
+    except (
+        OSError,
+        manager.QzTemplateError,
+        resolver.QzTemplateResolutionError,
+    ) as exc:
+        return None, str(exc)
+
+
+def materialize_batch(
+    mapping_path: Path,
+    task_names: Sequence[str],
+    client: manager.QzTemplateClient,
+    *,
+    workers: int,
+    timeout: float,
+    stderr: TextIO = sys.stderr,
+) -> dict[str, Any]:
+    """Materialize unique selected Templates and persist successes serially."""
+    if workers <= 0:
+        raise QzTemplateBatchError("workers must be greater than zero")
+
+    payload = resolver.load_mapping(mapping_path)
+    jobs = plan_jobs(payload, task_names)
+    if not jobs:
+        raise QzTemplateBatchError("task selection did not produce any jobs")
+
+    results: dict[str, dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=min(workers, len(jobs))) as executor:
+        futures = {
+            executor.submit(_run_job, job, client, timeout, stderr): job for job in jobs
+        }
+        for future in as_completed(futures):
+            job = futures[future]
+            template_id, error = future.result()
+            result = {
+                "template_key": job.template_key,
+                "tasks": list(job.tasks),
+            }
+            if error is None and template_id is not None:
+                try:
+                    resolver.record_template_id(
+                        mapping_path,
+                        job.template_key,
+                        template_id,
+                    )
+                except (OSError, resolver.QzTemplateResolutionError) as exc:
+                    error = f"failed to record ready Template {template_id!r}: {exc}"
+                else:
+                    result.update(status="ready", template_id=template_id)
+                    print(
+                        f"ready {job.template_key}: {template_id} "
+                        f"({len(job.tasks)} task(s))",
+                        file=stderr,
+                    )
+            if error is not None:
+                result.update(status="failed", error=error)
+                print(f"failed {job.template_key}: {error}", file=stderr)
+            results[job.template_key] = result
+
+    ordered_results = [results[job.template_key] for job in jobs]
+    ready_count = sum(result["status"] == "ready" for result in ordered_results)
+    return {
+        "mapping": str(mapping_path.expanduser().resolve()),
+        "selected_task_count": sum(len(job.tasks) for job in jobs),
+        "unique_template_count": len(jobs),
+        "ready_template_count": ready_count,
+        "failed_template_count": len(jobs) - ready_count,
+        "templates": ordered_results,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Materialize selected QZ Templates with bounded concurrency.",
+    )
+    parser.add_argument("--mapping", required=True, type=Path)
+    parser.add_argument("--task-list", required=True, type=Path)
+    parser.add_argument("--workers", type=_positive_workers, default=DEFAULT_WORKERS)
+    parser.add_argument(
+        "--timeout",
+        type=manager._positive_timeout,
+        default=manager.DEFAULT_BUILD_TIMEOUT_SEC,
+        help="per-Template build timeout in seconds",
+    )
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    args = parse_args(argv)
+    try:
+        task_names = load_task_names(args.task_list)
+        result = materialize_batch(
+            args.mapping,
+            task_names,
+            manager.client_from_environment(),
+            workers=args.workers,
+            timeout=args.timeout,
+            stderr=stderr,
+        )
+        json.dump(result, stdout, ensure_ascii=False, indent=2, sort_keys=True)
+        stdout.write("\n")
+        return 1 if result["failed_template_count"] else 0
+    except (
+        OSError,
+        manager.QzTemplateError,
+        QzTemplateBatchError,
+        resolver.QzTemplateResolutionError,
+    ) as exc:
+        print(f"error: {exc}", file=stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/utils/common/Harbor/qz_template_resolver.py
+++ b/Agents/utils/common/Harbor/qz_template_resolver.py
@@ -48,7 +48,8 @@ def load_mapping(path: Path) -> dict[str, Any]:
     return payload
 
 
-def _task_key(payload: Mapping[str, Any], task_name: str) -> str:
+def resolve_task_key(payload: Mapping[str, Any], task_name: str) -> str:
+    """Return the canonical mapping key for one Harbor task name."""
     tasks = payload["tasks"]
     name = task_name.strip().strip("/")
     if name in tasks:
@@ -101,7 +102,7 @@ def task_template_entry(
     task_name: str,
 ) -> tuple[str, dict[str, Any]]:
     """Return the template key and entry selected for one Harbor task."""
-    key = _task_key(payload, task_name)
+    key = resolve_task_key(payload, task_name)
     task = payload["tasks"].get(key)
     if not isinstance(task, dict):
         raise QzTemplateResolutionError(f"mapping task {key!r} must be an object")
@@ -269,7 +270,7 @@ def _write_mapping(path: Path, payload: Mapping[str, Any]) -> None:
     temporary.replace(path)
 
 
-def _record_template_id(
+def record_template_id(
     mapping_path: Path,
     template_key: str,
     template_id: str,
@@ -311,23 +312,37 @@ def bind_task_template(
         raise QzTemplateResolutionError(
             f"Template API returned {resolved_id!r} for requested ID {requested_id!r}"
         )
-    _record_template_id(mapping_path, template_key, resolved_id)
+    record_template_id(mapping_path, template_key, resolved_id)
     return resolved_id
 
 
-def materialize_task_template(
-    mapping_path: Path,
-    task_name: str,
+def materialize_template_entry(
+    template_key: str,
+    entry: Mapping[str, Any],
     client: manager.QzTemplateClient,
     *,
     timeout: float,
     stderr: TextIO = sys.stderr,
 ) -> str:
-    """Create or reuse one mapped Template, then persist its ready ID."""
-    payload = load_mapping(mapping_path)
-    template_key, entry = task_template_entry(payload, task_name)
-    if entry.get("template_id") is not None:
-        return resolve_task_template(mapping_path, task_name, client)
+    """Create or reuse one validated mapping entry without writing the mapping."""
+    cached_id = entry.get("template_id")
+    if cached_id is not None:
+        if not isinstance(cached_id, str) or not cached_id.strip():
+            raise QzTemplateResolutionError(
+                f"mapping Template {template_key!r} has an invalid template_id"
+            )
+        requested_id = cached_id.strip()
+        ready_id = _validated_ready_template_id(
+            client.get_template(requested_id),
+            entry,
+            f"mapped Template {template_key!r}",
+        )
+        if ready_id != requested_id:
+            raise QzTemplateResolutionError(
+                f"mapped Template {template_key!r} returned ID {ready_id!r} "
+                f"for requested ID {requested_id!r}"
+            )
+        return ready_id
 
     template_id = manager.create_template_from_image(
         client,
@@ -348,7 +363,28 @@ def materialize_task_template(
         raise QzTemplateResolutionError(
             f"Template API returned {ready_id!r} for materialized ID {template_id!r}"
         )
-    _record_template_id(mapping_path, template_key, ready_id)
+    return ready_id
+
+
+def materialize_task_template(
+    mapping_path: Path,
+    task_name: str,
+    client: manager.QzTemplateClient,
+    *,
+    timeout: float,
+    stderr: TextIO = sys.stderr,
+) -> str:
+    """Create or reuse one mapped Template, then persist its ready ID."""
+    payload = load_mapping(mapping_path)
+    template_key, entry = task_template_entry(payload, task_name)
+    ready_id = materialize_template_entry(
+        template_key,
+        entry,
+        client,
+        timeout=timeout,
+        stderr=stderr,
+    )
+    record_template_id(mapping_path, template_key, ready_id)
     return ready_id
 
 

--- a/Agents/utils/common/Harbor/tests/test_qz_template_batch_materialize.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_batch_materialize.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+HARBOR_DIR = Path(__file__).resolve().parents[1]
+if str(HARBOR_DIR) not in sys.path:
+    sys.path.insert(0, str(HARBOR_DIR))
+
+import qz_template_batch_materialize as batch
+import qz_template_manager as manager
+import qz_template_mapping as mapping
+import qz_template_resolver as resolver
+
+
+class QzTemplateBatchMaterializeTest(unittest.TestCase):
+    def make_mapping(self, root: Path) -> tuple[Path, dict]:
+        tasks = []
+        for task_name, image in (
+            ("task-a", "ubuntu:24.04"),
+            ("task-b", "ubuntu:24.04"),
+            ("task-c", "debian:12"),
+        ):
+            task_dir = root / task_name
+            task_dir.mkdir()
+            (task_dir / "task.toml").write_text(
+                f'[environment]\ndocker_image = "{image}"\n',
+                encoding="utf-8",
+            )
+            tasks.append((task_name, task_dir))
+        payload = mapping.build_inventory(
+            benchmark="terminalbench21",
+            tasks=tasks,
+        )
+        path = root / "mapping.json"
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return path, payload
+
+    def test_materializes_unique_templates_concurrently_and_records_ids(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path, payload = self.make_mapping(Path(temporary))
+            barrier = threading.Barrier(2)
+            calls = []
+            calls_lock = threading.Lock()
+            template_ids = {
+                template_key: f"template-{index}"
+                for index, template_key in enumerate(payload["templates"], start=1)
+            }
+
+            def materialize(template_key, entry, client, *, timeout, stderr):
+                del entry, client, timeout, stderr
+                with calls_lock:
+                    calls.append(template_key)
+                barrier.wait(timeout=5)
+                return template_ids[template_key]
+
+            with patch.object(
+                batch.resolver,
+                "materialize_template_entry",
+                side_effect=materialize,
+            ):
+                report = batch.materialize_batch(
+                    path,
+                    ["task-a", "task-b", "task-a", "task-c"],
+                    object(),
+                    workers=2,
+                    timeout=30,
+                    stderr=io.StringIO(),
+                )
+            saved = resolver.load_mapping(path)
+
+        self.assertCountEqual(calls, payload["templates"])
+        self.assertEqual(report["selected_task_count"], 3)
+        self.assertEqual(report["unique_template_count"], 2)
+        self.assertEqual(report["ready_template_count"], 2)
+        self.assertEqual(report["failed_template_count"], 0)
+        for template_key, template_id in template_ids.items():
+            self.assertEqual(
+                saved["templates"][template_key]["template_id"],
+                template_id,
+            )
+        grouped_tasks = sorted(len(result["tasks"]) for result in report["templates"])
+        self.assertEqual(grouped_tasks, [1, 2])
+
+    def test_partial_failure_persists_success(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path, payload = self.make_mapping(Path(temporary))
+            successful_key = next(
+                key
+                for key, entry in payload["templates"].items()
+                if entry["image"] == "ubuntu:24.04"
+            )
+
+            def materialize(template_key, entry, client, *, timeout, stderr):
+                del entry, client, timeout, stderr
+                if template_key == successful_key:
+                    return "template-ready"
+                raise manager.QzTemplateError("build failed")
+
+            with patch.object(
+                batch.resolver,
+                "materialize_template_entry",
+                side_effect=materialize,
+            ):
+                report = batch.materialize_batch(
+                    path,
+                    ["task-a", "task-b", "task-c"],
+                    object(),
+                    workers=2,
+                    timeout=30,
+                    stderr=io.StringIO(),
+                )
+            saved = resolver.load_mapping(path)
+
+        self.assertEqual(report["ready_template_count"], 1)
+        self.assertEqual(report["failed_template_count"], 1)
+        self.assertEqual(
+            saved["templates"][successful_key]["template_id"],
+            "template-ready",
+        )
+        failed = next(
+            result for result in report["templates"] if result["status"] == "failed"
+        )
+        self.assertIn("build failed", failed["error"])
+
+    def test_main_outputs_json_and_returns_failure_count(self):
+        result = {
+            "mapping": "/tmp/mapping.json",
+            "selected_task_count": 1,
+            "unique_template_count": 1,
+            "ready_template_count": 0,
+            "failed_template_count": 1,
+            "templates": [],
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            task_list = root / "tasks.txt"
+            task_list.write_text("# selected tasks\ntask-a\n", encoding="utf-8")
+            stdout = io.StringIO()
+            with (
+                patch.object(batch.manager, "client_from_environment"),
+                patch.object(batch, "materialize_batch", return_value=result),
+            ):
+                status = batch.main(
+                    [
+                        "--mapping",
+                        str(root / "mapping.json"),
+                        "--task-list",
+                        str(task_list),
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(json.loads(stdout.getvalue()), result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_qz_template_resolver.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_resolver.py
@@ -177,14 +177,14 @@ class QzTemplateResolverTest(unittest.TestCase):
 
     def test_task_key_resolves_unique_nested_names_and_rejects_ambiguity(self):
         self.assertEqual(
-            resolver._task_key(
+            resolver.resolve_task_key(
                 {"tasks": {"suite/task-a": {}}},
                 "task-a",
             ),
             "suite/task-a",
         )
         self.assertEqual(
-            resolver._task_key(
+            resolver.resolve_task_key(
                 {"tasks": {"task-a": {}, "suite/task-a": {}}},
                 "benchmark/suite/task-a",
             ),
@@ -194,7 +194,7 @@ class QzTemplateResolverTest(unittest.TestCase):
             resolver.QzTemplateResolutionError,
             "ambiguously matches",
         ):
-            resolver._task_key(
+            resolver.resolve_task_key(
                 {"tasks": {"first/task-a": {}, "second/task-a": {}}},
                 "task-a",
             )


### PR DESCRIPTION
## 1. Why the change?

The per-task QZ Template resolver introduced in #119 prepares only one task at a time. Preparing an explicit task set therefore requires repeated serial commands, while a batch implementation must also avoid concurrent workers overwriting the shared mapping.

## 2. Summary of the change

- Add `qz_template_batch_materialize.py` for an explicit task list; it intentionally has no `--all` mode.
- Resolve and deduplicate selected tasks by `template_key`, then prepare unique Templates with bounded worker concurrency.
- Reuse the existing single-Template materialization and live validation logic.
- Keep mapping writes in the main thread so successful `template_id` values are recorded serially and atomically.
- Isolate failures per unique Template and emit a JSON result with a non-zero exit code when any item fails.
- Document the preparation command and add focused concurrency, deduplication, persistence, and CLI tests.

Normal benchmark execution remains read-only with respect to Template creation.

## 3. Other details

Validation:

- Local QZ Python suite: 101 tests passed.
- Local `test_harboropik_qz.sh`: passed.
- Ruff check and format check: passed.
- Python compilation and `git diff --check`: passed.
- qz-sandbox isolated QZ Python suite: 101 tests passed.
- qz-sandbox `test_harboropik_qz.sh`: passed.
- Live read-only acceptance reused the existing ready `overfull-hbox` Template: 1 ready, 0 failed. No Template was created or modified.

Out of scope: automatic all-task discovery, image build/push, benchmark-worker integration, Template rebuild/delete, retry scheduling, and cross-process mapping locks.

Related design discussion: sii-system/tasks#160.
