### PR TITLE
feat(qz): support image-backed environment plans

### DIFF
--- a/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
+++ b/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
@@ -156,9 +156,10 @@ exactly this loop (oracle reward 1.0 in ~6 s, pi reward 1.0 in ~47 s against
 
 - Tasks must be **single-container and image-backed**. Final-image tasks use
   `environment.docker_image`; schema-v2 mappings may additionally put common
-  `RUN` / `WORKDIR` steps in the Template and execute ordered task init commands
-  after each fresh Sandbox is created. General Dockerfile/build-context and
-  docker-compose materialization are not supported.
+  `USER` / `RUN` / `WORKDIR` steps in the Template and execute ordered task
+  init commands after each fresh Sandbox is created. General
+  Dockerfile/build-context and docker-compose materialization are not
+  supported.
 - `QZ_SANDBOX_TEMPLATE` keeps the backward-compatible fixed mode.
   `QZ_SANDBOX_TEMPLATE_MAP` selects a ready Template per task; the runner
   validates live status but never creates Templates implicitly. Inventory,

--- a/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
+++ b/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
@@ -154,10 +154,11 @@ exactly this loop (oracle reward 1.0 in ~6 s, pi reward 1.0 in ~47 s against
 
 ## Limitations
 
-- Tasks must be **single-container with a prebuilt image**
-  (`environment.docker_image` in `task.toml`); docker-compose tasks and
-  on-the-fly Dockerfile builds are not supported — the environment image must
-  be registered as a Template beforehand.
+- Tasks must be **single-container and image-backed**. Final-image tasks use
+  `environment.docker_image`; schema-v2 mappings may additionally put common
+  `RUN` / `WORKDIR` steps in the Template and execute ordered task init commands
+  after each fresh Sandbox is created. General Dockerfile/build-context and
+  docker-compose materialization are not supported.
 - `QZ_SANDBOX_TEMPLATE` keeps the backward-compatible fixed mode.
   `QZ_SANDBOX_TEMPLATE_MAP` selects a ready Template per task; the runner
   validates live status but never creates Templates implicitly. Inventory,

--- a/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
+++ b/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
@@ -176,8 +176,8 @@ runs are read-only: they resolve the cached ID or deterministic alias through
 the live QZ API and reject missing, non-ready, or identity-mismatched
 Templates. The live Template must expose the mapping's content-derived alias
 and QZ spec. After a fresh Sandbox is created, schema-v2 `init_steps` run in
-order before agent setup/run; any non-zero step aborts the trial. Benchmark
-runs never create a Template implicitly.
+order as the Template's default user before agent setup/run; any non-zero step
+aborts the trial. Benchmark runs never create a Template implicitly.
 
 Before a live `resolve`, `bind`, or `materialize` command, either export the QZ
 API variables or load the repository-local configuration:

--- a/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
+++ b/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
@@ -38,6 +38,7 @@ keys; the mapping tool does not need dataset-specific code:
     "task-a": {
       "image": "example/shared-base:v1",
       "build_steps": [
+        {"type": "USER", "args": ["root"]},
         {"type": "WORKDIR", "args": ["/testbed"]},
         {"type": "RUN", "args": ["apt-get install -y git"]}
       ],
@@ -71,9 +72,9 @@ resulting schema-v2 mapping and do not branch on dataset name.
 
 ### SWE-Smith convenience producer
 
-For SWE-Smith, the built-in producer reads the generated adapter's
-base image and common `WORKDIR` / `RUN` steps, then moves the final task checkout
-into fresh-Sandbox initialization:
+For SWE-Smith, the built-in producer reads the generated adapter's base image,
+sets the Template build user to `root`, keeps the common `WORKDIR` / `RUN`
+steps, then moves the final task checkout into fresh-Sandbox initialization:
 
 ```bash
 python qz_template_mapping.py \
@@ -92,8 +93,10 @@ it is not a general Dockerfile or build-context materializer.
 
 SWE-bench Verified tasks do not declare `environment.docker_image` in
 `task.toml`. Their generated adapter Dockerfiles start from a per-task final
-SWE image and add only `WORKDIR` / `RUN` steps. Inventory them directly without
-an intermediate manifest:
+SWE image and add `WORKDIR` / `RUN` steps that use Docker's root default.
+The producer records an explicit `USER root` before those steps so QZ preserves
+that build and runtime user. Inventory them directly without an intermediate
+manifest:
 
 ```bash
 python qz_template_mapping.py \
@@ -136,6 +139,7 @@ dataset path, credentials, or live platform state.
       "image_source": "official",
       "spec": "g.c1",
       "build_steps": [
+        {"type": "USER", "args": ["root"]},
         {"type": "WORKDIR", "args": ["/testbed"]},
         {"type": "RUN", "args": ["apt-get install -y git"]}
       ],
@@ -154,7 +158,8 @@ part of Template identity, so tasks with different checkout commands can share
 one Template while still receiving isolated Sandboxes. Aliases contain only
 letters, digits, and underscores.
 
-The exact image string is intentionally preserved. Digest-qualified image
+The supported build-step subset is `USER`, `WORKDIR`, and `RUN`. The exact
+image string is intentionally preserved. Digest-qualified image
 references are preferred because mutable tags can move while retaining the
 same v2 key. Resolving a registry tag to a manifest digest is outside this
 inventory phase.

--- a/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
+++ b/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
@@ -88,6 +88,8 @@ python qz_template_mapping.py \
 
 This producer intentionally supports the current SWE-Smith adapter shape only;
 it is not a general Dockerfile or build-context materializer.
+The task-list entries remain raw instance IDs, while the emitted mapping keys
+use Harbor's `swe-smith__<instance_id>` task names.
 
 ### SWE-bench Verified convenience producer
 

--- a/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
+++ b/Agents/utils/common/Harbor/QZ_TEMPLATE_MAPPING.md
@@ -1,8 +1,9 @@
 # QZ Template Mapping Inventory
 
-`qz_template_mapping.py` inventories the prebuilt images declared by local
-Harbor tasks and writes deterministic input for the per-task QZ Template
-resolver. Inventory makes no QZ API calls and creates no Templates.
+`qz_template_mapping.py` inventories image-backed Harbor task environments and
+writes deterministic input for the per-task QZ Template resolver. An
+environment plan can contain common Template build steps and per-task Sandbox
+initialization. Inventory makes no QZ API calls and creates no Templates.
 
 ## Inventory a benchmark
 
@@ -21,10 +22,93 @@ python qz_template_mapping.py \
 
 Without `--task-list`, every immediate child containing `task.toml` is
 inventoried. `--dataset-root` may also point directly at one task. The command
-fails without writing a partial mapping if any selected task lacks a non-empty
-`environment.docker_image`.
+fails without writing a partial mapping if any selected task cannot be
+represented by the selected dataset kind.
 
-## Schema v1
+### Generic Environment Plan input
+
+Datasets that do not declare a final `environment.docker_image` can provide a
+dataset-independent JSON manifest. The keys match the selected relative task
+keys; the mapping tool does not need dataset-specific code:
+
+```json
+{
+  "schema_version": 1,
+  "tasks": {
+    "task-a": {
+      "image": "example/shared-base:v1",
+      "build_steps": [
+        {"type": "WORKDIR", "args": ["/testbed"]},
+        {"type": "RUN", "args": ["apt-get install -y git"]}
+      ],
+      "init_steps": [
+        {"run": "git reset --hard abc && git checkout abc", "cwd": "/testbed"}
+      ]
+    },
+    "task-b": {
+      "image": "example/clone-base:v1",
+      "build_steps": [],
+      "init_steps": [
+        {"run": "git clone https://github.com/org/repo.git /testbed", "cwd": "/"}
+      ]
+    }
+  }
+}
+```
+
+```bash
+python qz_template_mapping.py \
+  --dataset-root /path/to/harbor/tasks \
+  --benchmark benchmark-name \
+  --task-list /path/to/selected-tasks.txt \
+  --environment-plan-file /path/to/environment-plan.json \
+  --output /tmp/benchmark-qz-templates.json
+```
+
+This is the generic integration surface for checkout, reset, clone, or other
+image-backed task initialization. The resolver and QZ provider only consume the
+resulting schema-v2 mapping and do not branch on dataset name.
+
+### SWE-Smith convenience producer
+
+For SWE-Smith, the built-in producer reads the generated adapter's
+base image and common `WORKDIR` / `RUN` steps, then moves the final task checkout
+into fresh-Sandbox initialization:
+
+```bash
+python qz_template_mapping.py \
+  --dataset-root /workspace/harbor/datasets/swesmith \
+  --dataset-kind smith \
+  --benchmark smith \
+  --task-list ../../../../Tasks/SWE-smith/harbor_tasks.txt \
+  --spec g.c1 \
+  --output /tmp/smith-qz-templates.json
+```
+
+This producer intentionally supports the current SWE-Smith adapter shape only;
+it is not a general Dockerfile or build-context materializer.
+
+### SWE-bench Verified convenience producer
+
+SWE-bench Verified tasks do not declare `environment.docker_image` in
+`task.toml`. Their generated adapter Dockerfiles start from a per-task final
+SWE image and add only `WORKDIR` / `RUN` steps. Inventory them directly without
+an intermediate manifest:
+
+```bash
+python qz_template_mapping.py \
+  --dataset-root /workspace/swebench-verified \
+  --dataset-kind sweverify \
+  --benchmark sweverify \
+  --task-list ../../../../Tasks/SWE-verify/harbor_tasks.txt \
+  --spec g.c1 \
+  --output /tmp/sweverify-qz-templates.json
+```
+
+These tasks already use task-specific final images, so all Dockerfile steps
+remain Template build steps and the generated task initialization is empty.
+
+## Schema v2
 
 The output is deterministic: it contains no generation timestamp, absolute
 dataset path, credentials, or live platform state.
@@ -32,11 +116,17 @@ dataset path, credentials, or live platform state.
 ```json
 {
   "benchmark": "terminalbench21",
-  "identity_version": "qz-template-image-v1",
-  "schema_version": 1,
+  "identity_version": "qz-template-environment-v2",
+  "schema_version": 2,
   "tasks": {
     "adaptive-rejection-sampler": {
       "docker_image": "example/task-image:tag",
+      "init_steps": [
+        {
+          "cwd": "/testbed",
+          "run": "git fetch && git checkout instance-id"
+        }
+      ],
       "template_key": "sha256:..."
     }
   },
@@ -45,6 +135,10 @@ dataset path, credentials, or live platform state.
       "image": "example/task-image:tag",
       "image_source": "official",
       "spec": "g.c1",
+      "build_steps": [
+        {"type": "WORKDIR", "args": ["/testbed"]},
+        {"type": "RUN", "args": ["apt-get install -y git"]}
+      ],
       "template_id": null,
       "template_name": "af_task_image_tag_..."
     }
@@ -52,15 +146,21 @@ dataset path, credentials, or live platform state.
 }
 ```
 
-`template_key` is SHA-256 over canonical JSON containing
-`identity_version`, the exact image reference, `image_source`, and QZ spec.
-Tasks with the same tuple share one Template entry. Changing any member creates
-a new key and alias. Aliases contain only letters, digits, and underscores.
+`template_key` is SHA-256 over canonical JSON containing `identity_version`,
+the exact image reference, `image_source`, QZ spec, and ordered `build_steps`.
+Tasks with the same Template inputs share one Template entry. Changing any
+member or build-step order creates a new key and alias. `init_steps` are not
+part of Template identity, so tasks with different checkout commands can share
+one Template while still receiving isolated Sandboxes. Aliases contain only
+letters, digits, and underscores.
 
 The exact image string is intentionally preserved. Digest-qualified image
 references are preferred because mutable tags can move while retaining the
-same v1 key. Resolving a registry tag to a manifest digest is outside this
+same v2 key. Resolving a registry tag to a manifest digest is outside this
 inventory phase.
+
+Existing schema-v1 mappings remain readable and behave as empty `build_steps`
+plus empty `init_steps`. New inventory output always uses schema v2.
 
 ## Resolve or materialize one task
 
@@ -68,7 +168,9 @@ inventory phase.
 runs are read-only: they resolve the cached ID or deterministic alias through
 the live QZ API and reject missing, non-ready, or identity-mismatched
 Templates. The live Template must expose the mapping's content-derived alias
-and QZ spec. They never create a Template implicitly.
+and QZ spec. After a fresh Sandbox is created, schema-v2 `init_steps` run in
+order before agent setup/run; any non-zero step aborts the trial. Benchmark
+runs never create a Template implicitly.
 
 Before a live `resolve`, `bind`, or `materialize` command, either export the QZ
 API variables or load the repository-local configuration:
@@ -127,9 +229,9 @@ reuses IDs already saved in the mapping and ready deterministic aliases.
 The write commands record `template_id` only after live status, deterministic
 alias, and QZ spec validation succeed. QZ's read API does not expose the source
 image, so the server-returned alias is the live content-identity commitment: it
-is derived from the exact image reference, image source, and spec in the
-mapping. A legacy Template without that alias must be materialized under the
-deterministic name instead of being bound by ID.
+is derived from the exact image reference, image source, spec, and common
+build steps in the mapping. A legacy Template without that alias must be
+materialized under the deterministic name instead of being bound by ID.
 
 Enable per-task selection in the runner with:
 

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -370,7 +370,6 @@ class QzSandboxEnvironment(E2BEnvironment):
         for index, step in enumerate(self._task_init_steps, start=1):
             result = await self._sandbox.commands.run(
                 step["run"],
-                user="root",
                 cwd=step.get("cwd") or str(self._workdir),
                 timeout=QZ_TASK_INIT_TIMEOUT_SEC,
             )

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -46,7 +46,7 @@ from qz_template_resolver import (
     MAPPING_ENV_VAR,
     QzTemplateResolutionError,
     load_mapping,
-    resolve_task_template_from_environment,
+    resolve_task_environment_from_environment,
 )
 
 try:
@@ -95,6 +95,7 @@ QZ_DEFAULT_HOST_PREFIX = "sbx-"
 # greater than 4 hours"), while Harbor's E2B backend hardcodes 24h.
 QZ_MAX_SANDBOX_TIMEOUT_SEC = 4 * 60 * 60
 QZ_DEFAULT_SANDBOX_TIMEOUT_SEC = QZ_MAX_SANDBOX_TIMEOUT_SEC
+QZ_TASK_INIT_TIMEOUT_SEC = 600
 _API_VERSION_SUFFIX = "/v1"
 # These settings describe a particular cloud-E2B data plane rather than the
 # shared SDK API surface. Letting them leak into a qz process can create the
@@ -232,9 +233,10 @@ class QzSandboxEnvironment(E2BEnvironment):
     binding); qz does not mount the e2b remote build API. An explicit
     ``template`` kwarg or ``QZ_SANDBOX_TEMPLATE`` selects one fixed Template.
     Alternatively, ``QZ_SANDBOX_TEMPLATE_MAP`` resolves each task through a
-    schema-v1 mapping and verifies that the selected Template is live and
-    ready. Without either mode, Harbor's auto-generated per-task alias is
-    folded onto qz's allowed name alphabet.
+    mapping and verifies that the selected Template is live and ready. A
+    schema-v2 mapping may also provide commands to initialize each fresh
+    Sandbox before Harbor starts the agent. Without either mode, Harbor's
+    auto-generated per-task alias is folded onto qz's allowed name alphabet.
     """
 
     def __init__(self, *args, template: str | None = None, **kwargs) -> None:
@@ -251,12 +253,13 @@ class QzSandboxEnvironment(E2BEnvironment):
                 f"set only one of QZ_SANDBOX_TEMPLATE or {MAPPING_ENV_VAR}, not both"
             )
         self._template_override = fixed_template
+        self._task_init_steps: tuple[dict[str, str], ...] = ()
         super().__init__(*args, **kwargs)
         if self._template_override:
             self._template_name = self._template_override
         elif mapping_path:
             try:
-                self._template_override = resolve_task_template_from_environment(
+                environment_plan = resolve_task_environment_from_environment(
                     Path(mapping_path),
                     self.environment_name,
                 )
@@ -265,6 +268,8 @@ class QzSandboxEnvironment(E2BEnvironment):
                     "failed to resolve QZ Template for task "
                     f"{self.environment_name!r}: {exc}"
                 ) from exc
+            self._template_override = environment_plan.template_id
+            self._task_init_steps = environment_plan.init_steps
             self._template_name = self._template_override
         else:
             self._template_name = sanitize_template_name(self._template_name)
@@ -361,6 +366,20 @@ class QzSandboxEnvironment(E2BEnvironment):
                 f"failed to prepare task workdir {self._workdir}: "
                 f"exit {result.exit_code}: {result.stderr or result.stdout}"
             )
+
+        for index, step in enumerate(self._task_init_steps, start=1):
+            result = await self._sandbox.commands.run(
+                step["run"],
+                user="root",
+                cwd=step.get("cwd") or str(self._workdir),
+                timeout=QZ_TASK_INIT_TIMEOUT_SEC,
+            )
+            if result.exit_code != 0:
+                raise RuntimeError(
+                    f"QZ task init step {index} failed for "
+                    f"{self.environment_name!r}: exit {result.exit_code}: "
+                    f"{result.stderr or result.stdout}"
+                )
 
     @classmethod
     def preflight(cls) -> None:

--- a/Agents/utils/common/Harbor/qz_template_manager.py
+++ b/Agents/utils/common/Harbor/qz_template_manager.py
@@ -222,6 +222,7 @@ class QzTemplateClient:
         build_id: str,
         image: str,
         image_source: str,
+        build_steps: Sequence[Mapping[str, Any]] = (),
     ) -> None:
         encoded_template_id = urllib.parse.quote(template_id, safe="")
         encoded_build_id = urllib.parse.quote(build_id, safe="")
@@ -231,7 +232,7 @@ class QzTemplateClient:
             {
                 "fromImage": image,
                 "imageSource": image_source,
-                "steps": [],
+                "steps": [dict(step) for step in build_steps],
             },
         )
 
@@ -312,6 +313,7 @@ def create_template_from_image(
     image_source: str,
     timeout: float,
     exists_ok: bool,
+    build_steps: Sequence[Mapping[str, Any]] = (),
     stderr: TextIO | None = None,
     clock: Callable[[], float] | None = None,
     sleep: Callable[[float], None] | None = None,
@@ -356,6 +358,7 @@ def create_template_from_image(
             build_id=build_id,
             image=image,
             image_source=image_source,
+            build_steps=build_steps,
         )
     except QzTemplateError as exc:
         raise QzTemplateError(

--- a/Agents/utils/common/Harbor/qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/qz_template_mapping.py
@@ -250,7 +250,7 @@ def _parse_simple_build_steps(
         keyword, separator, argument = instruction.partition(" ")
         step_type = keyword.upper()
         argument = argument.strip()
-        if not separator or step_type not in {"RUN", "WORKDIR"} or not argument:
+        if not separator or step_type not in {"RUN", "USER", "WORKDIR"} or not argument:
             raise QzTemplateMappingError(
                 f"unsupported {dataset_name} Dockerfile instruction: {instruction!r}"
             )
@@ -263,7 +263,7 @@ def _parse_simple_build_steps(
 def load_swesmith_environment_plan(task_dir: Path) -> TaskEnvironmentPlan:
     """Split a generated SWE-Smith Dockerfile into shared and task steps.
 
-    This deliberately supports only the adapter's current FROM/WORKDIR/RUN
+    This deliberately supports only the adapter's current FROM/USER/WORKDIR/RUN
     shape. Other Dockerfiles belong to a later build-context materializer.
     """
     instance_id = _load_toml_string(task_dir, "metadata", "instance_id")
@@ -282,6 +282,7 @@ def load_swesmith_environment_plan(task_dir: Path) -> TaskEnvironmentPlan:
         instructions[:-1],
         dataset_name="SWE-Smith",
     )
+    build_steps.insert(0, _build_step("USER", "root"))
     return TaskEnvironmentPlan(
         image=image,
         build_steps=tuple(build_steps),
@@ -304,6 +305,7 @@ def load_sweverify_environment_plan(task_dir: Path) -> TaskEnvironmentPlan:
         instructions,
         dataset_name="SWE-bench Verified",
     )
+    build_steps.insert(0, _build_step("USER", "root"))
     return TaskEnvironmentPlan(image=image, build_steps=tuple(build_steps))
 
 
@@ -381,7 +383,7 @@ def normalize_build_steps(steps: Iterable[Mapping[str, Any]]) -> list[dict[str, 
             raise QzTemplateMappingError(f"build step {index} must be an object")
         step_type = step.get("type")
         args = step.get("args")
-        if step_type not in {"RUN", "WORKDIR"}:
+        if step_type not in {"RUN", "USER", "WORKDIR"}:
             raise QzTemplateMappingError(
                 f"build step {index} has unsupported type {step_type!r}"
             )

--- a/Agents/utils/common/Harbor/qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/qz_template_mapping.py
@@ -1,4 +1,4 @@
-"""Inventory Harbor task images and emit a deterministic QZ Template map."""
+"""Inventory Harbor environment plans and emit a deterministic QZ Template map."""
 
 from __future__ import annotations
 
@@ -8,7 +8,9 @@ import json
 import os
 import re
 import sys
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -18,11 +20,15 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.9/3.10
     tomllib = None
 
 
-SCHEMA_VERSION = 1
-IDENTITY_VERSION = "qz-template-image-v1"
+SCHEMA_VERSION = 2
+IDENTITY_VERSION = "qz-template-environment-v2"
+LEGACY_SCHEMA_VERSION = 1
+LEGACY_IDENTITY_VERSION = "qz-template-image-v1"
 DEFAULT_SPEC = "g.c1"
 DEFAULT_IMAGE_SOURCE = "official"
 SPEC_CHOICES = ("g.c1", "g.c2", "g.c4")
+DATASET_KINDS = ("image", "smith", "sweverify")
+ENVIRONMENT_PLAN_SCHEMA_VERSION = 1
 TEMPLATE_NAME_MAX_LENGTH = 63
 TEMPLATE_LABEL_MAX_LENGTH = 32
 TEMPLATE_NAME_PATTERN = re.compile(r"[A-Za-z0-9_]+")
@@ -32,7 +38,16 @@ class QzTemplateMappingError(RuntimeError):
     """Raised when a benchmark cannot be represented by the mapping schema."""
 
 
-def _fallback_environment_docker_image(path: Path) -> str:
+@dataclass(frozen=True)
+class TaskEnvironmentPlan:
+    """Template inputs and per-Sandbox initialization for one Harbor task."""
+
+    image: str
+    build_steps: tuple[dict[str, Any], ...] = ()
+    init_steps: tuple[dict[str, str], ...] = ()
+
+
+def _fallback_toml_string(path: Path, wanted_section: str, wanted_key: str) -> str:
     """Read one TOML string on Python versions that do not provide tomllib."""
     section = ""
     decoder = json.JSONDecoder()
@@ -41,10 +56,10 @@ def _fallback_environment_docker_image(path: Path) -> str:
         if stripped.startswith("[") and stripped.endswith("]"):
             section = stripped[1:-1].strip()
             continue
-        if section != "environment" or "=" not in stripped:
+        if section != wanted_section or "=" not in stripped:
             continue
         key, raw_value = stripped.split("=", 1)
-        if key.strip() != "docker_image":
+        if key.strip() != wanted_key:
             continue
         value = raw_value.lstrip()
         if value.startswith('"'):
@@ -52,60 +67,244 @@ def _fallback_environment_docker_image(path: Path) -> str:
                 parsed, end = decoder.raw_decode(value)
             except json.JSONDecodeError as exc:
                 raise QzTemplateMappingError(
-                    f"invalid environment.docker_image in {path}"
+                    f"invalid {wanted_section}.{wanted_key} in {path}"
                 ) from exc
             trailing = value[end:].strip()
             if trailing and not trailing.startswith("#"):
                 raise QzTemplateMappingError(
-                    f"invalid environment.docker_image in {path}"
+                    f"invalid {wanted_section}.{wanted_key} in {path}"
                 )
             return parsed
         if value.startswith("'"):
             end = value.find("'", 1)
             if end == -1:
                 raise QzTemplateMappingError(
-                    f"invalid environment.docker_image in {path}"
+                    f"invalid {wanted_section}.{wanted_key} in {path}"
                 )
             trailing = value[end + 1 :].strip()
             if trailing and not trailing.startswith("#"):
                 raise QzTemplateMappingError(
-                    f"invalid environment.docker_image in {path}"
+                    f"invalid {wanted_section}.{wanted_key} in {path}"
                 )
             return value[1:end]
         raise QzTemplateMappingError(
-            f"environment.docker_image must be a TOML string in {path}"
+            f"{wanted_section}.{wanted_key} must be a TOML string in {path}"
         )
     raise QzTemplateMappingError(
-        f"task is missing environment.docker_image: {path.parent}"
+        f"task is missing {wanted_section}.{wanted_key}: {path.parent}"
     )
 
 
-def load_task_image(task_dir: Path) -> str:
-    """Return the prebuilt image declared by a local Harbor task."""
+def _load_toml_string(task_dir: Path, section: str, key: str) -> str:
     task_config = task_dir / "task.toml"
     if not task_config.is_file():
         raise QzTemplateMappingError(f"task.toml not found under {task_dir}")
 
     if tomllib is None:
-        value = _fallback_environment_docker_image(task_config)
+        value = _fallback_toml_string(task_config, section, key)
     else:
         try:
             with task_config.open("rb") as handle:
                 payload = tomllib.load(handle)
         except tomllib.TOMLDecodeError as exc:
             raise QzTemplateMappingError(f"invalid TOML: {task_config}") from exc
-        environment = payload.get("environment")
+        section_payload = payload.get(section)
         value = (
-            environment.get("docker_image")
-            if isinstance(environment, Mapping)
-            else None
+            section_payload.get(key) if isinstance(section_payload, Mapping) else None
         )
 
     if not isinstance(value, str) or not value.strip():
-        raise QzTemplateMappingError(
-            f"task is missing environment.docker_image: {task_dir}"
-        )
+        raise QzTemplateMappingError(f"task is missing {section}.{key}: {task_dir}")
     return value.strip()
+
+
+def load_task_image(task_dir: Path) -> str:
+    """Return the prebuilt image declared by a local Harbor task."""
+    return _load_toml_string(task_dir, "environment", "docker_image")
+
+
+def load_image_environment_plan(task_dir: Path) -> TaskEnvironmentPlan:
+    """Represent one task that already declares its final runnable image."""
+    return TaskEnvironmentPlan(image=load_task_image(task_dir))
+
+
+def load_environment_plan_manifest(path: Path) -> dict[str, TaskEnvironmentPlan]:
+    """Load dataset-independent task plans from one JSON manifest."""
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise QzTemplateMappingError(
+            f"environment plan is not valid UTF-8 JSON: {path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise QzTemplateMappingError("environment plan must be a JSON object")
+    if payload.get("schema_version") != ENVIRONMENT_PLAN_SCHEMA_VERSION:
+        raise QzTemplateMappingError(
+            "unsupported environment plan schema_version: "
+            f"{payload.get('schema_version')!r}"
+        )
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, dict):
+        raise QzTemplateMappingError("environment plan is missing tasks")
+
+    plans = {}
+    for task_key, entry in tasks.items():
+        if not isinstance(task_key, str) or not task_key.strip():
+            raise QzTemplateMappingError("environment plan has an invalid task key")
+        if not isinstance(entry, dict):
+            raise QzTemplateMappingError(
+                f"environment plan task {task_key!r} must be an object"
+            )
+        image = entry.get("image")
+        build_steps = entry.get("build_steps", [])
+        init_steps = entry.get("init_steps", [])
+        if not isinstance(image, str) or not image.strip():
+            raise QzTemplateMappingError(
+                f"environment plan task {task_key!r} is missing image"
+            )
+        if not isinstance(build_steps, list):
+            raise QzTemplateMappingError(
+                f"environment plan task {task_key!r} build_steps must be a list"
+            )
+        if not isinstance(init_steps, list):
+            raise QzTemplateMappingError(
+                f"environment plan task {task_key!r} init_steps must be a list"
+            )
+        plans[task_key] = TaskEnvironmentPlan(
+            image=image.strip(),
+            build_steps=tuple(build_steps),
+            init_steps=tuple(init_steps),
+        )
+    return plans
+
+
+def environment_plan_for_task(
+    plans: Mapping[str, TaskEnvironmentPlan],
+    task_key: str,
+    _task_dir: Path,
+) -> TaskEnvironmentPlan:
+    """Select one task from a previously loaded generic manifest."""
+    try:
+        return plans[task_key]
+    except KeyError:
+        raise QzTemplateMappingError(
+            f"environment plan is missing selected task {task_key!r}"
+        ) from None
+
+
+def load_swesmith_task_plan(
+    _task_key: str,
+    task_dir: Path,
+) -> TaskEnvironmentPlan:
+    """Adapt the SWE-Smith convenience loader to the generic loader contract."""
+    return load_swesmith_environment_plan(task_dir)
+
+
+def load_sweverify_task_plan(
+    _task_key: str,
+    task_dir: Path,
+) -> TaskEnvironmentPlan:
+    """Adapt a generated SWE-bench Verified task to an environment plan."""
+    return load_sweverify_environment_plan(task_dir)
+
+
+def _build_step(step_type: str, argument: str) -> dict[str, Any]:
+    return {"type": step_type, "args": [argument]}
+
+
+def _load_simple_dockerfile(
+    task_dir: Path,
+    dataset_name: str,
+) -> tuple[Path, str, list[str]]:
+    dockerfile = task_dir / "environment" / "Dockerfile"
+    if not dockerfile.is_file():
+        raise QzTemplateMappingError(
+            f"{dataset_name} Dockerfile not found: {dockerfile}"
+        )
+
+    instructions = [
+        line.strip()
+        for line in dockerfile.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    if not instructions or not instructions[0].upper().startswith("FROM "):
+        raise QzTemplateMappingError(
+            f"{dataset_name} Dockerfile must start with FROM: {dockerfile}"
+        )
+    image_parts = instructions[0][5:].strip().split()
+    if len(image_parts) != 1:
+        raise QzTemplateMappingError(
+            f"unsupported {dataset_name} FROM instruction: {instructions[0]!r}"
+        )
+    return dockerfile, image_parts[0], instructions[1:]
+
+
+def _parse_simple_build_steps(
+    instructions: Iterable[str],
+    *,
+    dataset_name: str,
+) -> tuple[list[dict[str, Any]], str]:
+    build_steps = []
+    workdir = "/"
+    for instruction in instructions:
+        keyword, separator, argument = instruction.partition(" ")
+        step_type = keyword.upper()
+        argument = argument.strip()
+        if not separator or step_type not in {"RUN", "WORKDIR"} or not argument:
+            raise QzTemplateMappingError(
+                f"unsupported {dataset_name} Dockerfile instruction: {instruction!r}"
+            )
+        if step_type == "WORKDIR":
+            workdir = argument
+        build_steps.append(_build_step(step_type, argument))
+    return build_steps, workdir
+
+
+def load_swesmith_environment_plan(task_dir: Path) -> TaskEnvironmentPlan:
+    """Split a generated SWE-Smith Dockerfile into shared and task steps.
+
+    This deliberately supports only the adapter's current FROM/WORKDIR/RUN
+    shape. Other Dockerfiles belong to a later build-context materializer.
+    """
+    instance_id = _load_toml_string(task_dir, "metadata", "instance_id")
+    dockerfile, image, instructions = _load_simple_dockerfile(
+        task_dir,
+        "SWE-Smith",
+    )
+
+    expected_init = f"RUN git fetch && git checkout {instance_id}"
+    if not instructions or instructions[-1] != expected_init:
+        raise QzTemplateMappingError(
+            "SWE-Smith Dockerfile must end with task checkout "
+            f"{expected_init!r}: {dockerfile}"
+        )
+    build_steps, workdir = _parse_simple_build_steps(
+        instructions[:-1],
+        dataset_name="SWE-Smith",
+    )
+    return TaskEnvironmentPlan(
+        image=image,
+        build_steps=tuple(build_steps),
+        init_steps=(
+            {
+                "run": f"git fetch && git checkout {instance_id}",
+                "cwd": workdir,
+            },
+        ),
+    )
+
+
+def load_sweverify_environment_plan(task_dir: Path) -> TaskEnvironmentPlan:
+    """Read the generated SWE-bench Verified final-image Dockerfile."""
+    _, image, instructions = _load_simple_dockerfile(
+        task_dir,
+        "SWE-bench Verified",
+    )
+    build_steps, _ = _parse_simple_build_steps(
+        instructions,
+        dataset_name="SWE-bench Verified",
+    )
+    return TaskEnvironmentPlan(image=image, build_steps=tuple(build_steps))
 
 
 def _task_list_entries(path: Path) -> list[str]:
@@ -174,15 +373,81 @@ def discover_tasks(
     return sorted(discovered.items())
 
 
-def template_identity(image: str, spec: str, image_source: str) -> str:
+def normalize_build_steps(steps: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Validate the small QZ build-step subset supported by this mapping."""
+    normalized = []
+    for index, step in enumerate(steps):
+        if not isinstance(step, Mapping):
+            raise QzTemplateMappingError(f"build step {index} must be an object")
+        step_type = step.get("type")
+        args = step.get("args")
+        if step_type not in {"RUN", "WORKDIR"}:
+            raise QzTemplateMappingError(
+                f"build step {index} has unsupported type {step_type!r}"
+            )
+        if (
+            (not isinstance(args, list) and not isinstance(args, tuple))
+            or len(args) != 1
+            or not isinstance(args[0], str)
+            or not args[0].strip()
+        ):
+            raise QzTemplateMappingError(
+                f"build step {index} must contain one non-empty string argument"
+            )
+        normalized.append({"type": step_type, "args": [args[0].strip()]})
+    return normalized
+
+
+def normalize_init_steps(steps: Iterable[Mapping[str, Any]]) -> list[dict[str, str]]:
+    """Validate ordered commands executed after a fresh Sandbox is created."""
+    normalized = []
+    for index, step in enumerate(steps):
+        if not isinstance(step, Mapping):
+            raise QzTemplateMappingError(f"init step {index} must be an object")
+        command = step.get("run")
+        cwd = step.get("cwd")
+        if not isinstance(command, str) or not command.strip():
+            raise QzTemplateMappingError(
+                f"init step {index} is missing a non-empty run command"
+            )
+        normalized_step = {"run": command.strip()}
+        if cwd is not None:
+            if not isinstance(cwd, str) or not cwd.strip():
+                raise QzTemplateMappingError(f"init step {index} has an invalid cwd")
+            normalized_step["cwd"] = cwd.strip()
+        normalized.append(normalized_step)
+    return normalized
+
+
+def template_identity(
+    image: str,
+    spec: str,
+    image_source: str,
+    build_steps: Iterable[Mapping[str, Any]] = (),
+    *,
+    identity_version: str = IDENTITY_VERSION,
+) -> str:
     """Return the stable identity for one QZ Template input tuple."""
+    normalized_steps = normalize_build_steps(build_steps)
+    identity_payload: dict[str, Any] = {
+        "identity_version": identity_version,
+        "image": image,
+        "image_source": image_source,
+        "spec": spec,
+    }
+    if identity_version == IDENTITY_VERSION:
+        identity_payload["build_steps"] = normalized_steps
+    elif identity_version == LEGACY_IDENTITY_VERSION:
+        if normalized_steps:
+            raise QzTemplateMappingError(
+                "legacy Template identity does not support build steps"
+            )
+    else:
+        raise QzTemplateMappingError(
+            f"unsupported Template identity_version: {identity_version!r}"
+        )
     payload = json.dumps(
-        {
-            "identity_version": IDENTITY_VERSION,
-            "image": image,
-            "image_source": image_source,
-            "spec": spec,
-        },
+        identity_payload,
         ensure_ascii=True,
         sort_keys=True,
         separators=(",", ":"),
@@ -208,8 +473,9 @@ def build_inventory(
     tasks: Iterable[tuple[str, Path]],
     spec: str = DEFAULT_SPEC,
     image_source: str = DEFAULT_IMAGE_SOURCE,
+    plan_loader: Callable[[str, Path], TaskEnvironmentPlan] | None = None,
 ) -> dict[str, Any]:
-    """Build a deterministic schema-v1 task-to-Template inventory."""
+    """Build a deterministic schema-v2 task-to-Template inventory."""
     benchmark = benchmark.strip()
     image_source = image_source.strip()
     if not benchmark:
@@ -220,15 +486,26 @@ def build_inventory(
         raise QzTemplateMappingError("image source must not be empty")
 
     templates: dict[str, dict[str, Any]] = {}
-    task_map: dict[str, dict[str, str]] = {}
+    task_map: dict[str, dict[str, Any]] = {}
     failures = []
     for task_key, task_dir in sorted(tasks):
         try:
-            image = load_task_image(task_dir)
+            plan = (
+                plan_loader(task_key, task_dir)
+                if plan_loader is not None
+                else load_image_environment_plan(task_dir)
+            )
+            image = plan.image.strip()
+            if not image:
+                raise QzTemplateMappingError(
+                    f"environment plan has an empty image: {task_dir}"
+                )
+            build_steps = normalize_build_steps(plan.build_steps)
+            init_steps = normalize_init_steps(plan.init_steps)
         except QzTemplateMappingError as exc:
             failures.append(f"{task_key}: {exc}")
             continue
-        identity = template_identity(image, spec, image_source)
+        identity = template_identity(image, spec, image_source, build_steps)
         template_key = f"sha256:{identity}"
         templates.setdefault(
             template_key,
@@ -236,12 +513,14 @@ def build_inventory(
                 "image": image,
                 "image_source": image_source,
                 "spec": spec,
+                "build_steps": build_steps,
                 "template_id": None,
                 "template_name": template_name(image, identity),
             },
         )
         task_map[task_key] = {
             "docker_image": image,
+            "init_steps": init_steps,
             "template_key": template_key,
         }
 
@@ -326,6 +605,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dataset-root", required=True, type=Path)
     parser.add_argument("--benchmark", required=True)
     parser.add_argument("--task-list", type=Path)
+    parser.add_argument("--dataset-kind", choices=DATASET_KINDS, default="image")
+    parser.add_argument("--environment-plan-file", type=Path)
     parser.add_argument("--spec", choices=SPEC_CHOICES, default=DEFAULT_SPEC)
     parser.add_argument("--image-source", default=DEFAULT_IMAGE_SOURCE)
     parser.add_argument("--output", type=Path)
@@ -341,11 +622,25 @@ def main(
     args = parse_args(argv)
     try:
         tasks = discover_tasks(args.dataset_root, args.task_list)
+        if args.environment_plan_file is not None and args.dataset_kind != "image":
+            raise QzTemplateMappingError(
+                "use either --environment-plan-file or a generated dataset kind"
+            )
+        if args.environment_plan_file is not None:
+            plans = load_environment_plan_manifest(args.environment_plan_file)
+            plan_loader = partial(environment_plan_for_task, plans)
+        elif args.dataset_kind == "smith":
+            plan_loader = load_swesmith_task_plan
+        elif args.dataset_kind == "sweverify":
+            plan_loader = load_sweverify_task_plan
+        else:
+            plan_loader = None
         inventory = build_inventory(
             benchmark=args.benchmark,
             tasks=tasks,
             spec=args.spec,
             image_source=args.image_source,
+            plan_loader=plan_loader,
         )
         if args.output is None:
             json.dump(inventory, stdout, ensure_ascii=False, indent=2, sort_keys=True)
@@ -355,7 +650,7 @@ def main(
             _write_json(args.output, inventory)
             print(
                 f"wrote {len(inventory['tasks'])} tasks and "
-                f"{len(inventory['templates'])} unique images to {args.output}",
+                f"{len(inventory['templates'])} unique environments to {args.output}",
                 file=stderr,
             )
         return 0

--- a/Agents/utils/common/Harbor/qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/qz_template_mapping.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import sys
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
@@ -294,7 +295,7 @@ def load_swesmith_environment_plan(task_dir: Path) -> TaskEnvironmentPlan:
         build_steps=tuple(build_steps),
         init_steps=(
             {
-                "run": f"git fetch && git checkout {instance_id}",
+                "run": f"git fetch && git checkout {shlex.quote(instance_id)}",
                 "cwd": workdir,
             },
         ),

--- a/Agents/utils/common/Harbor/qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/qz_template_mapping.py
@@ -200,6 +200,12 @@ def load_swesmith_task_plan(
     return load_swesmith_environment_plan(task_dir)
 
 
+def swesmith_task_key(task_dir: Path) -> str:
+    """Return the task name Harbor passes to an environment provider."""
+    instance_id = _load_toml_string(task_dir, "metadata", "instance_id")
+    return f"swe-smith__{instance_id}"
+
+
 def load_sweverify_task_plan(
     _task_key: str,
     task_dir: Path,
@@ -632,6 +638,7 @@ def main(
             plans = load_environment_plan_manifest(args.environment_plan_file)
             plan_loader = partial(environment_plan_for_task, plans)
         elif args.dataset_kind == "smith":
+            tasks = [(swesmith_task_key(task_dir), task_dir) for _, task_dir in tasks]
             plan_loader = load_swesmith_task_plan
         elif args.dataset_kind == "sweverify":
             plan_loader = load_sweverify_task_plan

--- a/Agents/utils/common/Harbor/qz_template_resolver.py
+++ b/Agents/utils/common/Harbor/qz_template_resolver.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -14,15 +15,26 @@ import qz_template_manager as manager
 import qz_template_mapping as mapping
 
 MAPPING_ENV_VAR = "QZ_SANDBOX_TEMPLATE_MAP"
-SUPPORTED_SCHEMA_VERSION = mapping.SCHEMA_VERSION
+SUPPORTED_MAPPING_VERSIONS = {
+    (mapping.LEGACY_SCHEMA_VERSION, mapping.LEGACY_IDENTITY_VERSION),
+    (mapping.SCHEMA_VERSION, mapping.IDENTITY_VERSION),
+}
 
 
 class QzTemplateResolutionError(RuntimeError):
     """Raised when a task cannot resolve to one ready QZ Template."""
 
 
+@dataclass(frozen=True)
+class ResolvedTaskEnvironment:
+    """A ready Template plus commands required for this task's fresh Sandbox."""
+
+    template_id: str
+    init_steps: tuple[dict[str, str], ...]
+
+
 def load_mapping(path: Path) -> dict[str, Any]:
-    """Load and minimally validate a schema-v1 QZ Template mapping."""
+    """Load and minimally validate a supported QZ Template mapping."""
     try:
         payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -31,15 +43,15 @@ def load_mapping(path: Path) -> dict[str, Any]:
         ) from exc
     if not isinstance(payload, dict):
         raise QzTemplateResolutionError("QZ Template mapping must be a JSON object")
-    if payload.get("schema_version") != SUPPORTED_SCHEMA_VERSION:
+    version_pair = (
+        payload.get("schema_version"),
+        payload.get("identity_version"),
+    )
+    if version_pair not in SUPPORTED_MAPPING_VERSIONS:
         raise QzTemplateResolutionError(
-            "unsupported QZ Template mapping schema_version: "
-            f"{payload.get('schema_version')!r}"
-        )
-    if payload.get("identity_version") != mapping.IDENTITY_VERSION:
-        raise QzTemplateResolutionError(
-            "unsupported QZ Template mapping identity_version: "
-            f"{payload.get('identity_version')!r}"
+            "unsupported QZ Template mapping version pair: "
+            f"schema_version={version_pair[0]!r}, "
+            f"identity_version={version_pair[1]!r}"
         )
     if not isinstance(payload.get("tasks"), dict):
         raise QzTemplateResolutionError("QZ Template mapping is missing tasks")
@@ -97,11 +109,29 @@ def _required_string(
     return value.strip()
 
 
-def task_template_entry(
+def _normalized_plan_steps(
+    payload: Mapping[str, Any],
+    task: Mapping[str, Any],
+    template: Mapping[str, Any],
+    context: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    if payload.get("schema_version") == mapping.LEGACY_SCHEMA_VERSION:
+        return [], []
+    try:
+        build_steps = mapping.normalize_build_steps(template.get("build_steps", []))
+        init_steps = mapping.normalize_init_steps(task.get("init_steps", []))
+    except mapping.QzTemplateMappingError as exc:
+        raise QzTemplateResolutionError(
+            f"{context} has an invalid plan: {exc}"
+        ) from exc
+    return build_steps, init_steps
+
+
+def _task_environment_entries(
     payload: Mapping[str, Any],
     task_name: str,
-) -> tuple[str, dict[str, Any]]:
-    """Return the template key and entry selected for one Harbor task."""
+) -> tuple[str, dict[str, Any], list[dict[str, str]]]:
+    """Return validated Template and init entries selected for one task."""
     key = resolve_task_key(payload, task_name)
     task = payload["tasks"].get(key)
     if not isinstance(task, dict):
@@ -140,7 +170,23 @@ def task_template_entry(
         raise QzTemplateResolutionError(
             f"mapping task {key!r} image does not match Template {template_key!r}"
         )
-    identity = mapping.template_identity(image, spec, image_source)
+    build_steps, init_steps = _normalized_plan_steps(
+        payload,
+        task,
+        template,
+        f"mapping task {key!r}",
+    )
+    identity = mapping.template_identity(
+        image,
+        spec,
+        image_source,
+        build_steps,
+        identity_version=_required_string(
+            payload,
+            "identity_version",
+            "QZ Template mapping",
+        ),
+    )
     expected_key = f"sha256:{identity}"
     if template_key != expected_key:
         raise QzTemplateResolutionError(
@@ -152,6 +198,15 @@ def task_template_entry(
             f"mapping Template {template_key!r} does not use its "
             "content-derived template_name"
         )
+    return template_key, template, init_steps
+
+
+def task_template_entry(
+    payload: Mapping[str, Any],
+    task_name: str,
+) -> tuple[str, dict[str, Any]]:
+    """Return the template key and entry selected for one Harbor task."""
+    template_key, template, _ = _task_environment_entries(payload, task_name)
     return template_key, template
 
 
@@ -198,14 +253,11 @@ def _validated_ready_template_id(
     return template_id
 
 
-def resolve_task_template(
-    mapping_path: Path,
-    task_name: str,
+def _resolve_template_entry(
+    template_key: str,
+    entry: Mapping[str, Any],
     client: manager.QzTemplateClient,
 ) -> str:
-    """Resolve one task to a live, ready Template ID without creating it."""
-    payload = load_mapping(mapping_path)
-    template_key, entry = task_template_entry(payload, task_name)
     cached_id = entry.get("template_id")
     if cached_id is not None:
         if not isinstance(cached_id, str) or not cached_id.strip():
@@ -243,6 +295,31 @@ def resolve_task_template(
     )
 
 
+def resolve_task_template(
+    mapping_path: Path,
+    task_name: str,
+    client: manager.QzTemplateClient,
+) -> str:
+    """Resolve one task to a live, ready Template ID without creating it."""
+    payload = load_mapping(mapping_path)
+    template_key, entry = task_template_entry(payload, task_name)
+    return _resolve_template_entry(template_key, entry, client)
+
+
+def resolve_task_environment(
+    mapping_path: Path,
+    task_name: str,
+    client: manager.QzTemplateClient,
+) -> ResolvedTaskEnvironment:
+    """Resolve the ready Template and per-Sandbox init steps for one task."""
+    payload = load_mapping(mapping_path)
+    template_key, entry, init_steps = _task_environment_entries(payload, task_name)
+    return ResolvedTaskEnvironment(
+        template_id=_resolve_template_entry(template_key, entry, client),
+        init_steps=tuple(init_steps),
+    )
+
+
 def resolve_task_template_from_environment(
     mapping_path: Path,
     task_name: str,
@@ -250,6 +327,23 @@ def resolve_task_template_from_environment(
     """Resolve using QZ credentials held only in the process environment."""
     try:
         return resolve_task_template(
+            mapping_path,
+            task_name,
+            manager.client_from_environment(),
+        )
+    except manager.QzTemplateError as exc:
+        raise QzTemplateResolutionError(
+            f"live QZ Template lookup failed for task {task_name!r}: {exc}"
+        ) from exc
+
+
+def resolve_task_environment_from_environment(
+    mapping_path: Path,
+    task_name: str,
+) -> ResolvedTaskEnvironment:
+    """Resolve a task environment using credentials held only in the process."""
+    try:
+        return resolve_task_environment(
             mapping_path,
             task_name,
             manager.client_from_environment(),
@@ -350,6 +444,7 @@ def materialize_template_entry(
         image=_required_string(entry, "image", template_key),
         spec=_required_string(entry, "spec", template_key),
         image_source=_required_string(entry, "image_source", template_key),
+        build_steps=entry.get("build_steps", []),
         timeout=timeout,
         exists_ok=True,
         stderr=stderr,

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -401,6 +401,8 @@ class CreateRetryTest(unittest.TestCase):
         succeeds_after_failure: bool,
         prepare_failure_name: str | None = None,
         prepare_exit_code: int = 0,
+        init_steps: tuple[dict[str, str], ...] = (),
+        init_exit_code: int = 0,
     ) -> tuple[int, Exception | None, list[tuple[str, dict]]]:
         dependency_modules, error_types = retry_dependency_stubs()
         expected_error_types = (*error_types.values(), RuntimeError)
@@ -411,9 +413,12 @@ class CreateRetryTest(unittest.TestCase):
                 command_calls.append((command, kwargs))
                 if prepare_failure_name is not None:
                     raise error_types[prepare_failure_name]("prepare failed")
+                exit_code = (
+                    init_exit_code if len(command_calls) > 1 else prepare_exit_code
+                )
                 return types.SimpleNamespace(
-                    exit_code=prepare_exit_code,
-                    stderr="prepare stderr" if prepare_exit_code else "",
+                    exit_code=exit_code,
+                    stderr="command stderr" if exit_code else "",
                     stdout="",
                 )
 
@@ -448,6 +453,7 @@ class CreateRetryTest(unittest.TestCase):
             module = load_module()
             environment = module.QzSandboxEnvironment(template="test_template")
             environment._workdir = Path("/app")
+            environment._task_init_steps = init_steps
             try:
                 asyncio.run(environment._create_sandbox())
             except expected_error_types as exc:
@@ -511,7 +517,40 @@ class CreateRetryTest(unittest.TestCase):
         self.assertEqual(calls, 1)
         self.assertIsInstance(error, RuntimeError)
         self.assertIn("failed to prepare task workdir /app", str(error))
-        self.assertIn("exit 23: prepare stderr", str(error))
+        self.assertIn("exit 23: command stderr", str(error))
+
+    def test_runs_task_init_after_workdir_preparation(self):
+        calls, error, command_calls = self.run_create(
+            None,
+            succeeds_after_failure=True,
+            init_steps=(
+                {"run": "git fetch && git checkout instance-a", "cwd": "/testbed"},
+            ),
+        )
+
+        self.assertEqual(calls, 1)
+        self.assertIsNone(error)
+        self.assertEqual(
+            command_calls[1],
+            (
+                "git fetch && git checkout instance-a",
+                {"user": "root", "cwd": "/testbed", "timeout": 600},
+            ),
+        )
+
+    def test_task_init_failure_does_not_retry_allocation(self):
+        calls, error, command_calls = self.run_create(
+            None,
+            succeeds_after_failure=True,
+            init_steps=({"run": "git checkout missing", "cwd": "/testbed"},),
+            init_exit_code=7,
+        )
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(len(command_calls), 2)
+        self.assertIsInstance(error, RuntimeError)
+        self.assertIn("QZ task init step 1 failed", str(error))
+        self.assertIn("exit 7: command stderr", str(error))
 
 
 class TemplateResolutionTest(unittest.TestCase):
@@ -557,13 +596,20 @@ class TemplateResolutionTest(unittest.TestCase):
         self.env_vars["QZ_SANDBOX_TEMPLATE_MAP"] = "/tmp/qz-map.json"
         with patch.object(
             self.module,
-            "resolve_task_template_from_environment",
-            return_value="mapped-template-id",
+            "resolve_task_environment_from_environment",
+            return_value=types.SimpleNamespace(
+                template_id="mapped-template-id",
+                init_steps=({"run": "git checkout task", "cwd": "/testbed"},),
+            ),
         ) as resolve:
             env = self.make_env()
 
         self.assertEqual(env._template_name, "mapped-template-id")
         self.assertEqual(env._template_override, "mapped-template-id")
+        self.assertEqual(
+            env._task_init_steps,
+            ({"run": "git checkout task", "cwd": "/testbed"},),
+        )
         resolve.assert_called_once_with(
             Path("/tmp/qz-map.json"),
             "test-environment",

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -534,7 +534,7 @@ class CreateRetryTest(unittest.TestCase):
             command_calls[1],
             (
                 "git fetch && git checkout instance-a",
-                {"user": "root", "cwd": "/testbed", "timeout": 600},
+                {"cwd": "/testbed", "timeout": 600},
             ),
         )
 

--- a/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
@@ -249,6 +249,7 @@ class CreateTemplateTest(unittest.TestCase):
         template_id = self.create(
             opener,
             build_steps=[
+                {"type": "USER", "args": ["root"]},
                 {"type": "WORKDIR", "args": ["/testbed"]},
                 {"type": "RUN", "args": ["mkdir -p /logs"]},
             ],
@@ -273,6 +274,7 @@ class CreateTemplateTest(unittest.TestCase):
                 "fromImage": "registry.example/task:tag",
                 "imageSource": "official",
                 "steps": [
+                    {"type": "USER", "args": ["root"]},
                     {"type": "WORKDIR", "args": ["/testbed"]},
                     {"type": "RUN", "args": ["mkdir -p /logs"]},
                 ],

--- a/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_manager.py
@@ -248,6 +248,10 @@ class CreateTemplateTest(unittest.TestCase):
 
         template_id = self.create(
             opener,
+            build_steps=[
+                {"type": "WORKDIR", "args": ["/testbed"]},
+                {"type": "RUN", "args": ["mkdir -p /logs"]},
+            ],
             stderr=stderr,
             clock=clock,
             sleep=sleeps.append,
@@ -268,7 +272,10 @@ class CreateTemplateTest(unittest.TestCase):
             {
                 "fromImage": "registry.example/task:tag",
                 "imageSource": "official",
-                "steps": [],
+                "steps": [
+                    {"type": "WORKDIR", "args": ["/testbed"]},
+                    {"type": "RUN", "args": ["mkdir -p /logs"]},
+                ],
             },
         )
         self.assertIn("templateID=template-1 buildID=build-1", stderr.getvalue())

--- a/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
@@ -175,6 +175,35 @@ RUN mkdir -p /logs
 
         self.assertEqual(len(inventory["templates"]), 2)
 
+    def test_swesmith_cli_uses_harbor_task_name(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "tasks"
+            root.mkdir()
+            self.make_smith_task(root, "instance-a", "smith/base:v1")
+            output = Path(temporary) / "mapping.json"
+
+            result = mapping.main(
+                [
+                    "--dataset-root",
+                    str(root),
+                    "--dataset-kind",
+                    "smith",
+                    "--benchmark",
+                    "smith",
+                    "--output",
+                    str(output),
+                ],
+                stderr=io.StringIO(),
+            )
+            inventory = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(list(inventory["tasks"]), ["swe-smith__instance-a"])
+        self.assertEqual(
+            inventory["tasks"]["swe-smith__instance-a"]["init_steps"][0]["run"],
+            "git fetch && git checkout instance-a",
+        )
+
     def test_sweverify_cli_reads_generated_final_image_dockerfiles(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "tasks"

--- a/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
@@ -25,6 +25,49 @@ class QzTemplateMappingTest(unittest.TestCase):
         (task / "task.toml").write_text(environment, encoding="utf-8")
         return task
 
+    def make_smith_task(
+        self,
+        root: Path,
+        name: str,
+        image: str,
+        *,
+        common_command: str = "mkdir -p /logs",
+    ) -> Path:
+        task = root / name
+        (task / "environment").mkdir(parents=True)
+        (task / "task.toml").write_text(
+            f"[metadata]\ninstance_id = {json.dumps(name)}\n",
+            encoding="utf-8",
+        )
+        (task / "environment" / "Dockerfile").write_text(
+            f"""FROM {image}
+WORKDIR /testbed
+RUN apt-get update && apt-get install -y git
+RUN {common_command}
+RUN git fetch && git checkout {name}
+""",
+            encoding="utf-8",
+        )
+        return task
+
+    def make_sweverify_task(self, root: Path, name: str, image: str) -> Path:
+        task = root / name
+        (task / "environment").mkdir(parents=True)
+        (task / "task.toml").write_text(
+            "[environment]\nbuild_timeout_sec = 1800.0\n",
+            encoding="utf-8",
+        )
+        (task / "environment" / "Dockerfile").write_text(
+            f"""# Generated SWE-bench Verified adapter
+FROM {image}
+WORKDIR /testbed
+RUN curl -LsSf https://astral.sh/uv/0.7.13/install.sh | sh
+RUN mkdir -p /logs
+""",
+            encoding="utf-8",
+        )
+        return task
+
     def test_inventory_deduplicates_identical_images(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -45,11 +88,11 @@ class QzTemplateMappingTest(unittest.TestCase):
         baseline = mapping.template_identity("ubuntu:24.04", "g.c1", "official")
         self.assertEqual(
             baseline,
-            "916dae526a531141ceeeacb0b68f7a2830eca2a2d38754084b8db3ea7d2e488f",
+            "fa1e8ad968860c07b4ac6781615ea1876a087e0a4ca17cd5a692b69486a7d137",
         )
         self.assertEqual(
             mapping.template_name("ubuntu:24.04", baseline),
-            "af_ubuntu_24_04_916dae526a531141",
+            "af_ubuntu_24_04_fa1e8ad968860c07",
         )
         self.assertNotEqual(
             baseline,
@@ -62,6 +105,202 @@ class QzTemplateMappingTest(unittest.TestCase):
         self.assertNotEqual(
             baseline,
             mapping.template_identity("ubuntu:24.04", "g.c1", "custom"),
+        )
+        self.assertNotEqual(
+            baseline,
+            mapping.template_identity(
+                "ubuntu:24.04",
+                "g.c1",
+                "official",
+                [{"type": "RUN", "args": ["apt-get update"]}],
+            ),
+        )
+
+    def test_swesmith_tasks_share_build_plan_but_keep_task_init(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = self.make_smith_task(root, "instance-a", "smith/base:v1")
+            second = self.make_smith_task(root, "instance-b", "smith/base:v1")
+
+            inventory = mapping.build_inventory(
+                benchmark="smith",
+                tasks=[("instance-a", first), ("instance-b", second)],
+                plan_loader=mapping.load_swesmith_task_plan,
+            )
+
+        self.assertEqual(len(inventory["templates"]), 1)
+        template = next(iter(inventory["templates"].values()))
+        self.assertEqual(
+            template["build_steps"],
+            [
+                {"type": "WORKDIR", "args": ["/testbed"]},
+                {
+                    "type": "RUN",
+                    "args": ["apt-get update && apt-get install -y git"],
+                },
+                {"type": "RUN", "args": ["mkdir -p /logs"]},
+            ],
+        )
+        self.assertEqual(
+            inventory["tasks"]["instance-a"]["init_steps"],
+            [
+                {
+                    "run": "git fetch && git checkout instance-a",
+                    "cwd": "/testbed",
+                }
+            ],
+        )
+        self.assertEqual(
+            inventory["tasks"]["instance-b"]["init_steps"][0]["run"],
+            "git fetch && git checkout instance-b",
+        )
+
+    def test_swesmith_common_build_change_creates_another_template(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = self.make_smith_task(root, "instance-a", "smith/base:v1")
+            second = self.make_smith_task(
+                root,
+                "instance-b",
+                "smith/base:v1",
+                common_command="mkdir -p /different-logs",
+            )
+
+            inventory = mapping.build_inventory(
+                benchmark="smith",
+                tasks=[("instance-a", first), ("instance-b", second)],
+                plan_loader=mapping.load_swesmith_task_plan,
+            )
+
+        self.assertEqual(len(inventory["templates"]), 2)
+
+    def test_sweverify_cli_reads_generated_final_image_dockerfiles(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "tasks"
+            root.mkdir()
+            self.make_sweverify_task(
+                root,
+                "astropy__astropy-12907",
+                "swebench/sweb.eval.x86_64.astropy_1776_astropy-12907:latest",
+            )
+            output = Path(temporary) / "mapping.json"
+
+            result = mapping.main(
+                [
+                    "--dataset-root",
+                    str(root),
+                    "--dataset-kind",
+                    "sweverify",
+                    "--benchmark",
+                    "sweverify",
+                    "--output",
+                    str(output),
+                ],
+                stderr=io.StringIO(),
+            )
+            inventory = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        template = next(iter(inventory["templates"].values()))
+        self.assertEqual(
+            template["image"],
+            "swebench/sweb.eval.x86_64.astropy_1776_astropy-12907:latest",
+        )
+        self.assertEqual(
+            template["build_steps"],
+            [
+                {"type": "WORKDIR", "args": ["/testbed"]},
+                {
+                    "type": "RUN",
+                    "args": ["curl -LsSf https://astral.sh/uv/0.7.13/install.sh | sh"],
+                },
+                {"type": "RUN", "args": ["mkdir -p /logs"]},
+            ],
+        )
+        self.assertEqual(
+            inventory["tasks"]["astropy__astropy-12907"]["init_steps"],
+            [],
+        )
+
+    def test_generic_manifest_supports_checkout_reset_and_clone(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "tasks"
+            root.mkdir()
+            for task_name in ("checkout", "reset", "clone"):
+                self.make_task(root, task_name, None)
+            plan_path = Path(temporary) / "environment-plan.json"
+            plan_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "tasks": {
+                            "checkout": {
+                                "image": "shared/base:v1",
+                                "build_steps": [
+                                    {"type": "WORKDIR", "args": ["/testbed"]}
+                                ],
+                                "init_steps": [
+                                    {
+                                        "run": "git fetch && git checkout instance-a",
+                                        "cwd": "/testbed",
+                                    }
+                                ],
+                            },
+                            "reset": {
+                                "image": "shared/base:v1",
+                                "build_steps": [
+                                    {"type": "WORKDIR", "args": ["/testbed"]}
+                                ],
+                                "init_steps": [
+                                    {
+                                        "run": "git reset --hard abc && git clean -fd && git checkout abc",
+                                        "cwd": "/testbed",
+                                    }
+                                ],
+                            },
+                            "clone": {
+                                "image": "clone/base:v1",
+                                "init_steps": [
+                                    {
+                                        "run": "git clone https://github.com/org/repo.git /testbed && git -C /testbed checkout def",
+                                        "cwd": "/",
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = Path(temporary) / "mapping.json"
+
+            result = mapping.main(
+                [
+                    "--dataset-root",
+                    str(root),
+                    "--benchmark",
+                    "generic",
+                    "--environment-plan-file",
+                    str(plan_path),
+                    "--output",
+                    str(output),
+                ],
+                stderr=io.StringIO(),
+            )
+            inventory = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            inventory["tasks"]["checkout"]["template_key"],
+            inventory["tasks"]["reset"]["template_key"],
+        )
+        self.assertIn(
+            "git reset --hard",
+            inventory["tasks"]["reset"]["init_steps"][0]["run"],
+        )
+        self.assertIn(
+            "git clone",
+            inventory["tasks"]["clone"]["init_steps"][0]["run"],
         )
 
     def test_template_name_is_stable_and_qz_safe(self):
@@ -196,11 +435,13 @@ class QzTemplateMappingTest(unittest.TestCase):
             payload = json.loads(output.read_text(encoding="utf-8"))
 
         self.assertEqual(result, 0)
-        self.assertEqual(payload["schema_version"], 1)
-        self.assertEqual(payload["identity_version"], "qz-template-image-v1")
+        self.assertEqual(payload["schema_version"], 2)
+        self.assertEqual(payload["identity_version"], "qz-template-environment-v2")
         template = next(iter(payload["templates"].values()))
         self.assertIsNone(template["template_id"])
-        self.assertIn("1 tasks and 1 unique images", stderr.getvalue())
+        self.assertEqual(template["build_steps"], [])
+        self.assertEqual(payload["tasks"]["task-a"]["init_steps"], [])
+        self.assertIn("1 tasks and 1 unique environments", stderr.getvalue())
 
     def test_cli_does_not_write_partial_output_on_failure(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
@@ -133,6 +133,7 @@ RUN mkdir -p /logs
         self.assertEqual(
             template["build_steps"],
             [
+                {"type": "USER", "args": ["root"]},
                 {"type": "WORKDIR", "args": ["/testbed"]},
                 {
                     "type": "RUN",
@@ -209,6 +210,7 @@ RUN mkdir -p /logs
         self.assertEqual(
             template["build_steps"],
             [
+                {"type": "USER", "args": ["root"]},
                 {"type": "WORKDIR", "args": ["/testbed"]},
                 {
                     "type": "RUN",
@@ -237,7 +239,8 @@ RUN mkdir -p /logs
                             "checkout": {
                                 "image": "shared/base:v1",
                                 "build_steps": [
-                                    {"type": "WORKDIR", "args": ["/testbed"]}
+                                    {"type": "USER", "args": ["root"]},
+                                    {"type": "WORKDIR", "args": ["/testbed"]},
                                 ],
                                 "init_steps": [
                                     {
@@ -249,7 +252,8 @@ RUN mkdir -p /logs
                             "reset": {
                                 "image": "shared/base:v1",
                                 "build_steps": [
-                                    {"type": "WORKDIR", "args": ["/testbed"]}
+                                    {"type": "USER", "args": ["root"]},
+                                    {"type": "WORKDIR", "args": ["/testbed"]},
                                 ],
                                 "init_steps": [
                                     {
@@ -294,6 +298,8 @@ RUN mkdir -p /logs
             inventory["tasks"]["checkout"]["template_key"],
             inventory["tasks"]["reset"]["template_key"],
         )
+        template = next(iter(inventory["templates"].values()))
+        self.assertEqual(template["build_steps"][0], {"type": "USER", "args": ["root"]})
         self.assertIn(
             "git reset --hard",
             inventory["tasks"]["reset"]["init_steps"][0]["run"],

--- a/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_mapping.py
@@ -175,6 +175,21 @@ RUN mkdir -p /logs
 
         self.assertEqual(len(inventory["templates"]), 2)
 
+    def test_swesmith_quotes_instance_id_in_task_init(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            task = self.make_smith_task(
+                Path(temporary),
+                "instance;touch marker",
+                "smith/base:v1",
+            )
+
+            plan = mapping.load_swesmith_environment_plan(task)
+
+        self.assertEqual(
+            plan.init_steps[0]["run"],
+            "git fetch && git checkout 'instance;touch marker'",
+        )
+
     def test_swesmith_cli_uses_harbor_task_name(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "tasks"

--- a/Agents/utils/common/Harbor/tests/test_qz_template_resolver.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_template_resolver.py
@@ -175,6 +175,71 @@ class QzTemplateResolverTest(unittest.TestCase):
         self.assertEqual(template_id, "template-1")
         self.assertEqual(client.get_by_name_calls, [entry["template_name"]])
 
+    def test_resolve_task_environment_returns_task_init_steps(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path, _, entry = self.make_mapping(Path(temporary))
+            payload = resolver.load_mapping(path)
+            payload["tasks"]["task-a"]["init_steps"] = [
+                {"run": "git checkout task-a", "cwd": "/testbed"}
+            ]
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            client = FakeClient()
+            client.by_name[entry["template_name"]] = self.ready("template-1")
+
+            environment = resolver.resolve_task_environment(
+                path,
+                "task-a",
+                client,
+            )
+
+        self.assertEqual(environment.template_id, "template-1")
+        self.assertEqual(
+            environment.init_steps,
+            ({"run": "git checkout task-a", "cwd": "/testbed"},),
+        )
+
+    def test_schema_v1_resolves_as_an_empty_environment_plan(self):
+        legacy_identity = mapping.template_identity(
+            TEST_IMAGE,
+            TEST_SPEC,
+            TEST_IMAGE_SOURCE,
+            identity_version=mapping.LEGACY_IDENTITY_VERSION,
+        )
+        legacy_name = mapping.template_name(TEST_IMAGE, legacy_identity)
+        payload = {
+            "benchmark": "legacy",
+            "schema_version": mapping.LEGACY_SCHEMA_VERSION,
+            "identity_version": mapping.LEGACY_IDENTITY_VERSION,
+            "tasks": {
+                "task-a": {
+                    "docker_image": TEST_IMAGE,
+                    "template_key": f"sha256:{legacy_identity}",
+                }
+            },
+            "templates": {
+                f"sha256:{legacy_identity}": {
+                    "image": TEST_IMAGE,
+                    "image_source": TEST_IMAGE_SOURCE,
+                    "spec": TEST_SPEC,
+                    "template_name": legacy_name,
+                    "template_id": None,
+                }
+            },
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "mapping.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            client = FakeClient()
+            client.by_name[legacy_name] = self.ready(
+                "template-legacy",
+                template_name=legacy_name,
+            )
+
+            environment = resolver.resolve_task_environment(path, "task-a", client)
+
+        self.assertEqual(environment.template_id, "template-legacy")
+        self.assertEqual(environment.init_steps, ())
+
     def test_task_key_resolves_unique_nested_names_and_rejects_ambiguity(self):
         self.assertEqual(
             resolver.resolve_task_key(
@@ -308,6 +373,7 @@ class QzTemplateResolverTest(unittest.TestCase):
             image=entry["image"],
             spec=entry["spec"],
             image_source=entry["image_source"],
+            build_steps=[],
             timeout=30,
             exists_ok=True,
             stderr=stderr,


### PR DESCRIPTION
## 1. Why the change?

QZ Template mapping currently requires every Harbor task to declare a final `environment.docker_image`. SWE-Smith and SWE-bench Verified instead expose image-backed environments through generated Dockerfiles, and SWE-Smith needs a task-specific checkout after each fresh Sandbox starts.

This PR adds the minimum environment-plan layer needed to represent those datasets without adding general Dockerfile/build-context materialization.

Related to sii-system/tasks#160.

## 2. Summary of the change

- Add mapping schema v2 with Template `build_steps` and per-task `init_steps`; Template identity includes the ordered build steps.
- Keep existing final-image tasks and schema-v1 mappings readable.
- Support the verified QZ build-step subset: `USER`, `WORKDIR`, and `RUN`.
- Add a generic JSON environment-plan input plus built-in producers for:
  - SWE-Smith: explicitly select `USER root`, keep common `WORKDIR` / `RUN` steps in the Template, and run task checkout during fresh-Sandbox initialization.
  - SWE-bench Verified: parse its per-task final image, explicitly select `USER root`, and preserve its generated `WORKDIR` / `RUN` steps.
- Pass build steps through Template Manager/materialization and execute ordered init steps before Harbor agent setup/run.
- Document the mapping and runtime behavior.

The explicit build user is part of Template identity. This prevents a failed or semantically different non-root build from being reused under the same deterministic alias.

The scope intentionally excludes SWE-Rebench semantic changes, general Dockerfile/build-context support, image build/push, rebuild/delete, and implicit Template creation during benchmark runs.

## 3. Other details

Validation:

- Ruff format and lint checks passed.
- Local QZ Python tests: 109/109 passed.
- qz-sandbox QZ Python tests: 109/109 passed.
- `test_harboropik_qz.sh` passed.
- Python compilation and `git diff --check` passed.
- A full 500-task SWE-bench Verified export generated 500 mappings and 500 unique environments; every Template plan begins with `USER root`.
- Live QZ confirmed that `USER root` makes subsequent build steps run as UID 0.
- A real `astropy__astropy-12907` Template build reached `ready`, followed by a fresh-Sandbox Harbor Oracle trial with reward 1.0 and zero exceptions.

Agent Fleet did not build or push the SWE image; QZ pulled the already-published task image during explicit Template materialization.