### PR TITLE
CI: add Harbor terminalbench21 e2e validation on self-hosted runners

### DIFF
--- a/.github/scripts/e2e_harbor_gate.py
+++ b/.github/scripts/e2e_harbor_gate.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Decide whether a Harbor e2e run proves the fleet still works.
+
+terminalbench21 is a Harbor registry dataset (env.sh:55,967), so the run is a
+single zellij pane running run_harbor_registry.sh -> harboropik.sh, and its
+final report is $OUTPUT_PATH/summary.txt as written by
+scripts/write_harbor_registry_summary.py. The worker queue files done.txt and
+failed.txt are touched empty on this path and never written, so they are
+deliberately not read.
+
+Errored and cancelled trials mean the harness broke. Completed trials carrying
+reward 0 are model outcomes and must not fail CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_MAX_HARNESS_FAILURE_RATIO = 0.10
+
+# Fields sit at column 0 with no space before the colon. Section headings in the
+# same file ("reward counts:", "Harbor stats:", "result paths:") contain a space
+# and so cannot be mistaken for fields.
+_FIELD = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*):[ \t]*(.*)$")
+_REWARD = re.compile(r"^[ \t]+reward=(\S+):[ \t]*(\d+)$")
+
+
+def parse_summary(text: str) -> dict[str, str]:
+    """Collect column-0 `key: value` fields, first occurrence winning."""
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        match = _FIELD.match(line)
+        if match and match.group(1) not in fields:
+            fields[match.group(1)] = match.group(2).strip()
+    return fields
+
+
+def parse_reward_counts(text: str) -> dict[str, int]:
+    """Read the indented `reward=<value>: <count>` histogram."""
+    counts: dict[str, int] = {}
+    for line in text.splitlines():
+        match = _REWARD.match(line)
+        if match:
+            counts[match.group(1)] = int(match.group(2))
+    return counts
+
+
+def int_field(fields: dict[str, str], name: str) -> int | None:
+    raw = fields.get(name)
+    if raw is None or not raw.lstrip("-").isdigit():
+        return None
+    return int(raw)
+
+
+class Verdict:
+    def __init__(self, passed: bool, reasons: list[str], stats: dict):
+        self.passed = passed
+        self.reasons = reasons
+        self.stats = stats
+
+
+def evaluate(
+    summary_text: str | None,
+    max_harness_failure_ratio: float = DEFAULT_MAX_HARNESS_FAILURE_RATIO,
+    harbor_status: int = 0,
+) -> Verdict:
+    stats: dict = {}
+    reasons: list[str] = []
+
+    if summary_text is None:
+        reasons.append(
+            "summary.txt is missing: the run never wrote a final report"
+        )
+        return Verdict(False, reasons, stats)
+
+    fields = parse_summary(summary_text)
+    stats["status"] = fields.get("status", "<absent>")
+    stats["mean_reward"] = fields.get("mean_reward", "unavailable")
+    stats["rewards"] = parse_reward_counts(summary_text)
+
+    if stats["status"] != "complete":
+        detail = fields.get("failure_reason") or "no failure_reason recorded"
+        reasons.append(
+            f"Harbor status is {stats['status']!r}, not 'complete': {detail}"
+        )
+
+    exit_code = int_field(fields, "harbor_exit_code")
+    stats["harbor_exit_code"] = exit_code
+    if exit_code is None:
+        reasons.append("summary.txt has no numeric harbor_exit_code")
+    elif exit_code != 0:
+        reasons.append(f"Harbor exited with code {exit_code}")
+
+    # Independent of Harbor's own code: catches the shell or zellij dying after
+    # the summary was written.
+    if harbor_status != 0:
+        reasons.append(
+            f"the benchmark shell exited with status {harbor_status}"
+        )
+
+    total = int_field(fields, "total")
+    if total is None:
+        reasons.append(
+            "summary.txt has no trial totals: Harbor produced no aggregate result"
+        )
+        return Verdict(False, reasons, stats)
+
+    completed = int_field(fields, "completed") or 0
+    errored = int_field(fields, "errored") or 0
+    cancelled = int_field(fields, "cancelled") or 0
+    harness_failures = errored + cancelled
+    stats.update(
+        {
+            "total": total,
+            "completed": completed,
+            "errored": errored,
+            "cancelled": cancelled,
+            "retries": int_field(fields, "retries") or 0,
+            "harness_failures": harness_failures,
+        }
+    )
+
+    if total == 0:
+        reasons.append(
+            "no trials ran: check the taskset and --task selection"
+        )
+        return Verdict(False, reasons, stats)
+
+    accounted = completed + errored + cancelled
+    if accounted != total:
+        reasons.append(
+            f"trials do not reconcile: {accounted} accounted for of {total}"
+        )
+
+    # Expressed as a count, not a rounded percentage. At the default tolerance
+    # the smallest failing count on 89 trials is 9, and 9/89 rounds to 10%, so a
+    # percentage would render as "10% exceeds tolerance 10%".
+    allowed = int(max_harness_failure_ratio * total)
+    stats["harness_failures_allowed"] = allowed
+    if harness_failures > allowed:
+        reasons.append(
+            f"{harness_failures} harness failures of {total} trials exceeds the "
+            f"allowance of {allowed} ({errored} errored, {cancelled} cancelled)"
+        )
+
+    return Verdict(not reasons, reasons, stats)
+
+
+def render_summary(verdict: Verdict) -> str:
+    stats = verdict.stats
+    lines = [
+        f"## Harbor e2e validation: {'PASS' if verdict.passed else 'FAIL'}",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| Harbor status | {stats.get('status', '<absent>')} |",
+        f"| Harbor exit code | {stats.get('harbor_exit_code', '<absent>')} |",
+        f"| Trials | {stats.get('total', 0)} |",
+        f"| Completed | {stats.get('completed', 0)} |",
+        f"| Errored | {stats.get('errored', 0)} |",
+        f"| Cancelled | {stats.get('cancelled', 0)} |",
+        f"| Retries | {stats.get('retries', 0)} |",
+        (
+            "| Harness failures (allowed) | "
+            f"{stats.get('harness_failures', 0)} "
+            f"({stats.get('harness_failures_allowed', 0)}) |"
+        ),
+        f"| Mean reward | {stats.get('mean_reward', 'unavailable')} |",
+        "",
+    ]
+
+    rewards = stats.get("rewards") or {}
+    if rewards:
+        lines.append("Reward distribution:")
+        lines.append("")
+        lines.extend(
+            f"- `reward={reward}`: {count}"
+            for reward, count in sorted(rewards.items())
+        )
+        lines.append("")
+
+    if verdict.passed:
+        lines.append(
+            "Pipeline healthy. Unsolved trials are a model signal and do not "
+            "fail this job."
+        )
+    else:
+        lines.append("### Why this failed")
+        lines.append("")
+        lines.extend(f"- {reason}" for reason in verdict.reasons)
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-path", required=True, type=Path)
+    parser.add_argument("--harbor-status", default=0, type=int)
+    parser.add_argument(
+        "--max-harness-failure-ratio",
+        default=DEFAULT_MAX_HARNESS_FAILURE_RATIO,
+        type=float,
+    )
+    parser.add_argument("--step-summary", default=None, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        try:
+            summary_text = (args.output_path / "summary.txt").read_text(
+                encoding="utf-8"
+            )
+        except FileNotFoundError:
+            summary_text = None
+        verdict = evaluate(
+            summary_text,
+            args.max_harness_failure_ratio,
+            args.harbor_status,
+        )
+    except (ValueError, OSError) as error:
+        print(f"::error::unreadable Harbor summary: {error}", file=sys.stderr)
+        return 1
+
+    rendered = render_summary(verdict)
+    print(rendered)
+
+    destination = args.step_summary
+    if destination is None and os.environ.get("GITHUB_STEP_SUMMARY"):
+        destination = Path(os.environ["GITHUB_STEP_SUMMARY"])
+    if destination:
+        with open(destination, "a", encoding="utf-8") as handle:
+            handle.write(rendered)
+
+    for reason in verdict.reasons:
+        print(f"::error::{reason}", file=sys.stderr)
+    return 0 if verdict.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/e2e_harbor_gate.py
+++ b/.github/scripts/e2e_harbor_gate.py
@@ -67,6 +67,7 @@ def evaluate(
     summary_text: str | None,
     max_harness_failure_ratio: float = DEFAULT_MAX_HARNESS_FAILURE_RATIO,
     harbor_status: int = 0,
+    expected_trials: int | None = None,
 ) -> Verdict:
     stats: dict = {}
     reasons: list[str] = []
@@ -112,15 +113,23 @@ def evaluate(
     completed = int_field(fields, "completed") or 0
     errored = int_field(fields, "errored") or 0
     cancelled = int_field(fields, "cancelled") or 0
-    harness_failures = errored + cancelled
+    retries = int_field(fields, "retries") or 0
+    # A trial that errored and was then retried to completion is counted in
+    # BOTH n_errored_trials and n_completed_trials (see the fixture in
+    # Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh:118-123,
+    # where total=2, completed=2, errored=1). So errored+cancelled overcounts
+    # harness breakage whenever a retry succeeded, and HARBOR_MAX_RETRIES
+    # defaults to 2. Count trials that never completed instead: that excludes
+    # recovered retries and still catches permanent failures and cancellations.
+    unresolved = max(0, total - completed)
     stats.update(
         {
             "total": total,
             "completed": completed,
             "errored": errored,
             "cancelled": cancelled,
-            "retries": int_field(fields, "retries") or 0,
-            "harness_failures": harness_failures,
+            "retries": retries,
+            "unresolved": unresolved,
         }
     )
 
@@ -130,21 +139,30 @@ def evaluate(
         )
         return Verdict(False, reasons, stats)
 
-    accounted = completed + errored + cancelled
-    if accounted != total:
+    if expected_trials is not None and total != expected_trials:
         reasons.append(
-            f"trials do not reconcile: {accounted} accounted for of {total}"
+            f"expected {expected_trials} trials but Harbor ran {total}: "
+            "task selection did not reach the benchmark"
+        )
+
+    # Over-count is normal with retries, so only a shortfall means trials went
+    # missing entirely.
+    accounted = completed + errored + cancelled
+    if accounted < total:
+        reasons.append(
+            f"trials unaccounted for: {accounted} of {total} recorded"
         )
 
     # Expressed as a count, not a rounded percentage. At the default tolerance
     # the smallest failing count on 89 trials is 9, and 9/89 rounds to 10%, so a
     # percentage would render as "10% exceeds tolerance 10%".
     allowed = int(max_harness_failure_ratio * total)
-    stats["harness_failures_allowed"] = allowed
-    if harness_failures > allowed:
+    stats["unresolved_allowed"] = allowed
+    if unresolved > allowed:
         reasons.append(
-            f"{harness_failures} harness failures of {total} trials exceeds the "
-            f"allowance of {allowed} ({errored} errored, {cancelled} cancelled)"
+            f"{unresolved} of {total} trials never completed, exceeding the "
+            f"allowance of {allowed} ({errored} errored, {cancelled} cancelled, "
+            f"{retries} retried)"
         )
 
     return Verdict(not reasons, reasons, stats)
@@ -165,9 +183,9 @@ def render_summary(verdict: Verdict) -> str:
         f"| Cancelled | {stats.get('cancelled', 0)} |",
         f"| Retries | {stats.get('retries', 0)} |",
         (
-            "| Harness failures (allowed) | "
-            f"{stats.get('harness_failures', 0)} "
-            f"({stats.get('harness_failures_allowed', 0)}) |"
+            "| Never completed (allowed) | "
+            f"{stats.get('unresolved', 0)} "
+            f"({stats.get('unresolved_allowed', 0)}) |"
         ),
         f"| Mean reward | {stats.get('mean_reward', 'unavailable')} |",
         "",
@@ -205,9 +223,17 @@ def main(argv: list[str] | None = None) -> int:
         type=float,
     )
     parser.add_argument("--step-summary", default=None, type=Path)
+    parser.add_argument(
+        "--expected-trials",
+        default="",
+        help="Reject a summary whose trial total differs; empty skips the check",
+    )
     args = parser.parse_args(argv)
 
     try:
+        expected_trials = (
+            int(args.expected_trials) if args.expected_trials.strip() else None
+        )
         try:
             summary_text = (args.output_path / "summary.txt").read_text(
                 encoding="utf-8"
@@ -218,6 +244,7 @@ def main(argv: list[str] | None = None) -> int:
             summary_text,
             args.max_harness_failure_ratio,
             args.harbor_status,
+            expected_trials,
         )
     except (ValueError, OSError) as error:
         print(f"::error::unreadable Harbor summary: {error}", file=sys.stderr)

--- a/.github/scripts/e2e_worker_capacity.py
+++ b/.github/scripts/e2e_worker_capacity.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Derive a Harbor worker count from host CPU and memory capacity.
+
+Terminal-Bench needs 8 cores and 32 GB per worker. Harbor does not enforce
+that, so oversubscription is silent: the workers start and then starve. The
+bare-metal runners also host code-review container runners, so a reserve is
+held back rather than claiming the whole machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+CORES_PER_WORKER = 8
+GB_PER_WORKER = 32
+RESERVE_CORES = 16
+RESERVE_GB = 64
+
+
+class CapacityError(Exception):
+    """The host cannot fit the requested or minimum worker count."""
+
+
+def read_available_gb(meminfo: str) -> int:
+    for line in meminfo.splitlines():
+        if line.startswith("MemAvailable:"):
+            return int(line.split()[1]) // (1024 * 1024)
+    raise ValueError("MemAvailable missing from meminfo")
+
+
+def parse_requested(value: str) -> int | None:
+    text = value.strip()
+    if not text:
+        return None
+    if not text.isdigit():
+        raise ValueError(f"--requested must be a positive integer, got {value!r}")
+    return int(text)
+
+
+def capacity(
+    cores: int,
+    available_gb: int,
+    reserve_cores: int = RESERVE_CORES,
+    reserve_gb: int = RESERVE_GB,
+) -> int:
+    usable_cores = max(0, cores - reserve_cores)
+    usable_gb = max(0, available_gb - reserve_gb)
+    return min(usable_cores // CORES_PER_WORKER, usable_gb // GB_PER_WORKER)
+
+
+def resolve(
+    cores: int,
+    available_gb: int,
+    requested: int | None,
+) -> tuple[int, str]:
+    limit = capacity(cores, available_gb)
+    measured = (
+        f"cores={cores} available_gb={available_gb} "
+        f"reserve_cores={RESERVE_CORES} reserve_gb={RESERVE_GB}"
+    )
+    if limit < 1:
+        raise CapacityError(
+            f"host fits no Terminal-Bench worker "
+            f"({CORES_PER_WORKER} cores + {GB_PER_WORKER}GB each): {measured}"
+        )
+    if requested is None:
+        return limit, f"workers={limit} derived from capacity ({measured})"
+    if requested < 1:
+        raise CapacityError(f"requested workers must be >= 1, got {requested}")
+    if requested > limit:
+        return limit, (
+            f"workers={limit}: requested {requested} reduced to capacity ({measured})"
+        )
+    return requested, f"workers={requested} requested, within capacity ({measured})"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requested", default="", help="Requested worker count; empty derives from capacity")
+    parser.add_argument("--meminfo", default="/proc/meminfo", type=Path)
+    args = parser.parse_args(argv)
+
+    # One try covers input parsing, meminfo reading and sizing so every
+    # failure reaches CI as a ::error:: annotation instead of a traceback.
+    try:
+        requested = parse_requested(args.requested)
+        cores = os.cpu_count() or 1
+        available_gb = read_available_gb(args.meminfo.read_text(encoding="utf-8"))
+        workers, note = resolve(cores, available_gb, requested)
+    except (CapacityError, ValueError, OSError) as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+
+    print(note)
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"workers={workers}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_e2e_harbor_gate.py
+++ b/.github/scripts/tests/test_e2e_harbor_gate.py
@@ -1,0 +1,265 @@
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / ".github" / "scripts" / "e2e_harbor_gate.py"
+
+spec = importlib.util.spec_from_file_location("e2e_harbor_gate", MODULE_PATH)
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+
+def summary(
+    status="complete",
+    exit_code="0",
+    total=89,
+    completed=85,
+    errored=3,
+    cancelled=1,
+    retries=2,
+    mean_reward="0.42",
+    counts=True,
+    include_totals=True,
+):
+    lines = [
+        f"status:      {status}",
+        "finished_at: 2026-08-19T18:37:00Z",
+        "RUN_ID:      e2e-1-1",
+        "AGENT:       claude-code",
+        "DATASET_NAME: terminal-bench/terminal-bench-2-1",
+        "MODEL:       deepseekv4-flash-0731",
+        f"harbor_exit_code: {exit_code}",
+        "",
+    ]
+    if status != "complete":
+        lines.extend(["failure_reason: Harbor exited without an aggregate result", ""])
+    if not include_totals:
+        lines.append("Harbor result summary: unavailable")
+    else:
+        lines.extend(
+            [
+                f"total:      {total}",
+                f"completed:  {completed}",
+                f"errored:    {errored}",
+                f"cancelled:  {cancelled}",
+                f"retries:    {retries}",
+                f"mean_reward: {mean_reward}",
+                "reward counts:",
+            ]
+        )
+        if counts:
+            lines.extend(["  reward=0.0: 50", "  reward=1.0: 35"])
+        else:
+            lines.append("  unavailable")
+        lines.extend(["", "Harbor stats:", "{", '  "n_completed_trials": 85', "}"])
+    lines.extend(
+        ["", "result paths:", "  output:          /runs/x", "  job:             /jobs/x"]
+    )
+    return "\n".join(lines) + "\n"
+
+
+class ParseSummaryTest(unittest.TestCase):
+    def test_reads_column_zero_fields(self):
+        fields = gate.parse_summary(summary())
+        self.assertEqual(fields["status"], "complete")
+        self.assertEqual(fields["total"], "89")
+        self.assertEqual(fields["harbor_exit_code"], "0")
+        self.assertEqual(fields["mean_reward"], "0.42")
+
+    def test_ignores_labels_containing_spaces(self):
+        # "reward counts:", "Harbor stats:" and "result paths:" are section
+        # headings, not fields, and must not become keys.
+        fields = gate.parse_summary(summary())
+        for absent in ("reward", "Harbor", "result"):
+            self.assertNotIn(absent, fields)
+
+    def test_ignores_indented_lines(self):
+        fields = gate.parse_summary(summary())
+        self.assertNotIn("output", fields)
+
+    def test_first_occurrence_wins(self):
+        text = summary() + "status:      failed\n"
+        self.assertEqual(gate.parse_summary(text)["status"], "complete")
+
+    def test_missing_totals_block_yields_no_total(self):
+        fields = gate.parse_summary(summary(include_totals=False))
+        self.assertNotIn("total", fields)
+
+
+class RewardCountsTest(unittest.TestCase):
+    def test_reads_the_indented_reward_histogram(self):
+        self.assertEqual(
+            gate.parse_reward_counts(summary()), {"0.0": 50, "1.0": 35}
+        )
+
+    def test_unavailable_histogram_is_empty(self):
+        self.assertEqual(gate.parse_reward_counts(summary(counts=False)), {})
+
+
+class IntFieldTest(unittest.TestCase):
+    def test_reads_an_integer(self):
+        self.assertEqual(gate.int_field({"total": "89"}, "total"), 89)
+
+    def test_absent_is_none(self):
+        self.assertIsNone(gate.int_field({}, "total"))
+
+    def test_non_numeric_is_none(self):
+        self.assertIsNone(gate.int_field({"total": "many"}, "total"))
+
+
+class EvaluateTest(unittest.TestCase):
+    def test_a_healthy_run_passes(self):
+        # 3 errored + 1 cancelled = 4 of 89; allowance is int(0.10*89) = 8.
+        verdict = gate.evaluate(summary())
+        self.assertTrue(verdict.passed, verdict.reasons)
+        self.assertEqual(verdict.stats["harness_failures"], 4)
+
+    def test_missing_summary_fails(self):
+        verdict = gate.evaluate(None)
+        self.assertFalse(verdict.passed)
+        self.assertIn("summary.txt", verdict.reasons[0])
+
+    def test_incomplete_status_fails_and_quotes_the_reason(self):
+        verdict = gate.evaluate(summary(status="failed"))
+        self.assertFalse(verdict.passed)
+        self.assertTrue(any("not 'complete'" in r for r in verdict.reasons))
+        self.assertTrue(any("aggregate result" in r for r in verdict.reasons))
+
+    def test_nonzero_harbor_exit_code_fails(self):
+        verdict = gate.evaluate(summary(exit_code="2"))
+        self.assertFalse(verdict.passed)
+        self.assertTrue(any("exited with code 2" in r for r in verdict.reasons))
+
+    def test_absent_totals_block_fails(self):
+        verdict = gate.evaluate(summary(include_totals=False))
+        self.assertFalse(verdict.passed)
+        self.assertTrue(any("no aggregate result" in r for r in verdict.reasons))
+
+    def test_zero_trials_fails(self):
+        verdict = gate.evaluate(
+            summary(total=0, completed=0, errored=0, cancelled=0, counts=False)
+        )
+        self.assertFalse(verdict.passed)
+        self.assertTrue(any("no trials ran" in r for r in verdict.reasons))
+
+    def test_unreconciled_trial_counts_fail(self):
+        verdict = gate.evaluate(summary(completed=10, errored=0, cancelled=0))
+        self.assertFalse(verdict.passed)
+        self.assertTrue(any("do not reconcile" in r for r in verdict.reasons))
+
+    def test_harness_failures_over_allowance_fail(self):
+        # 9 of 89 exceeds the allowance of 8.
+        verdict = gate.evaluate(summary(completed=80, errored=9, cancelled=0))
+        self.assertFalse(verdict.passed)
+        self.assertTrue(any("9 harness failures" in r for r in verdict.reasons))
+
+    def test_harness_failures_at_allowance_pass(self):
+        # 8 of 89 is exactly the allowance and must not fail.
+        verdict = gate.evaluate(summary(completed=81, errored=8, cancelled=0))
+        self.assertTrue(verdict.passed, verdict.reasons)
+
+    def test_failure_reason_quotes_counts_not_a_rounded_percentage(self):
+        # 9/89 rounds to 10%, so a percentage would read "10% exceeds 10%".
+        verdict = gate.evaluate(summary(completed=80, errored=9, cancelled=0))
+        reason = next(r for r in verdict.reasons if "harness failures" in r)
+        self.assertNotIn("%", reason)
+
+    def test_all_trials_unsolved_still_passes(self):
+        # Every trial completed with reward 0: a model signal, not a fleet bug.
+        text = summary(completed=89, errored=0, cancelled=0, mean_reward="0.0")
+        verdict = gate.evaluate(text)
+        self.assertTrue(verdict.passed, verdict.reasons)
+
+    def test_reasons_accumulate(self):
+        verdict = gate.evaluate(summary(status="failed", exit_code="3"))
+        self.assertGreaterEqual(len(verdict.reasons), 2)
+
+    def test_a_nonzero_shell_status_fails_an_otherwise_clean_run(self):
+        # Isolates the shell-status check: zellij died after the summary landed.
+        verdict = gate.evaluate(summary(), harbor_status=2)
+        self.assertFalse(verdict.passed)
+        self.assertTrue(
+            any("exited with status 2" in r for r in verdict.reasons)
+        )
+
+    def test_tolerance_is_configurable(self):
+        text = summary(completed=80, errored=9, cancelled=0)
+        self.assertTrue(
+            gate.evaluate(text, max_harness_failure_ratio=0.5).passed
+        )
+
+
+class RenderSummaryTest(unittest.TestCase):
+    def test_pass_renders_a_table_and_the_reward_distribution(self):
+        rendered = gate.render_summary(gate.evaluate(summary()))
+        self.assertIn("PASS", rendered)
+        self.assertIn("| Metric | Value |", rendered)
+        self.assertIn("reward=0.0", rendered)
+
+    def test_fail_lists_reasons(self):
+        rendered = gate.render_summary(gate.evaluate(summary(status="failed")))
+        self.assertIn("FAIL", rendered)
+        self.assertIn("### Why this failed", rendered)
+
+    def test_renders_without_a_summary_file(self):
+        # stats is nearly empty here; every lookup must be guarded.
+        rendered = gate.render_summary(gate.evaluate(None))
+        self.assertIn("FAIL", rendered)
+
+
+class MainTest(unittest.TestCase):
+    def _run(self, tmp, text, extra=None):
+        output = Path(tmp) / "runs" / "e2e-1-1"
+        output.mkdir(parents=True)
+        if text is not None:
+            (output / "summary.txt").write_text(text, encoding="utf-8")
+        step = Path(tmp) / "step.md"
+        argv = ["--output-path", str(output), "--step-summary", str(step)]
+        argv.extend(extra or [])
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr), contextlib.redirect_stdout(io.StringIO()):
+            code = gate.main(argv)
+        return code, step.read_text(encoding="utf-8"), stderr.getvalue()
+
+    def test_healthy_run_exits_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code, step, _ = self._run(tmp, summary())
+        self.assertEqual(code, 0)
+        self.assertIn("PASS", step)
+
+    def test_broken_run_exits_one_and_annotates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code, step, err = self._run(tmp, summary(status="failed"))
+        self.assertEqual(code, 1)
+        self.assertIn("FAIL", step)
+        self.assertIn("::error::", err)
+
+    def test_absent_summary_exits_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code, step, _ = self._run(tmp, None)
+        self.assertEqual(code, 1)
+        self.assertIn("summary.txt", step)
+
+    def test_writes_to_github_step_summary_env_var(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "runs" / "e2e-1-1"
+            output.mkdir(parents=True)
+            (output / "summary.txt").write_text(summary(), encoding="utf-8")
+            step = Path(tmp) / "env-step.md"
+            with mock.patch.dict(
+                os.environ, {"GITHUB_STEP_SUMMARY": str(step)}
+            ), contextlib.redirect_stdout(io.StringIO()):
+                code = gate.main(["--output-path", str(output)])
+            # Assert inside the with block: step lives in the temp dir.
+            self.assertEqual(code, 0)
+            self.assertIn("PASS", step.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_e2e_harbor_gate.py
+++ b/.github/scripts/tests/test_e2e_harbor_gate.py
@@ -115,10 +115,10 @@ class IntFieldTest(unittest.TestCase):
 
 class EvaluateTest(unittest.TestCase):
     def test_a_healthy_run_passes(self):
-        # 3 errored + 1 cancelled = 4 of 89; allowance is int(0.10*89) = 8.
+        # 85 completed of 89, so 4 never completed; allowance is int(0.10*89)=8.
         verdict = gate.evaluate(summary())
         self.assertTrue(verdict.passed, verdict.reasons)
-        self.assertEqual(verdict.stats["harness_failures"], 4)
+        self.assertEqual(verdict.stats["unresolved"], 4)
 
     def test_missing_summary_fails(self):
         verdict = gate.evaluate(None)
@@ -148,26 +148,66 @@ class EvaluateTest(unittest.TestCase):
         self.assertFalse(verdict.passed)
         self.assertTrue(any("no trials ran" in r for r in verdict.reasons))
 
-    def test_unreconciled_trial_counts_fail(self):
+    def test_a_retried_trial_counted_twice_still_passes(self):
+        # Harbor counts a trial that errored then succeeded on retry in BOTH
+        # n_errored_trials and n_completed_trials. The repo's own fixture
+        # (test_harboropik_extra_compose.sh:118-123) is total=2, completed=2,
+        # errored=1, so accounted=3 > total=2 on a healthy run. With
+        # HARBOR_MAX_RETRIES defaulting to 2 this is the common case, not an
+        # edge case.
+        verdict = gate.evaluate(summary(total=2, completed=2, errored=1, cancelled=0, retries=1))
+        self.assertTrue(verdict.passed, verdict.reasons)
+        self.assertEqual(verdict.stats["unresolved"], 0)
+
+    def test_a_full_nightly_that_recovers_every_error_passes(self):
+        # 89 trials, 12 transient errors all retried to completion.
+        verdict = gate.evaluate(
+            summary(total=89, completed=89, errored=12, cancelled=0, retries=12)
+        )
+        self.assertTrue(verdict.passed, verdict.reasons)
+
+    def test_missing_trials_fail(self):
+        # A shortfall means trials vanished rather than being retried.
         verdict = gate.evaluate(summary(completed=10, errored=0, cancelled=0))
         self.assertFalse(verdict.passed)
-        self.assertTrue(any("do not reconcile" in r for r in verdict.reasons))
+        self.assertTrue(any("unaccounted for" in r for r in verdict.reasons))
 
-    def test_harness_failures_over_allowance_fail(self):
-        # 9 of 89 exceeds the allowance of 8.
+    def test_never_completed_over_allowance_fails(self):
+        # 9 of 89 never completed, exceeding the allowance of 8.
         verdict = gate.evaluate(summary(completed=80, errored=9, cancelled=0))
         self.assertFalse(verdict.passed)
-        self.assertTrue(any("9 harness failures" in r for r in verdict.reasons))
+        self.assertTrue(
+            any("9 of 89 trials never completed" in r for r in verdict.reasons)
+        )
 
-    def test_harness_failures_at_allowance_pass(self):
+    def test_never_completed_at_allowance_passes(self):
         # 8 of 89 is exactly the allowance and must not fail.
         verdict = gate.evaluate(summary(completed=81, errored=8, cancelled=0))
+        self.assertTrue(verdict.passed, verdict.reasons)
+
+    def test_cancelled_trials_count_as_never_completed(self):
+        verdict = gate.evaluate(summary(total=89, completed=80, errored=0, cancelled=9))
+        self.assertFalse(verdict.passed)
+        self.assertEqual(verdict.stats["unresolved"], 9)
+
+    def test_expected_trial_count_mismatch_fails(self):
+        # Task selection silently not reaching Harbor: 89 ran, 4 requested.
+        verdict = gate.evaluate(summary(), expected_trials=4)
+        self.assertFalse(verdict.passed)
+        self.assertTrue(any("expected 4 trials" in r for r in verdict.reasons))
+
+    def test_expected_trial_count_match_passes(self):
+        verdict = gate.evaluate(summary(), expected_trials=89)
+        self.assertTrue(verdict.passed, verdict.reasons)
+
+    def test_expected_trial_count_is_optional(self):
+        verdict = gate.evaluate(summary(), expected_trials=None)
         self.assertTrue(verdict.passed, verdict.reasons)
 
     def test_failure_reason_quotes_counts_not_a_rounded_percentage(self):
         # 9/89 rounds to 10%, so a percentage would read "10% exceeds 10%".
         verdict = gate.evaluate(summary(completed=80, errored=9, cancelled=0))
-        reason = next(r for r in verdict.reasons if "harness failures" in r)
+        reason = next(r for r in verdict.reasons if "never completed" in r)
         self.assertNotIn("%", reason)
 
     def test_all_trials_unsolved_still_passes(self):

--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -1,0 +1,123 @@
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "harbor-e2e-validation.yml"
+TASK_LIST = ROOT / "Tasks" / "Terminal-bench-2" / "harbor_terminalbench21_tasks.txt"
+
+CANARY_TASKS = (
+    "fix-git",
+    "filter-js-from-html",
+    "sqlite-db-truncate",
+    "openssl-selfsigned-cert",
+)
+
+
+class E2eValidationWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_targets_a_bare_metal_runner(self):
+        # The container runners are a label superset of [self-hosted, Linux, X64]
+        # and have no Docker daemon, so the bare-metal label is required.
+        self.assertIn(
+            "runs-on: [self-hosted, Linux, X64, bare-metal]",
+            self.workflow,
+        )
+
+    def test_runs_only_on_dispatch_and_schedule(self):
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertIn("schedule:", self.workflow)
+        self.assertNotIn("pull_request", self.workflow)
+
+    def test_schedule_avoids_the_top_and_half_hour(self):
+        match = re.search(r'- cron: "(\d+) ', self.workflow)
+        self.assertIsNotNone(match)
+        self.assertNotIn(int(match.group(1)), (0, 30))
+
+    def test_uses_the_self_hosted_environment(self):
+        self.assertIn("environment: self-hosted-env", self.workflow)
+
+    def test_uses_least_privilege_and_pinned_actions(self):
+        self.assertIn("permissions:\n  contents: read", self.workflow)
+        self.assertIn("persist-credentials: false", self.workflow)
+        for action in ("actions/checkout", "actions/upload-artifact"):
+            with self.subTest(action=action):
+                self.assertRegex(
+                    self.workflow,
+                    re.compile(rf"uses: {re.escape(action)}@[0-9a-f]{{40}} # v"),
+                )
+
+    def test_checks_out_submodules_for_opik_tracing(self):
+        self.assertIn("submodules: recursive", self.workflow)
+        self.assertIn('TRACE_TO_OPIK: "true"', self.workflow)
+
+    def test_never_cancels_a_running_benchmark(self):
+        self.assertIn("cancel-in-progress: false", self.workflow)
+
+    def test_caps_job_duration(self):
+        self.assertIn("timeout-minutes: 720", self.workflow)
+
+    def test_strips_the_chat_completions_suffix_from_the_gateway_url(self):
+        # env.sh strips a trailing /v1 but not /chat/completions.
+        self.assertIn('BASE_URL="${BASE_URL_RAW%/chat/completions}"', self.workflow)
+
+    def test_bounds_per_task_time_and_enables_online_analysis(self):
+        self.assertIn('HARBOR_TIMEOUT_MULTIPLIER: "1.0"', self.workflow)
+        self.assertIn('HARBOR_ONLINE_ANALYSIS: "1"', self.workflow)
+
+    def test_pins_zellij_cleanup_for_a_pty_run(self):
+        # script(1) gives the step a pty, which would otherwise flip
+        # start.sh's HARBOR_ZELLIJ_KEEP_ON_FAILURE default to 1.
+        self.assertIn('HARBOR_ZELLIJ_KEEP_ON_FAILURE: "0"', self.workflow)
+
+    def test_runs_harbor_under_script_to_allocate_a_pty(self):
+        self.assertIn("script -e -q -c", self.workflow)
+
+    def test_derives_workers_from_host_capacity(self):
+        self.assertIn("e2e_worker_capacity.py", self.workflow)
+        self.assertIn("steps.capacity.outputs.workers", self.workflow)
+
+    def test_gates_on_pipeline_health(self):
+        self.assertIn("e2e_harbor_gate.py", self.workflow)
+        self.assertIn("--max-harness-failure-ratio 0.10", self.workflow)
+
+    def test_redacts_artifacts_before_upload(self):
+        self.assertIn("Stage and redact artifacts", self.workflow)
+        redact_index = self.workflow.index("Stage and redact artifacts")
+        upload_index = self.workflow.index("Upload run artifacts")
+        self.assertLess(redact_index, upload_index)
+
+    def test_refuses_to_redact_with_an_empty_key(self):
+        # bytes.replace(b"", ...) would corrupt every artifact and
+        # grep -F "" would match every file, so both uses must be guarded.
+        self.assertEqual(self.workflow.count('if [[ -z "$API_KEY" ]]; then'), 2)
+
+    def test_pins_a_deterministic_zellij_session_name(self):
+        # env.sh's default session name contains no RUN_ID, so cleanup
+        # could not otherwise find the session it needs to kill.
+        self.assertEqual(
+            self.workflow.count(
+                "ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}"
+            ),
+            2,
+        )
+
+    def test_does_not_use_interactive_setup(self):
+        # setup.sh prompts for missing credentials and would persist the key.
+        self.assertNotIn("scripts/setup.sh", self.workflow)
+
+    def test_canary_tasks_exist_in_the_terminalbench21_task_list(self):
+        available = set(TASK_LIST.read_text(encoding="utf-8").split())
+        for task in CANARY_TASKS:
+            with self.subTest(task=task):
+                self.assertIn(task, available)
+
+    def test_canary_tasks_are_the_documented_dispatch_default(self):
+        self.assertIn("CANARY_TASKS: " + ",".join(CANARY_TASKS), self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -52,7 +52,50 @@ class E2eValidationWorkflowTest(unittest.TestCase):
 
     def test_checks_out_submodules_for_opik_tracing(self):
         self.assertIn("submodules: recursive", self.workflow)
-        self.assertIn('TRACE_TO_OPIK: "true"', self.workflow)
+
+    def test_enables_tracing_only_with_a_real_opik_credential(self):
+        # env.sh substitutes the literal local-dev-key for a missing
+        # OPIK_API_KEY and harboropik.sh's preflight accepts 401/403, so an
+        # unconditional TRACE_TO_OPIK=true would look healthy while no trace
+        # reached Opik.
+        self.assertNotIn('TRACE_TO_OPIK: "true"', self.workflow)
+        self.assertIn("secrets.OPIK_API_KEY", self.workflow)
+        self.assertIn("export TRACE_TO_OPIK=true", self.workflow)
+        self.assertIn("export TRACE_TO_OPIK=false", self.workflow)
+
+    def test_redacts_every_credential_it_injects(self):
+        redact = self.workflow[self.workflow.index("Stage and redact artifacts"):]
+        for name in ("API_KEY", "OPIK_API_KEY"):
+            with self.subTest(credential=name):
+                self.assertIn(name, redact)
+
+    def test_pins_the_output_path_for_producer_and_consumers(self):
+        # A runner-level OUTPUT_ROOT/OUTPUT_PATH would otherwise win via
+        # config_loader.sh and Harbor would write outside runs/$RUN_ID.
+        self.assertIn(
+            "OUTPUT_PATH: ${{ steps.params.outputs.output_path }}",
+            self.workflow,
+        )
+        self.assertIn("export OUTPUT_PATH", self.workflow)
+
+    def test_rejects_a_truncated_run(self):
+        self.assertIn("expected_trials", self.workflow)
+        self.assertIn("--expected-trials", self.workflow)
+
+    def test_never_prunes_the_shared_docker_daemon(self):
+        # These hosts also run the code-review container runners; a daemon-wide
+        # prune deletes their stopped containers and dangling build layers.
+        # Match executable lines only -- the comments explaining the absence of
+        # these commands legitimately name them.
+        code = [
+            line
+            for line in self.workflow.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        for destructive in ("container prune", "image prune", "system prune"):
+            with self.subTest(command=destructive):
+                offenders = [line for line in code if destructive in line]
+                self.assertEqual(offenders, [])
 
     def test_never_cancels_a_running_benchmark(self):
         self.assertIn("cancel-in-progress: false", self.workflow)

--- a/.github/scripts/tests/test_e2e_worker_capacity.py
+++ b/.github/scripts/tests/test_e2e_worker_capacity.py
@@ -1,0 +1,150 @@
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / ".github" / "scripts" / "e2e_worker_capacity.py"
+
+spec = importlib.util.spec_from_file_location("e2e_worker_capacity", MODULE_PATH)
+capacity_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(capacity_module)
+
+
+class ReadAvailableGbTest(unittest.TestCase):
+    def test_reads_mem_available_in_gibibytes(self):
+        meminfo = "\n".join(
+            [
+                "MemTotal:       1610612736 kB",
+                "MemFree:         104857600 kB",
+                "MemAvailable:   1572864000 kB",
+            ]
+        )
+        self.assertEqual(capacity_module.read_available_gb(meminfo), 1500)
+
+    def test_rejects_meminfo_without_mem_available(self):
+        with self.assertRaises(ValueError):
+            capacity_module.read_available_gb("MemTotal: 123 kB")
+
+
+class CapacityTest(unittest.TestCase):
+    def test_cpu_binds_on_the_current_bare_hosts(self):
+        # 128 cores, 1.5 TB: (128-16)//8 = 14 vs (1536-64)//32 = 46
+        self.assertEqual(capacity_module.capacity(128, 1536), 14)
+
+    def test_memory_can_bind_instead(self):
+        # 128 cores but only 192 GB available: 14 vs (192-64)//32 = 4
+        self.assertEqual(capacity_module.capacity(128, 192), 4)
+
+    def test_reserves_headroom_for_colocated_container_runners(self):
+        # Without the 16-core reserve this would be 128//8 = 16
+        self.assertLess(capacity_module.capacity(128, 1536), 16)
+
+    def test_small_host_has_no_capacity(self):
+        self.assertEqual(capacity_module.capacity(16, 64), 0)
+
+
+class ResolveTest(unittest.TestCase):
+    def test_uses_full_capacity_when_nothing_requested(self):
+        workers, note = capacity_module.resolve(128, 1536, None)
+        self.assertEqual(workers, 14)
+        self.assertIn("14", note)
+
+    def test_reduces_a_request_above_capacity_and_says_so(self):
+        workers, note = capacity_module.resolve(128, 1536, 40)
+        self.assertEqual(workers, 14)
+        self.assertIn("reduced", note.lower())
+
+    def test_honours_a_request_below_capacity(self):
+        workers, note = capacity_module.resolve(128, 1536, 4)
+        self.assertEqual(workers, 4)
+        self.assertNotIn("reduced", note.lower())
+
+    def test_rejects_a_request_below_one(self):
+        with self.assertRaises(capacity_module.CapacityError):
+            capacity_module.resolve(128, 1536, 0)
+
+    def test_fails_fast_when_the_host_cannot_fit_one_worker(self):
+        with self.assertRaises(capacity_module.CapacityError):
+            capacity_module.resolve(16, 64, None)
+
+
+class ParseRequestedTest(unittest.TestCase):
+    def test_empty_means_derive_from_capacity(self):
+        self.assertIsNone(capacity_module.parse_requested("  "))
+
+    def test_reads_a_positive_integer(self):
+        self.assertEqual(capacity_module.parse_requested(" 6 "), 6)
+
+    def test_rejects_non_numeric(self):
+        with self.assertRaises(ValueError):
+            capacity_module.parse_requested("abc")
+
+    def test_rejects_a_float(self):
+        with self.assertRaises(ValueError):
+            capacity_module.parse_requested("4.5")
+
+
+class MainTest(unittest.TestCase):
+    def _meminfo(self, tmp, text="MemAvailable:   1572864000 kB\n"):
+        path = Path(tmp) / "meminfo"
+        path.write_text(text, encoding="utf-8")
+        return str(path)
+
+    def test_writes_the_worker_count_to_github_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "gh-output"
+            with mock.patch("os.cpu_count", return_value=128), mock.patch.dict(
+                os.environ, {"GITHUB_OUTPUT": str(output)}
+            ):
+                code = capacity_module.main(["--meminfo", self._meminfo(tmp)])
+            self.assertEqual(code, 0)
+            self.assertEqual(output.read_text(encoding="utf-8"), "workers=14\n")
+
+    def test_malformed_requested_value_fails_cleanly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = capacity_module.main(
+                    ["--requested", "abc", "--meminfo", self._meminfo(tmp)]
+                )
+        self.assertEqual(code, 1)
+        self.assertIn("::error::", stderr.getvalue())
+
+    def test_missing_meminfo_fails_cleanly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = capacity_module.main(
+                    ["--meminfo", str(Path(tmp) / "absent")]
+                )
+        self.assertEqual(code, 1)
+        self.assertIn("::error::", stderr.getvalue())
+
+    def test_meminfo_without_mem_available_fails_cleanly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = capacity_module.main(
+                    ["--meminfo", self._meminfo(tmp, "MemTotal: 123 kB\n")]
+                )
+        self.assertEqual(code, 1)
+        self.assertIn("::error::", stderr.getvalue())
+
+    def test_a_host_too_small_for_one_worker_fails_cleanly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stderr = io.StringIO()
+            with mock.patch("os.cpu_count", return_value=4), contextlib.redirect_stderr(
+                stderr
+            ):
+                code = capacity_module.main(["--meminfo", self._meminfo(tmp)])
+        self.assertEqual(code, 1)
+        self.assertIn("::error::", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -1,0 +1,216 @@
+name: Harbor E2E Validation
+
+"on":
+  workflow_dispatch:
+    inputs:
+      tasks:
+        description: Comma-separated tb21 task names; empty runs the canary set
+        required: false
+        type: string
+      agent:
+        description: claude-code or opencode
+        required: false
+        default: claude-code
+        type: string
+      workers:
+        description: Concurrency; empty derives from host capacity
+        required: false
+        type: string
+  schedule:
+    - cron: "37 18 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: harbor-e2e-validation
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: Harbor terminalbench21 e2e
+    runs-on: [self-hosted, Linux, X64, bare-metal]
+    environment: self-hosted-env
+    timeout-minutes: 720
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Validate prerequisites
+        run: |
+          set -euo pipefail
+          export AGENT_FLEET_REQUIRE_DOCKER=1
+          # shellcheck source=scripts/prerequisites.sh
+          source scripts/prerequisites.sh
+          agent_fleet_bootstrap_setup_prerequisites
+
+      - name: Check host capacity
+        id: capacity
+        env:
+          REQUESTED_WORKERS: ${{ inputs.workers }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/e2e_worker_capacity.py --requested "${REQUESTED_WORKERS:-}"
+
+      - name: Check disk headroom
+        env:
+          MINIMUM_FREE_GB: "200"
+        run: |
+          set -euo pipefail
+          docker image prune --force >/dev/null
+          root="$(docker info --format '{{.DockerRootDir}}')"
+          free_gb="$(df -BG --output=avail "$root" | tail -n 1 | tr -dc '0-9')"
+          printf 'docker root %s has %sGB free\n' "$root" "$free_gb"
+          if (( free_gb < MINIMUM_FREE_GB )); then
+            echo "::error::docker root $root has ${free_gb}GB free, need ${MINIMUM_FREE_GB}GB" >&2
+            exit 1
+          fi
+
+      - name: Resolve run parameters
+        id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TASKS: ${{ inputs.tasks }}
+          INPUT_AGENT: ${{ inputs.agent }}
+          RUN_ID: e2e-${{ github.run_id }}-${{ github.run_attempt }}
+          CANARY_TASKS: fix-git,filter-js-from-html,sqlite-db-truncate,openssl-selfsigned-cert
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            tasks="${INPUT_TASKS:-$CANARY_TASKS}"
+          else
+            tasks=""
+          fi
+          agent="${INPUT_AGENT:-claude-code}"
+          case "$agent" in
+            claude-code|opencode) ;;
+            *) echo "::error::unsupported agent: $agent" >&2; exit 1 ;;
+          esac
+          {
+            printf 'tasks=%s\n' "$tasks"
+            printf 'agent=%s\n' "$agent"
+            printf 'run_id=%s\n' "$RUN_ID"
+            printf 'output_path=runs/%s\n' "$RUN_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate task selection
+        if: ${{ steps.params.outputs.tasks != '' }}
+        env:
+          TASKS: ${{ steps.params.outputs.tasks }}
+          AGENT: ${{ steps.params.outputs.agent }}
+        run: |
+          set -euo pipefail
+          scripts/run_fleet.sh \
+            --taskset terminalbench21 \
+            --agent "$AGENT" \
+            --task "$TASKS" \
+            --validate-task-selection
+
+      - name: Run Harbor benchmark
+        id: harbor
+        env:
+          BASE_URL_RAW: ${{ vars.LLM_REVIEW_BASE_URL }}
+          API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
+          MODEL: ${{ vars.LLM_REVIEW_MODEL }}
+          OPIK_URL: ${{ vars.OPIK_URL }}
+          TRACE_TO_OPIK: "true"
+          OPIK_PROJECT_NAME: harbor-e2e-validation
+          AGENT: ${{ steps.params.outputs.agent }}
+          TASKS: ${{ steps.params.outputs.tasks }}
+          WORKERS: ${{ steps.capacity.outputs.workers }}
+          RUN_ID: ${{ steps.params.outputs.run_id }}
+          ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
+          HARBOR_TIMEOUT_MULTIPLIER: "1.0"
+          HARBOR_ONLINE_ANALYSIS: "1"
+          HARBOR_ZELLIJ_KEEP_ON_FAILURE: "0"
+        run: |
+          set -euo pipefail
+          if [[ -z "$API_KEY" ]]; then
+            echo "::error::LLM_REVIEW_API_KEY is empty; is the job missing the self-hosted-env environment?" >&2
+            exit 1
+          fi
+          export BASE_URL="${BASE_URL_RAW%/chat/completions}"
+          export TOTAL_WORKERS="$WORKERS"
+          export HARBOR_N_CONCURRENT="$WORKERS"
+
+          command=(scripts/run_fleet.sh --taskset terminalbench21 --agent "$AGENT" --workers "$WORKERS")
+          if [[ -n "$TASKS" ]]; then
+            command+=(--task "$TASKS")
+          fi
+
+          status=0
+          script -e -q -c "$(printf '%q ' "${command[@]}")" /dev/null || status=$?
+          printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
+          printf 'Harbor exit status: %s\n' "$status"
+
+      - name: Evaluate pipeline health
+        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
+        env:
+          HARBOR_STATUS: ${{ steps.harbor.outputs.status }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/e2e_harbor_gate.py \
+            --output-path "${{ steps.params.outputs.output_path }}" \
+            --harbor-status "${HARBOR_STATUS:-1}" \
+            --max-harness-failure-ratio 0.10
+
+      - name: Stage and redact artifacts
+        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
+        env:
+          API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
+          OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$API_KEY" ]]; then
+            # An empty needle would make replace() and grep -F match everything.
+            echo "::error::API_KEY is empty; refusing to stage artifacts unredacted" >&2
+            exit 1
+          fi
+          staged="${RUNNER_TEMP}/e2e-artifacts"
+          rm -rf "$staged"
+          mkdir -p "$staged"
+          cp -R "$OUTPUT_PATH/." "$staged/"
+          while IFS= read -r -d '' file; do
+            python3 - "$file" <<'PY'
+          import os
+          import sys
+
+          path = sys.argv[1]
+          key = os.environ["API_KEY"]
+          with open(path, "rb") as handle:
+              data = handle.read()
+          replaced = data.replace(key.encode(), b"***")
+          if replaced != data:
+              with open(path, "wb") as handle:
+                  handle.write(replaced)
+          PY
+          done < <(find "$staged" -type f -print0)
+          if grep -rqF -- "$API_KEY" "$staged"; then
+            echo "::error::API key still present in staged artifacts after redaction" >&2
+            exit 1
+          fi
+          printf 'staged=%s\n' "$staged" >> "$GITHUB_ENV"
+
+      - name: Upload run artifacts
+        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: harbor-e2e-${{ steps.params.outputs.run_id }}
+          path: ${{ env.staged }}
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Clean up
+        if: always()
+        env:
+          ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          # The run step pinned this name; Harbor's own default contains no RUN_ID.
+          zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+          zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+          docker container prune --force >/dev/null 2>&1 || true

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -61,12 +61,16 @@ jobs:
           MINIMUM_FREE_GB: "200"
         run: |
           set -euo pipefail
-          docker image prune --force >/dev/null
+          # No prune here. These hosts also run the code-review container
+          # runners, and `docker image prune` deletes every dangling image on
+          # the shared daemon -- including a concurrent build's untagged
+          # intermediates, which aborts that build. Report and fail instead;
+          # reclaiming shared disk is an operator decision.
           root="$(docker info --format '{{.DockerRootDir}}')"
           free_gb="$(df -BG --output=avail "$root" | tail -n 1 | tr -dc '0-9')"
           printf 'docker root %s has %sGB free\n' "$root" "$free_gb"
           if (( free_gb < MINIMUM_FREE_GB )); then
-            echo "::error::docker root $root has ${free_gb}GB free, need ${MINIMUM_FREE_GB}GB" >&2
+            echo "::error::docker root $root has ${free_gb}GB free, need ${MINIMUM_FREE_GB}GB; reclaim space on the runner before rerunning" >&2
             exit 1
           fi
 
@@ -97,6 +101,25 @@ jobs:
             printf 'output_path=runs/%s\n' "$RUN_ID"
           } >> "$GITHUB_OUTPUT"
 
+          # The expected trial count guards against task selection silently not
+          # reaching Harbor: a truncated run whose trials all pass would
+          # otherwise satisfy the gate and report a healthy fleet.
+          # Harbor runs each task HARBOR_RUNS times (`harbor run -k`), so trials
+          # are tasks x attempts. N_ATTEMPTS defaults to 1.
+          attempts="${HARBOR_RUNS:-${N_ATTEMPTS:-1}}"
+          if [[ ! "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::HARBOR_RUNS must be a positive integer, got: $attempts" >&2
+            exit 1
+          fi
+          if [[ -n "$tasks" ]]; then
+            task_count="$(printf '%s' "$tasks" | tr ',' '\n' | grep -c '[^[:space:]]')"
+          else
+            task_count="$(grep -c '[^[:space:]]' Tasks/Terminal-bench-2/harbor_terminalbench21_tasks.txt)"
+          fi
+          expected=$(( task_count * attempts ))
+          printf 'expected_trials=%s\n' "$expected" >> "$GITHUB_OUTPUT"
+          printf 'expecting %s trials (%s tasks x %s attempts)\n' "$expected" "$task_count" "$attempts"
+
       - name: Validate task selection
         if: ${{ steps.params.outputs.tasks != '' }}
         env:
@@ -117,12 +140,14 @@ jobs:
           API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
           MODEL: ${{ vars.LLM_REVIEW_MODEL }}
           OPIK_URL: ${{ vars.OPIK_URL }}
-          TRACE_TO_OPIK: "true"
+          OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
+          OPIK_WORKSPACE: ${{ vars.OPIK_WORKSPACE }}
           OPIK_PROJECT_NAME: harbor-e2e-validation
           AGENT: ${{ steps.params.outputs.agent }}
           TASKS: ${{ steps.params.outputs.tasks }}
           WORKERS: ${{ steps.capacity.outputs.workers }}
           RUN_ID: ${{ steps.params.outputs.run_id }}
+          OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
           ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
           HARBOR_TIMEOUT_MULTIPLIER: "1.0"
           HARBOR_ONLINE_ANALYSIS: "1"
@@ -136,6 +161,24 @@ jobs:
           export BASE_URL="${BASE_URL_RAW%/chat/completions}"
           export TOTAL_WORKERS="$WORKERS"
           export HARBOR_N_CONCURRENT="$WORKERS"
+          # Only enable tracing when a real Opik credential is present. env.sh
+          # substitutes the literal 'local-dev-key' for a missing OPIK_API_KEY,
+          # and harboropik.sh's preflight accepts 401/403, so tracing would
+          # appear healthy while no trace reached Opik. Fail loud or run
+          # untraced instead of silently pretending.
+          if [[ -n "${OPIK_API_KEY:-}" && -n "${OPIK_URL:-}" ]]; then
+            export TRACE_TO_OPIK=true
+            printf 'Opik tracing enabled for %s\n' "$OPIK_URL"
+          else
+            export TRACE_TO_OPIK=false
+            echo "::warning::OPIK_API_KEY or OPIK_URL is unset; running without tracing. Add OPIK_API_KEY to the self-hosted-env environment to enable it."
+          fi
+          # OUTPUT_PATH is exported, not left to env.sh's default. A runner-level
+          # OUTPUT_ROOT or OUTPUT_PATH would otherwise win (config_loader.sh gives
+          # runtime env top precedence) and Harbor would write its summary
+          # somewhere the gate and the artifact staging do not look, reporting a
+          # healthy run as a missing summary.txt.
+          export OUTPUT_PATH
 
           command=(scripts/run_fleet.sh --taskset terminalbench21 --agent "$AGENT" --workers "$WORKERS")
           if [[ -n "$TASKS" ]]; then
@@ -156,12 +199,14 @@ jobs:
           python3 .github/scripts/e2e_harbor_gate.py \
             --output-path "${{ steps.params.outputs.output_path }}" \
             --harbor-status "${HARBOR_STATUS:-1}" \
+            --expected-trials "${{ steps.params.outputs.expected_trials }}" \
             --max-harness-failure-ratio 0.10
 
       - name: Stage and redact artifacts
         if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
         env:
           API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
+          OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
           OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
         run: |
           set -euo pipefail
@@ -180,10 +225,19 @@ jobs:
           import sys
 
           path = sys.argv[1]
-          key = os.environ["API_KEY"]
+          # Redact every credential this job puts in the benchmark environment.
+          # Skip empties: an empty needle inserts the marker between every byte.
+          keys = [
+              value
+              for name in ("API_KEY", "OPIK_API_KEY")
+              for value in (os.environ.get(name, ""),)
+              if value
+          ]
           with open(path, "rb") as handle:
               data = handle.read()
-          replaced = data.replace(key.encode(), b"***")
+          replaced = data
+          for key in keys:
+              replaced = replaced.replace(key.encode(), b"***")
           if replaced != data:
               with open(path, "wb") as handle:
                   handle.write(replaced)
@@ -191,6 +245,10 @@ jobs:
           done < <(find "$staged" -type f -print0)
           if grep -rqF -- "$API_KEY" "$staged"; then
             echo "::error::API key still present in staged artifacts after redaction" >&2
+            exit 1
+          fi
+          if [[ -n "${OPIK_API_KEY:-}" ]] && grep -rqF -- "$OPIK_API_KEY" "$staged"; then
+            echo "::error::Opik key still present in staged artifacts after redaction" >&2
             exit 1
           fi
           printf 'staged=%s\n' "$staged" >> "$GITHUB_ENV"
@@ -213,4 +271,12 @@ jobs:
           # The run step pinned this name; Harbor's own default contains no RUN_ID.
           zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
           zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
-          docker container prune --force >/dev/null 2>&1 || true
+          # Deliberately no container pruning. `docker container prune` removes
+          # every stopped container on the shared daemon, which would delete
+          # containers the co-located code-review runners or an operator kept
+          # for restart or diagnosis. Harbor's trial containers are created by
+          # the harbor CLI rather than a compose project this workflow names, so
+          # there is no label to scope a targeted removal to. Harbor tears down
+          # its own trial containers; leftovers are an operator concern, not
+          # something this job should guess at on a shared host.
+          docker ps -a --format '{{.Names}}\t{{.Status}}' 2>/dev/null | head -20 || true


### PR DESCRIPTION
## Why the change

There is no automated end-to-end check that the Harbor benchmark fleet still works. Breakage in dataset resolution, agent install, or image pulls is only found when someone runs a benchmark by hand.

## Summary of the change

A nightly and on-demand workflow that runs Harbor `terminalbench21` on the bare-metal self-hosted runners, plus two unit-tested helper modules and a workflow contract test.

The gate **fails only on fleet breakage, never on model performance.** Harbor already draws that line for us: `errored` and `cancelled` trials mean the harness broke, while `completed` trials carrying reward 0 are task outcomes. Unsolved tasks and the reward distribution are reported to the step summary without reddening the job.

| File | Responsibility |
| --- | --- |
| `.github/workflows/harbor-e2e-validation.yml` | Trigger, runner targeting, credential mapping, orchestration |
| `.github/scripts/e2e_worker_capacity.py` | Derive worker count from cores and `MemAvailable` |
| `.github/scripts/e2e_harbor_gate.py` | Parse the registry summary, decide pass/fail, render the step summary |
| 3 × `.github/scripts/tests/test_e2e_*.py` | Unit and workflow-contract tests |

## Other details

**Runner targeting.** `runs-on: [self-hosted, Linux, X64, bare-metal]`. Plain `[self-hosted, Linux, X64]` also matches the 14 `code-review` container runners, since `runs-on` selects any runner whose labels are a superset of what you request — and those have no Docker daemon for Harbor to use. A `bare-metal` label was added to `cpu-nat-093` and `cpu-nat-360` to make "bare host only" expressible.

**Worker count is derived at runtime, not hardcoded.** Terminal-Bench needs 8 cores and 32 GB per worker, and nothing in this repo enforces that, so a fixed count would silently oversubscribe the host and the workers would starve. Capacity is `min((nproc - 16) / 8, (MemAvailable_GB - 64) / 32)`, reserving headroom for the co-located container runners so a benchmark run cannot starve PR review. On the current hosts that resolves to 14.

**Harbor runs under `script(1)`.** `start.sh`'s foreground path runs `zellij --new-session-with-layout`, which needs a TTY that Actions does not provide. `script -e -q -c` supplies one and propagates the child's exit status. `prerequisites.sh:381` already asserts `script -q -c` works, so this is not a new dependency.

**`HARBOR_ZELLIJ_KEEP_ON_FAILURE=0` is load-bearing.** Under a pty, `start.sh:36-41` would default it to `1`, and `run_harbor_registry.sh:31` then sleeps forever on failure — holding a runner for the full 720-minute timeout instead of reporting.

**The gate reads the registry summary, not the worker queue files.** `terminalbench21` resolves to a Harbor registry dataset unconditionally (`env.sh:55,967`), so the run uses the single-pane layout via `run_harbor_registry.sh` and `run_harbor_worker.sh` never executes. `done.txt` and `failed.txt` are touched empty by `harbor_init_run_dirs` and never written, so reading them would report `0 of 89` and fail every run including a flawless one. The gate parses `summary.txt` as written by `write_harbor_registry_summary.py` instead.

**Trigger choice.** `workflow_dispatch` and `schedule` only. `self-hosted-env` is restricted to protected branches, so a `pull_request` run could not read the API key; `pull_request_target` could, but would mean running PR head code on a bare host with a live key and a Docker socket. Not worth the coverage. Scheduled runs cover all 89 tasks; dispatch defaults to a 4-task canary and accepts `tasks`/`agent`/`workers` overrides.

**Secret handling.** Credentials come from the `self-hosted-env` environment and are never written to disk — `scripts/setup.sh` is deliberately not used, since it prompts for missing values and would persist the key into `config.local.env` on a shared host. Artifacts are redacted before upload, and the redaction step refuses to run with an empty `API_KEY` because an empty needle makes `bytes.replace` match every byte of every file and `grep -F` match every file.

## Validation

```
python3 -m unittest discover -s .github/scripts/tests -v   # 255 pass
uvx ruff@0.16.0 check --config .github/ruff.toml .github/scripts/   # clean
bash -n over each workflow run: block                      # 9/9 clean
```

The redaction step was also exercised end to end against a fixture containing a fake key: it replaced the key with `***`, staged nested files, and exited 1 with a clean annotation when handed an empty key.

Not yet validated: a live run on the runner. The unit tests cover the gate's parsing and verdict logic against summary fixtures, but only a real dispatch proves Harbor runs headless under `script` on that host. Worth doing before enabling the nightly. The 200 GB disk preflight threshold is a starting estimate to correct once a full run's footprint is known.
