### PR TITLE
Fix Pi summary JSON guidance

### DIFF
--- a/.github/scripts/pi_summary_prompt.md
+++ b/.github/scripts/pi_summary_prompt.md
@@ -21,6 +21,7 @@ When component interaction is meaningful, use a Mermaid `sequenceDiagram`,
 `flowchart`, or `graph`. If the interaction cannot be represented with one of
 those supported Mermaid forms, use an ASCII diagram. Return diagram source
 without code fences. Otherwise set `diagram` to null. For flowcharts and graphs,
-use simple alphanumeric node IDs, rectangular or diamond nodes, and double-quote
-all node text, for example `A["Start"] --> B{"Ready?"}`. Keep edge text to simple
-words.
+use simple alphanumeric node IDs and rectangular or diamond nodes. Keep node
+text unquoted in the raw JSON, for example `A[Start] --> B{Ready?}`; the
+validator adds double quotes after parsing. Keep edge text to simple words and
+escape line breaks as `\n` so the response remains valid JSON.

--- a/.github/scripts/tests/test_llm_pr_review_workflow.py
+++ b/.github/scripts/tests/test_llm_pr_review_workflow.py
@@ -156,6 +156,16 @@ class PiPrSummaryWorkflowTest(unittest.TestCase):
         self.assertNotIn('"findings"', prompt)
         self.assertNotIn("labels", prompt.casefold())
 
+    def test_prompt_keeps_mermaid_node_quotes_out_of_raw_json(self) -> None:
+        prompt = (ROOT / ".github" / "scripts" / "pi_summary_prompt.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("adds double quotes after parsing", prompt)
+        self.assertIn("escape line breaks as `\\n`", prompt)
+        self.assertIn("`A[Start] --> B{Ready?}`", prompt)
+        self.assertNotIn('A["Start"]', prompt)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 1. Why the change?

The Pi PR Summary job can exhaust its bounded malformed-response retry and fail with "pi response is not valid JSON". The prompt asked the model to put double-quoted Mermaid labels inside a JSON string without explicitly requiring escaped line breaks, making invalid JSON more likely.

Failing run: https://github.com/sii-system/agent-fleet/actions/runs/32323830426/job/96290999922?pr=126

## 2. Summary of the change

- Keep Mermaid node labels unquoted in the raw model response; the existing validator adds safe double quotes after JSON parsing.
- Require diagram line breaks to be JSON-escaped.
- Add prompt-contract regression coverage for both constraints.

## 3. Other details

Verification:

- python3 -m unittest discover -s .github/scripts/tests (267 passed)
- python3 -m py_compile .github/scripts/tests/test_llm_pr_review_workflow.py
- uvx ruff@0.16.0 check --config .github/ruff.toml .github/scripts/tests/test_llm_pr_review_workflow.py
- git diff --check