### PR TITLE
feat(harbor): expose fixer report CLI

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -428,13 +428,28 @@ Verification writes
 `verification-result-latest.json`. If the Fix Plan was generated without a
 local monitor, select `claude-code`, `opencode`, or `oracle` with `--agent`.
 
-### Human-readable Fixer result
+### Generate a report
 
-After Controller-approved execution and verification, Fixer writes a
-deterministic `fix-report-latest.md` from the validated Fix Plan, execution
-result, and verification result. The report contains the summary, successfully
-applied changes, and remaining issues. Controller then replaces only the
-existing `## Fixer Results` section in `benchmark-summary.md`; it does not
+```bash
+python3 Agents/utils/common/Harbor/scripts/fixer.py \
+  --report-only \
+  --verification-result /path/to/fixer-output/verification-result-latest.json \
+  --analyzer-output /path/to/analyzer-output \
+  --output-dir /path/to/fixer-output \
+  --pi-model "$HARBOR_FIXER_MODEL" \
+  --pi-base-url "$BASE_URL" \
+  --baseline-run-dir /path/to/old-harbor-run
+```
+
+Reporter keeps task, execution, and verification observations code-owned. A
+no-tool Pi agent may generate only the bounded human-readable summary. The
+Markdown view presents observed results and unavailable data before attributed
+Analyzer findings and Fix Plan reasoning. Smoke-test outcomes remain scoped to
+sampled tasks. The machine contract is written to `fix-report-latest.json`; the
+deterministic, secret-redacted view is written to `fix-report-latest.md`.
+
+After Controller-approved execution and verification, Controller replaces only
+the existing `## Fixer Results` section in `benchmark-summary.md`; it does not
 regenerate the Monitor or Analyzer summary.
 
 ## More Details

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -56,7 +56,7 @@ Agents/utils/common/Harbor/
     │   ├── planning_context/   # Runtime inventory and workspace evidence
     │   ├── policy/             # T1 rules, path routing, and T2/T3 Agent policy
     │   ├── prompts.py          # Task and plan agent contracts
-    │   ├── report.py           # Deterministic human-readable Fixer report
+    │   ├── report/             # Summary runtime, JSON generation, and Markdown rendering
     │   ├── validation.py       # Plan, execution, and verification validation
     │   ├── verification/       # Selection, rerun, and Harbor-state details
     │   └── verifier.py         # Verification public entry points

--- a/Agents/utils/common/Harbor/scripts/fixer.py
+++ b/Agents/utils/common/Harbor/scripts/fixer.py
@@ -19,6 +19,8 @@ from harbor_fixer.plan_generation import (
     task_artifact_label,
 )
 from harbor_fixer.prompts import MAIN_AGENT_PROMPT, TASK_SUBAGENT_PROMPT
+from harbor_fixer.report import run_report_from_paths
+from harbor_fixer.report.prompt import REPORT_MAIN_AGENT_PROMPT
 from harbor_fixer.validation import HARBOR_AGENTS, ValidationError
 from harbor_fixer.verifier import run_verification_from_paths
 
@@ -45,6 +47,13 @@ def build_pi_config(args: argparse.Namespace) -> PiInvocationConfig:
 
 
 def parse_args() -> argparse.Namespace:
+    mode_parser = argparse.ArgumentParser(add_help=False)
+    mode_parser.add_argument("--report-only", action="store_true")
+    report_only, _ = mode_parser.parse_known_args()
+
+    def mode_default(name: str, default: str) -> str:
+        return default if report_only.report_only else os.environ.get(name, default)
+
     parser = argparse.ArgumentParser(description="Harbor Fixer MVP CLI")
     parser.add_argument(
         "--analyzer-output",
@@ -68,29 +77,29 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--execution-timeout",
         type=int,
-        default=os.environ.get("HARBOR_FIXER_EXECUTION_TIMEOUT", "300"),
+        default=mode_default("HARBOR_FIXER_EXECUTION_TIMEOUT", "300"),
     )
     parser.add_argument(
         "--summary-limit",
         type=int,
-        default=os.environ.get("HARBOR_FIXER_SUMMARY_LIMIT", "4000"),
+        default=mode_default("HARBOR_FIXER_SUMMARY_LIMIT", "4000"),
     )
     parser.add_argument(
         "--max-concurrency",
         type=int,
-        default=os.environ.get("HARBOR_FIXER_MAX_CONCURRENCY", "4"),
+        default=mode_default("HARBOR_FIXER_MAX_CONCURRENCY", "4"),
     )
     parser.add_argument(
         "--max-task-summary-chars",
         type=int,
-        default=os.environ.get(
+        default=mode_default(
             "HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS", str(MAX_TASK_SUMMARY_CHARS)
         ),
     )
     parser.add_argument(
         "--max-task-summaries-chars",
         type=int,
-        default=os.environ.get(
+        default=mode_default(
             "HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS", str(MAX_TASK_SUMMARIES_CHARS)
         ),
     )
@@ -110,11 +119,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--exec-result", type=Path)
     parser.add_argument("--verification-run-dir", type=Path)
     parser.add_argument("--agent", choices=sorted(HARBOR_AGENTS))
+    parser.add_argument("--report-only", action="store_true")
+    parser.add_argument("--verification-result", type=Path)
+    parser.add_argument("--baseline-run-dir", type=Path)
+    parser.add_argument(
+        "--baseline-monitor-policy", choices=["auto", "on", "off"], default="auto"
+    )
     parser.add_argument("--rerun-command", default=None)
     parser.add_argument(
         "--rerun-timeout",
         type=int,
-        default=os.environ.get("HARBOR_FIXER_RERUN_TIMEOUT", "600"),
+        default=mode_default("HARBOR_FIXER_RERUN_TIMEOUT", "600"),
     )
     parser.add_argument("--monitor-policy", choices=["auto", "on", "off"], default="auto")
     parser.add_argument("--monitor-wait-timeout", type=int, default=3600)
@@ -143,15 +158,31 @@ def main() -> int:
         raise SystemExit("--max-task-summaries-chars must be positive")
     if args.verification_task_limit_per_plan <= 0:
         raise SystemExit("--verification-task-limit-per-plan must be positive")
-    selected_modes = [args.prepare_only, args.exec_only, args.verify_only]
+    selected_modes = [
+        args.prepare_only,
+        args.exec_only,
+        args.verify_only,
+        args.report_only,
+    ]
     if sum(1 for selected in selected_modes if selected) > 1:
         raise SystemExit(
-            "--prepare-only, --exec-only, and --verify-only are mutually exclusive"
+            "--prepare-only, --exec-only, --verify-only, and --report-only are mutually exclusive"
         )
     args.output_dir.mkdir(parents=True, exist_ok=True)
     if args.write_prompts:
-        write_text(args.output_dir / "prompts" / "task-subagent-prompt.md", TASK_SUBAGENT_PROMPT)
-        write_text(args.output_dir / "prompts" / "main-agent-prompt.md", MAIN_AGENT_PROMPT)
+        if args.report_only:
+            write_text(
+                args.output_dir / "prompts" / "report-main-agent-prompt.md",
+                REPORT_MAIN_AGENT_PROMPT,
+            )
+        else:
+            write_text(
+                args.output_dir / "prompts" / "task-subagent-prompt.md",
+                TASK_SUBAGENT_PROMPT,
+            )
+            write_text(
+                args.output_dir / "prompts" / "main-agent-prompt.md", MAIN_AGENT_PROMPT
+            )
     if args.exec_only:
         if args.fix_plan is None:
             raise SystemExit("--fix-plan is required with --exec-only")
@@ -193,6 +224,23 @@ def main() -> int:
         except ValidationError as exc:
             raise SystemExit(str(exc)) from None
         return 0 if result["status"] in {"fixed", "partially_fixed"} else 1
+    if args.report_only:
+        if args.verification_result is None:
+            raise SystemExit("--verification-result is required with --report-only")
+        if args.analyzer_output is None:
+            raise SystemExit("--analyzer-output is required with --report-only")
+        try:
+            result = run_report_from_paths(
+                args.verification_result,
+                args.analyzer_output,
+                args.output_dir,
+                PiAgentInvoker(args.output_dir, build_pi_config(args)),
+                baseline_run_dir=args.baseline_run_dir,
+                baseline_monitor_policy=args.baseline_monitor_policy,
+            )
+        except ValidationError as exc:
+            raise SystemExit(str(exc)) from None
+        return 0 if result["summary"]["status"] == "success" else 1
     if args.analyzer_output is None:
         raise SystemExit("--analyzer-output is required unless --exec-only is used")
     if args.prepare_only:

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -503,3 +504,47 @@ class HarborFixerReportTest(FixerTestCase):
             os.stat(output_dir / "fix-report-latest.json").st_mode & 0o777,
             0o600,
         )
+
+    def test_cli_routes_report_mode_and_returns_clean_validation_error(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            analyzer_dir = root_path / "analyzer"
+            analyzer_dir.mkdir()
+            verification_path = root_path / "verification.json"
+            output_dir = root_path / "output"
+            write_json(verification_path, {})
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_DIR / "fixer.py"),
+                    "--report-only",
+                    "--verification-result",
+                    str(verification_path),
+                    "--analyzer-output",
+                    str(analyzer_dir),
+                    "--output-dir",
+                    str(output_dir),
+                    "--write-prompts",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+                env={
+                    "PATH": "/usr/bin:/bin",
+                    "HARBOR_FIXER_EXECUTION_TIMEOUT": "invalid",
+                    "HARBOR_FIXER_MAX_CONCURRENCY": "0",
+                    "HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS": "invalid",
+                    "HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS": "invalid",
+                    "HARBOR_FIXER_RERUN_TIMEOUT": "invalid",
+                    "HARBOR_FIXER_SUMMARY_LIMIT": "invalid",
+                },
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("verification result schema_version must be 2", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertTrue(
+                (output_dir / "prompts" / "report-main-agent-prompt.md").is_file()
+            )
+            self.assertFalse((output_dir / "prompts" / "main-agent-prompt.md").exists())


### PR DESCRIPTION
## 1. Why the change?

Harbor Fixer can generate machine-readable and Markdown reports through its Python APIs, but operators need a standalone CLI path to regenerate reports from persisted verification and Analyzer artifacts without rerunning planning, execution, or verification.

## 2. Summary of the change

- Add report-only CLI arguments for the verification result, optional baseline run, and baseline monitor policy.
- Route report-only mode through the existing report generation API and print the report-agent prompt when requested.
- Isolate report-only parsing from inherited planning, execution, and verification settings that this mode does not use.
- Document the report-only workflow and cover its CLI validation behavior.

## 3. Other details

- Rebased onto the current upstream main, including #122.
- Full Harbor Fixer suite: 73 tests passed.
- Ruff 0.16.0 passes for the changed Python files; upstream main Ruff CI is green.