### PR TITLE
fix(fixer): harden fixer workflow and controller's usage

### DIFF
--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -319,8 +319,9 @@ python3 Agents/utils/common/Harbor/scripts/controller.py \
 Use `fixer cancel --workflow-id "$FIXER_WORKFLOW_ID"` to reject a plan awaiting
 approval. A cancellation requested during planning or policy review takes
 effect at the next stage boundary. Approval synchronously executes the exact
-plan, runs smoke verification, writes `fix-report-latest.md`, and updates the
-existing `benchmark-summary.md` Fixer section. These automatic follow-up steps
+plan, runs smoke verification, writes `fix-report-latest.json` and
+`fix-report-latest.md`, and updates the existing `benchmark-summary.md` Fixer
+section. These automatic follow-up steps
 do not require additional user decisions and cannot be safely cancelled after
 execution starts. Approval is bound to the run, workflow, approval request,
 and SHA-256 digest of the reviewed Fix Plan; a changed plan is blocked instead
@@ -335,8 +336,8 @@ process remains.
 The Controller uses the repository `start.sh` directly for the isolated smoke
 rerun; no restart, stop, or verification command configuration is required.
 `controller.py ... status` exposes `verifying` and `reporting` while they run,
-then reports the verification outcome and report path. Workflow control state
-is written below `$RUN_DIR/fixer` as `fixer-state.json`,
+then reports the verification outcome and both report paths. Workflow control
+state is written below `$RUN_DIR/fixer` as `fixer-state.json`,
 `fixer-control-request.json`, `fixer-approval-request.json`, and
 `fixer-user-decision.json` alongside the existing Fixer artifacts.
 

--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -375,6 +375,9 @@ Generated artifacts, including `fix-plan-latest.json`, prompts, events, and
 provenance, are written below `--output-dir`. The summary-limit options are
 optional and use the defaults shown above. Fixer CLI flags override the
 corresponding `HARBOR_FIXER_*` defaults loaded by `env.sh`.
+Analyzer and Fixer Agent retries use bounded exponential backoff, starting at
+one second and capped at 30 seconds. Override these values with
+`HARBOR_AGENT_RETRY_INITIAL_SECONDS` and `HARBOR_AGENT_RETRY_MAX_SECONDS`.
 
 ### Stage 2: Execution Policy
 
@@ -420,9 +423,13 @@ python3 Agents/utils/common/Harbor/scripts/fixer.py \
 
 Use `--rerun-command` to launch the smoke run. The wrapper receives an ordered
 `TASK_SOURCE_FILE` and `HARBOR_FIXER_SMOKE_SELECTION`; it must preserve their
-line-to-task mapping. `--rerun-timeout` limits that command to 600 seconds by
+line-to-task mapping. `--rerun-timeout` limits that command to 3600 seconds by
 default and can also be set with `HARBOR_FIXER_RERUN_TIMEOUT`. Task identities
 come directly from Fix Plan v2.
+While the rerun is active, stdout and stderr are written to
+`runtime/<agent>/verification-rerun.stdout.log` and
+`runtime/<agent>/verification-rerun.stderr.log`; the verifier also emits a
+progress message every 30 seconds.
 Verification writes
 `verification-smoke-selection.json`, `verification-smoke-tasks.txt`, and
 `verification-result-latest.json`. If the Fix Plan was generated without a

--- a/Agents/utils/common/Harbor/harbor_prepare_runner_cli.py
+++ b/Agents/utils/common/Harbor/harbor_prepare_runner_cli.py
@@ -126,6 +126,14 @@ def main() -> int:
 
     status_file.write_text("failed\n", encoding="utf-8")
     workers_failed_file.touch()
+    details = log_file.read_text(encoding="utf-8").strip()
+    if details:
+        print(details, file=sys.stderr)
+    print(
+        "configured Harbor runner is not ready; rerun the repository's "
+        f"./scripts/setup.sh or inspect {log_file}",
+        file=sys.stderr,
+    )
     return 1
 
 

--- a/Agents/utils/common/Harbor/scripts/fixer.py
+++ b/Agents/utils/common/Harbor/scripts/fixer.py
@@ -129,7 +129,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--rerun-timeout",
         type=int,
-        default=mode_default("HARBOR_FIXER_RERUN_TIMEOUT", "600"),
+        default=mode_default("HARBOR_FIXER_RERUN_TIMEOUT", "3600"),
     )
     parser.add_argument("--monitor-policy", choices=["auto", "on", "off"], default="auto")
     parser.add_argument("--monitor-wait-timeout", type=int, default=3600)

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from harbor_pi_runtime import sleep_before_retry
+
 from . import PROMPT_VERSION, SCHEMA_VERSION, TAXONOMY_VERSION
 from .contract import validate_handover
 from .io import load_json, stable_hash, utc_now, write_json_atomic, write_text_atomic
@@ -654,6 +656,7 @@ def _run_task_analysis(
                 provenance["retry_reason"] = reason
                 timeout_seconds = _retry_timeout_seconds(reason, timeout_seconds)
                 prompt = build_dispatch_retry_prompt(base_prompt=base_prompt, block_reason=reason)
+                provenance["retry_delay_seconds"] = sleep_before_retry(attempt)
                 attempt += 1
                 continue
             provenance["retry_decision"] = "fallback"
@@ -695,6 +698,7 @@ def _run_task_analysis(
                     previous_json=task_report,
                     validation_errors=validation_errors,
                 )
+                provenance["retry_delay_seconds"] = sleep_before_retry(attempt)
                 attempt += 1
                 continue
             raw_task_path = raw_task_dir / f"{task_slug}.json"

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/fixer.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/fixer.py
@@ -30,7 +30,7 @@ from harbor_fixer.plan_generation import (
     run_plan_generation,
 )
 from harbor_fixer.policy import run_policy_preflight
-from harbor_fixer.report import write_fix_report
+from harbor_fixer.report import run_report_from_paths
 from harbor_fixer.verifier import run_verification_from_paths
 from write_benchmark_summary import update_fixer_results
 
@@ -225,7 +225,7 @@ def _runtime_config(
         "pi_api_key_env": "HARBOR_FIXER_API_KEY",
         "agent_timeout": _positive_env_int("HARBOR_FIXER_AGENT_TIMEOUT", 900),
         "execution_timeout": _positive_env_int("HARBOR_FIXER_EXECUTION_TIMEOUT", 300),
-        "rerun_timeout": _positive_env_int("HARBOR_FIXER_RERUN_TIMEOUT", 600),
+        "rerun_timeout": _positive_env_int("HARBOR_FIXER_RERUN_TIMEOUT", 3600),
         "summary_limit": _positive_env_int(
             "HARBOR_FIXER_SUMMARY_LIMIT",
             4000,
@@ -639,6 +639,7 @@ def start_fixer(
                 "verification_result": str(
                     output_dir / "verification-result-latest.json"
                 ),
+                "fix_report_json": str(output_dir / "fix-report-latest.json"),
                 "fix_report": str(output_dir / "fix-report-latest.md"),
                 "benchmark_summary": str(analyzer_output / "benchmark-summary.md"),
             },
@@ -736,6 +737,7 @@ def _finish_execution(
     workflow_id = str(state["fixer_workflow_id"])
     exec_result_path = output_dir / "exec-result-latest.json"
     verification_result_path = output_dir / "verification-result-latest.json"
+    report_json_path = output_dir / "fix-report-latest.json"
     report_path = output_dir / "fix-report-latest.md"
     config = state["config"]
     summary_path = Path(config["analyzer_output"]) / "benchmark-summary.md"
@@ -743,6 +745,7 @@ def _finish_execution(
         **state["paths"],
         "exec_result": str(exec_result_path),
         "verification_result": str(verification_result_path),
+        "fix_report_json": str(report_json_path),
         "fix_report": str(report_path),
         "benchmark_summary": str(summary_path),
     }
@@ -804,12 +807,13 @@ def _finish_execution(
         paths=paths,
     )
     try:
-        write_fix_report(
-            str(state["run_id"]),
-            fix_plan,
-            result,
-            verification,
-            report_path,
+        run_report_from_paths(
+            verification_result_path,
+            Path(config["analyzer_output"]),
+            output_dir,
+            PiAgentInvoker(output_dir, _pi_config(config)),
+            baseline_run_dir=run_dir,
+            baseline_monitor_policy="auto",
         )
         update_fixer_results(summary_path, report_path)
     except Exception as exc:
@@ -981,6 +985,7 @@ def fixer_status(run_dir: Path) -> dict[str, Any]:
         "approval_request": str(_approval_request_path(run_dir)),
         "decision": str(_decision_path(run_dir)),
         "benchmark_summary": str(run_dir / "analyzer" / "benchmark-summary.md"),
+        "fix_report_json": str(_fixer_dir(run_dir) / "fix-report-latest.json"),
         "fix_report": str(_fixer_dir(run_dir) / "fix-report-latest.md"),
     }
     try:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/plan_generation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/plan_generation.py
@@ -9,6 +9,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from harbor_pi_runtime import sleep_before_retry
+
 from .agent_invocation import AgentInvoker
 from .analyzer_inputs import build_task_inputs
 from .artifact_io import write_json, write_json_atomic, write_text
@@ -74,6 +76,8 @@ def _summarize_task_with_retry(
                     previous_output=raw,
                     validation_error=last_error,
                 )
+            if attempt < max_attempts:
+                sleep_before_retry(attempt)
     return None, {
         "stage": "task_subagent",
         "task": task_input["task"],
@@ -200,6 +204,8 @@ def request_fix_plan(
                     previous_output=raw,
                     validation_error=last_error,
                 )
+            if attempt < max_attempts:
+                sleep_before_retry(attempt)
     raise ValidationError(
         f"main agent failed to emit a valid fix plan after {max_attempts} attempts: {last_error}"
     )

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/agent.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/agent.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from harbor_pi_runtime import sleep_before_retry
+
 from ..agent_invocation import AgentInvoker
 from ..prompts import build_validation_retry_prompt
 from ..validation import (
@@ -109,6 +111,8 @@ def evaluate_agent(
                 previous_output=previous_output,
                 validation_error=last_error,
             )
+            if attempt < 2:
+                sleep_before_retry(attempt)
     return {
         "tier": tier,
         "decision": "deny",

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/builtin.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/builtin.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 _DENY_EXECUTABLES = {"rm", "rmdir", "shred", "unlink", "wipefs"}
 _READ_ONLY_COMMANDS = {
@@ -15,6 +17,32 @@ _READ_ONLY_COMMANDS = {
     "uname",
     "which",
 }
+_DOCKERFILE_ROOT_FIND_RE = re.compile(
+    r"(?im)^\s*RUN\b.*?(?<![\w/])(?:/(?:usr/)?bin/)?find"
+    r"(?:\s+|[\"']\s*,\s*[\"'])"
+    r"(?:(?:-[HLP]|-O[^\s,\"']+)(?:\s+|[\"']\s*,\s*[\"']))*"
+    r"/(?=[\"']?(?:[\s,;&|)\]]|$))"
+)
+
+
+def unsafe_file_edit_reason(action: dict[str, Any]) -> tuple[str, str] | None:
+    """Reject newly introduced, deterministically unsafe file-edit content."""
+
+    if action.get("action_type") != "file_edit":
+        return None
+    if Path(str(action.get("path") or "")).name.lower() != "dockerfile":
+        return None
+    edit = action.get("edit") if isinstance(action.get("edit"), dict) else {}
+    old_text = str(edit.get("old_text") or "").replace("\\\n", " ")
+    new_text = str(edit.get("new_text") or "").replace("\\\n", " ")
+    if _DOCKERFILE_ROOT_FIND_RE.search(
+        new_text
+    ) and not _DOCKERFILE_ROOT_FIND_RE.search(old_text):
+        return (
+            "dockerfile_unbounded_root_scan",
+            "Dockerfile edit introduces an unbounded find traversal from filesystem root",
+        )
+    return None
 
 
 def destructive_reason(tokens: Sequence[str]) -> tuple[str, str] | None:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/preflight.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/preflight.py
@@ -13,6 +13,7 @@ from ..artifact_io import write_json_atomic
 from ..command_analysis import CommandAnalysis, analyze_command
 from ..validation import ValidationError
 from .agent import evaluate_agent
+from .builtin import unsafe_file_edit_reason
 from .paths import analyze_paths
 from .rules import evaluate_t1, load_user_rules
 
@@ -176,6 +177,16 @@ def run_policy_preflight(
                                 resolved_executable
                             ),
                         )
+                elif unsafe_reason := unsafe_file_edit_reason(action):
+                    decision = {
+                        "tier": "T1",
+                        "decision": "deny",
+                        "risk_level": "high",
+                        "source": "builtin_rule",
+                        "rule_id": unsafe_reason[0],
+                        "reason_code": unsafe_reason[0],
+                        "reason": unsafe_reason[1],
+                    }
                 elif path_analysis["classification"] != "inside_writable_roots":
                     decision = {
                         "tier": "T3",

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/generation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/generation.py
@@ -193,7 +193,14 @@ def _build_old_run(
             handover.get("run_id") != analyzer_paths["run_id"]
             or handover.get("agent") != agent
         ):
-            raise ValidationError("baseline monitor does not match analyzer run")
+            if baseline_monitor_policy == "on":
+                raise ValidationError("baseline monitor does not match analyzer run")
+            snapshot, monitor_output_path, monitor_records, monitor_summary = (
+                None,
+                "",
+                {},
+                None,
+            )
     by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
     monitor_task_keys: dict[tuple[str, str], set[tuple[str, str, str]]] = {}
     handover_ids: list[str] = []

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
@@ -7,7 +7,7 @@ import shlex
 import shutil
 import signal
 import subprocess
-import tempfile
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -69,6 +69,7 @@ RUN_SCOPED_ENV_VARS = {
 }
 
 TERMINATION_GRACE_SECONDS = 5.0
+RERUN_PROGRESS_INTERVAL_SECONDS = 30.0
 
 GENERATED_MONITOR_FILES = {
     "monitor-state.json",
@@ -87,6 +88,20 @@ def _read_log_tail(stream: Any) -> str:
     end = stream.seek(0, os.SEEK_END)
     stream.seek(max(0, end - 16384))
     return stream.read().decode(errors="replace")[-4000:]
+
+
+def _open_log(path: Path) -> Any:
+    fd = os.open(
+        path,
+        os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW | os.O_CLOEXEC,
+        0o600,
+    )
+    try:
+        os.fchmod(fd, 0o600)
+        return os.fdopen(fd, "w+b")
+    except Exception:
+        os.close(fd)
+        raise
 
 
 def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
@@ -179,6 +194,8 @@ def run_command(
             "duration_ms": 0,
             "stdout_summary": "",
             "stderr_summary": "",
+            "stdout_path": "",
+            "stderr_path": "",
             "skipped_reason": skipped_reason,
         }
     try:
@@ -243,10 +260,14 @@ def run_command(
     started_at = _utc_now()
     started = time.monotonic()
     timed_out = False
+    runtime_dir = run_dir / "runtime" / agent
+    stdout_path = runtime_dir / "verification-rerun.stdout.log"
+    stderr_path = runtime_dir / "verification-rerun.stderr.log"
     try:
+        runtime_dir.mkdir(parents=True, exist_ok=True)
         with (
-            tempfile.TemporaryFile() as stdout_file,
-            tempfile.TemporaryFile() as stderr_file,
+            _open_log(stdout_path) as stdout_file,
+            _open_log(stderr_path) as stderr_file,
         ):
             process = subprocess.Popen(
                 argv,
@@ -256,13 +277,30 @@ def run_command(
                 env=env,
                 start_new_session=True,
             )
-            try:
-                exit_code = process.wait(timeout=timeout_seconds)
-            except subprocess.TimeoutExpired:
-                _terminate_process_group(process)
-                _cleanup_verifier_backups(run_dir, agent)
-                exit_code = 124
-                timed_out = True
+            deadline = started + timeout_seconds
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    _terminate_process_group(process)
+                    _cleanup_verifier_backups(run_dir, agent)
+                    exit_code = 124
+                    timed_out = True
+                    break
+                try:
+                    exit_code = process.wait(
+                        timeout=min(remaining, RERUN_PROGRESS_INTERVAL_SECONDS)
+                    )
+                    break
+                except subprocess.TimeoutExpired:
+                    if deadline - time.monotonic() <= 0:
+                        continue
+                    elapsed = int(time.monotonic() - started)
+                    print(
+                        "verification rerun is still running "
+                        f"({elapsed}s elapsed); logs: {stdout_path}, {stderr_path}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
             stdout_summary = _read_log_tail(stdout_file)
             stderr_summary = _read_log_tail(stderr_file)
     except OSError as exc:
@@ -280,6 +318,8 @@ def run_command(
         "duration_ms": int((time.monotonic() - started) * 1000),
         "stdout_summary": stdout_summary,
         "stderr_summary": stderr_summary,
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
         "skipped_reason": "",
     }
 

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/workflow.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/workflow.py
@@ -33,7 +33,7 @@ from .run_state import (
 )
 from .selection import build_smoke_selection, plan_exec_map, plan_tasks
 
-DEFAULT_RERUN_TIMEOUT_SECONDS = 600
+DEFAULT_RERUN_TIMEOUT_SECONDS = 3600
 
 
 def _prepare_verification_output(output_dir: Path) -> None:

--- a/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_analyzer_runtime.py
@@ -747,6 +747,49 @@ class HarborAnalyzerRuntimeTest(unittest.TestCase):
                 self.assertIn(f"/{HANDOVER_ID}/{publication_id}/", provenance["stderr_path"])
                 self.assertIn(f"/{HANDOVER_ID}/{publication_id}/", provenance["tool_access_audit_path"])
 
+    def test_run_handover_uses_backoff_before_agent_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            run_dir = Path(root) / "run"
+            queue_dir = run_dir / "queue"
+            output_dir = Path(root) / "analyzer"
+            payload = handover(run_dir, queue_dir)
+            source_path = run_dir / "handover.json"
+            config = AnalyzerConfig(run_dir=run_dir, queue_dir=queue_dir, output_dir=output_dir)
+            dispatches = [
+                SimpleNamespace(
+                    report=None,
+                    block_reason="pi_provider_request_failed:timeout",
+                    provenance={},
+                ),
+                SimpleNamespace(
+                    report=task_analysis(HANDOVER_ID, RUN_ID, payload["tasks"][0]),
+                    block_reason=None,
+                    provenance={
+                        "tool_access_audit_path": str(output_dir / "tool-access.jsonl")
+                    },
+                ),
+            ]
+
+            with (
+                mock.patch.object(
+                    analyzer_runner, "dispatch_to_child", side_effect=dispatches
+                ),
+                mock.patch.object(analyzer_runner, "sleep_before_retry", return_value=2.0) as backoff,
+            ):
+                result, exit_code = run_handover(
+                    payload,
+                    handover_path=source_path,
+                    config=config,
+                )
+
+            self.assertEqual(exit_code, 0)
+            backoff.assert_called_once_with(1)
+            task_slug = _task_slug(task())
+            attempts = result["analyzer_metadata"]["agent_provenance"]["per_task"][task_slug][
+                "attempts"
+            ]
+            self.assertEqual(attempts[0]["retry_delay_seconds"], 2.0)
+
     def test_write_outputs_publishes_one_latest_artifact_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             output_dir = Path(root) / "analyzer"

--- a/Agents/utils/common/Harbor/tests/test_harbor_controller_fixer.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_controller_fixer.py
@@ -74,11 +74,18 @@ class HarborControllerFixerTest(FixerTestCase):
             "harbor_controller.fixer.run_verification_from_paths",
             return_value={"status": "fixed"},
         )
-        self.write_report = mock.patch(
-            "harbor_controller.fixer.write_fix_report",
-            side_effect=lambda *args: args[-1].write_text(
+        def write_report(*args: object, **kwargs: object) -> dict:
+            output_dir = args[2]
+            assert isinstance(output_dir, Path)
+            write_json(output_dir / "fix-report-latest.json", {"status": "fixed"})
+            (output_dir / "fix-report-latest.md").write_text(
                 "# Harbor Fixer Report\n", encoding="utf-8"
-            ),
+            )
+            return {"summary": {"status": "success"}}
+
+        self.write_report = mock.patch(
+            "harbor_controller.fixer.run_report_from_paths",
+            side_effect=write_report,
         )
         self.update_summary = mock.patch(
             "harbor_controller.fixer.update_fixer_results"
@@ -142,6 +149,21 @@ class HarborControllerFixerTest(FixerTestCase):
         self.assertEqual(self.verify_mock.call_args.kwargs["model"], "source-model")
         self.assertEqual(self.verify_mock.call_args.kwargs["rerun_timeout"], 900)
         self.write_report_mock.assert_called_once()
+        report_call = self.write_report_mock.call_args
+        self.assertEqual(
+            report_call.args[:3],
+            (
+                self.run_dir / "fixer" / "verification-result-latest.json",
+                self.run_dir / "analyzer",
+                self.run_dir / "fixer",
+            ),
+        )
+        self.assertEqual(report_call.kwargs["baseline_run_dir"], self.run_dir)
+        self.assertEqual(report_call.kwargs["baseline_monitor_policy"], "auto")
+        self.assertEqual(
+            completed["paths"]["fix_report_json"],
+            str(self.run_dir / "fixer" / "fix-report-latest.json"),
+        )
         self.update_summary_mock.assert_called_once_with(
             self.run_dir / "analyzer" / "benchmark-summary.md",
             self.run_dir / "fixer" / "fix-report-latest.md",
@@ -169,12 +191,17 @@ class HarborControllerFixerTest(FixerTestCase):
                 cancel_fixer(self.run_dir, state["fixer_workflow_id"])
             return {"status": "partially_fixed"}
 
-        def report(*args: object) -> None:
+        def report(*args: object, **kwargs: object) -> dict:
             status = fixer_status(self.run_dir)
             observed.append(str(status["status"]))
             self.assertEqual(status["verification_status"], "partially_fixed")
             self.assertEqual(status["report_status"], "running")
-            args[-1].write_text("# Harbor Fixer Report\n", encoding="utf-8")
+            output_dir = args[2]
+            assert isinstance(output_dir, Path)
+            (output_dir / "fix-report-latest.md").write_text(
+                "# Harbor Fixer Report\n", encoding="utf-8"
+            )
+            return {"summary": {"status": "success"}}
 
         self.verify_mock.side_effect = verify
         self.write_report_mock.side_effect = report

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_policy.py
@@ -140,6 +140,42 @@ class HarborFixerPolicyTest(FixerTestCase):
             result["decisions"][1]["path_analysis"]["path_resolution_stable"]
         )
 
+    def test_deterministically_denies_new_dockerfile_root_scan(self) -> None:
+        allowed_root = self.root / "dataset"
+        allowed_root.mkdir()
+        commands = (
+            "RUN find / -name x",
+            'RUN sh -c "find / -name x"',
+            "RUN bash -c 'find / -name x'",
+            "RUN (find / -name x)",
+            "RUN /bin/find / -name x",
+            'RUN ["find", "/", "-name", "x"]',
+            "RUN find -H / -name x",
+            "RUN find -O3 / -name x",
+            'RUN ["find", "-L", "/", "-name", "x"]',
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                plan = make_fix_plan()
+                action = _file_edit(
+                    "dockerfile-edit", ".", str(allowed_root / "Dockerfile")
+                )
+                action["edit"].update(
+                    {"old_text": "RUN pytest -q\n", "new_text": f"{command}\n"}
+                )
+                plan["plans"][0]["actions"] = [action]
+                invoker = PolicyInvoker()
+
+                result = self._run(plan, invoker, writable_roots=[allowed_root])
+
+                decision = result["decisions"][0]
+                self.assertEqual(decision["tier"], "T1")
+                self.assertEqual(decision["decision"], "deny")
+                self.assertEqual(
+                    decision["reason_code"], "dockerfile_unbounded_root_scan"
+                )
+                self.assertEqual(invoker.records, [])
+
     def test_t3_read_probe_preserves_file_edit_path_stability(self) -> None:
         allowed_root = self.root / "config"
         allowed_root.mkdir()

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_report.py
@@ -346,15 +346,26 @@ class HarborFixerReportTest(FixerTestCase):
         with mock.patch(
             "harbor_fixer.report.generation.read_monitor_snapshot",
             return_value=(wrong_snapshot, "snapshot.json"),
-        ), self.assertRaisesRegex(ValidationError, "baseline monitor"):
-            generate_report_from_paths(
+        ):
+            report = run_report_from_paths(
                 verification_path,
                 analyzer_dir,
                 output_dir,
                 _FailingInvoker(),
                 baseline_run_dir=self.root / "baseline",
-                baseline_monitor_policy="on",
+                baseline_monitor_policy="auto",
             )
+            self.assertFalse(report["old_run"]["monitor_available"])
+            self.assertTrue((output_dir / "fix-report-latest.md").is_file())
+            with self.assertRaisesRegex(ValidationError, "baseline monitor"):
+                generate_report_from_paths(
+                    verification_path,
+                    analyzer_dir,
+                    output_dir,
+                    _FailingInvoker(),
+                    baseline_run_dir=self.root / "baseline",
+                    baseline_monitor_policy="on",
+                )
 
     def test_markdown_is_deterministic_redacted_view_of_report_artifacts(self) -> None:
         output_dir = self.root / "markdown"

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_runtime.py
@@ -186,6 +186,12 @@ class HarborFixerVerificationRuntimeTest(FixerTestCase):
             )
 
         self.assertEqual(result["exit_code"], 0)
+        stdout_path = self.root / "run/runtime/opencode/verification-rerun.stdout.log"
+        self.assertEqual(result["stdout_path"], str(stdout_path))
+        self.assertTrue(Path(result["stdout_path"]).is_file())
+        self.assertTrue(Path(result["stderr_path"]).is_file())
+        self.assertEqual(stdout_path.stat().st_mode & 0o777, 0o600)
+        self.assertEqual(Path(result["stderr_path"]).stat().st_mode & 0o777, 0o600)
         call = popen.call_args.kwargs
         env = call["env"]
         self.assertNotIn("QUEUE_DIR", env)
@@ -214,10 +220,34 @@ class HarborFixerVerificationRuntimeTest(FixerTestCase):
         self.assertTrue(call["start_new_session"])
         self.assertTrue(call["stdout"].closed)
         self.assertTrue(call["stderr"].closed)
-        process.wait.assert_called_once_with(timeout=9)
+        process.wait.assert_called_once()
+        self.assertGreater(process.wait.call_args.kwargs["timeout"], 8.9)
+        self.assertLessEqual(process.wait.call_args.kwargs["timeout"], 9)
         self.assertEqual(
             (self.root / "run" / "tasks.txt").read_text(), "task-b\ntask-a\n"
         )
+
+    def test_run_command_rejects_symlinked_log(self) -> None:
+        task_source = self.root / "tasks.txt"
+        task_source.write_text("task-a\n", encoding="utf-8")
+        runtime_dir = self.root / "run/runtime/opencode"
+        runtime_dir.mkdir(parents=True)
+        victim = self.root / "victim.txt"
+        victim.write_text("preserve", encoding="utf-8")
+        (runtime_dir / "verification-rerun.stdout.log").symlink_to(victim)
+
+        with self.assertRaisesRegex(ValidationError, "cannot launch"):
+            run_command(
+                "true",
+                self.root / "run",
+                "opencode",
+                task_source_path=str(task_source),
+                selection_path=str(self.root / "selection.json"),
+                should_run=True,
+                timeout_seconds=1,
+            )
+
+        self.assertEqual(victim.read_text(encoding="utf-8"), "preserve")
 
     def test_run_command_times_out(self) -> None:
         task_source = self.root / "tasks.txt"

--- a/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_workflow.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_fixer_verification_workflow.py
@@ -138,7 +138,7 @@ class HarborFixerVerificationWorkflowTest(FixerTestCase):
 
         self.assertEqual(result["rerun"]["command"], "")
         self.assertEqual(result["source"]["analyzer_monitor_path"], "")
-        self.assertEqual(verification_input["rerun_timeout"], 600)
+        self.assertEqual(verification_input["rerun_timeout"], 3600)
 
     def test_clears_stale_result_before_input_validation(self) -> None:
         result_path = self.root / "verification-output" / "verification-result-latest.json"

--- a/Agents/utils/common/Harbor/tests/test_harbor_prepare_runner_cli.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_prepare_runner_cli.py
@@ -7,6 +7,7 @@ import stat
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from unittest import mock
 
@@ -111,10 +112,13 @@ class RunnerValidationTest(unittest.TestCase):
         self.assertEqual((self.runtime / "status").read_text(), "done\n")
 
         self.harbor.unlink()
-        with mock.patch.dict(os.environ, self.environment):
+        stderr = io.StringIO()
+        with mock.patch.dict(os.environ, self.environment), redirect_stderr(stderr):
             self.assertEqual(MODULE.main(), 1)
         self.assertEqual((self.runtime / "status").read_text(), "failed\n")
         self.assertTrue((self.runtime / "workers.failed").is_file())
+        self.assertIn("runner executable is missing", stderr.getvalue())
+        self.assertIn("repository's ./scripts/setup.sh", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 1. Why the change?

Harbor fixer was found to work slightly unstable during e2e test. In this PR we harden its workflow by adding exponential backoff for fixer agents, lengthening verification rerun timeout, adding more safety rules about Dockerfiles in T1 policy agents, supplying more info for diagnostics when Harbor runner fails and add tests for them.

Moreover, since Harbor controller had been merged before Harbor fixer report which changed its main procedure entry. This PR also amends this must-to-have update in API for controller adaptations.

## 2. Summary of the change 

- Add exponential backoff for fixer agents.
- Lengthen verification rerun timeout.
- Add more safety rules about Dockerfiles in T1 policy agents.
- Supply more info for diagnostics when Harbor runner fails.
- Revise Harbor fixer report entry used by Harbor controller.
- Add more tests for the changes.

## 3. Other details

- Full Harbor Fixer and Harbor Controller suite: all tests passed.
- Ruff 0.16.0 passes for the changed Python files; upstream main Ruff CI is green.
