### PR TITLE
refactor(harbor): share workflow runtime helpers

### DIFF
--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -33,7 +33,13 @@ Agents/utils/common/Harbor/
     ├── controller.py           # Submit benchmark decisions and user-controlled Fixer actions
     ├── analyzer_subagent.py    # Analyzer entrypoint for Pi/GLM-5.2 root-cause analysis
     ├── harbor_analyzer/        # Analyzer policy, Pi adapter, contracts, and output validation
-    ├── harbor_pi_runtime/      # Shared isolated Pi process and JSON-event helper
+    ├── harbor_pi_runtime/
+    │   ├── config.py           # Shared Pi connection and provider configuration
+    │   └── process.py          # Isolated Pi process and JSON-event helper
+    ├── harbor_runtime/
+    │   ├── artifacts.py        # Shared serialization and atomic artifact writes
+    │   ├── identity.py         # Cross-stage task identity
+    │   └── process_identity.py # Stable process ownership identity
     ├── harbor_monitor/
     │   ├── artifacts.py        # Queue, result, manifest, environment, and state I/O
     │   ├── classification.py   # Task and benchmark status classification

--- a/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
+++ b/Agents/utils/common/Harbor/scripts/analyzer_subagent.py
@@ -24,6 +24,7 @@ from harbor_analyzer.runner import (
     run_handover,
     task_analysis_timeout_budget_seconds,
 )
+from harbor_pi_runtime import base_url_from_env, inherit_api_key, model_from_env
 
 FOLLOW_MAX_BACKOFF_SECONDS = 300.0
 FOLLOW_MAX_FAILURE_ATTEMPTS = 3
@@ -37,21 +38,11 @@ def _follow_backoff_seconds(attempt_count: int, poll_interval: float) -> float:
 
 
 def _default_base_url() -> str:
-    value = (
-        os.environ.get("HARBOR_ANALYZER_BASE_URL") or os.environ.get("BASE_URL") or ""
-    ).rstrip("/")
-    if value and not value.endswith("/v1"):
-        value += "/v1"
-    return value
+    return base_url_from_env("HARBOR_ANALYZER", normalize=True)
 
 
 def _default_model() -> str:
-    return os.environ.get("HARBOR_ANALYZER_MODEL") or os.environ.get("MODEL") or ""
-
-
-def _ensure_analyzer_env_defaults() -> None:
-    if not os.environ.get("HARBOR_ANALYZER_API_KEY") and os.environ.get("API_KEY"):
-        os.environ["HARBOR_ANALYZER_API_KEY"] = os.environ["API_KEY"]
+    return model_from_env("HARBOR_ANALYZER")
 
 
 def parse_args() -> argparse.Namespace:
@@ -340,7 +331,7 @@ def _write_ready_file(path: Path | None) -> None:
 
 
 def main() -> int:
-    _ensure_analyzer_env_defaults()
+    inherit_api_key("HARBOR_ANALYZER_API_KEY")
     args = parse_args()
     config = _config(args)
     _write_ready_file(args.ready_file)

--- a/Agents/utils/common/Harbor/scripts/fixer.py
+++ b/Agents/utils/common/Harbor/scripts/fixer.py
@@ -23,19 +23,18 @@ from harbor_fixer.report import run_report_from_paths
 from harbor_fixer.report.prompt import REPORT_MAIN_AGENT_PROMPT
 from harbor_fixer.validation import HARBOR_AGENTS, ValidationError
 from harbor_fixer.verifier import run_verification_from_paths
+from harbor_pi_runtime import base_url_from_env, model_from_env
 
 
 def _default_model() -> str:
-    return os.environ.get("HARBOR_FIXER_MODEL") or os.environ.get("MODEL") or ""
+    return model_from_env("HARBOR_FIXER")
 
 
 def _default_base_url() -> str:
-    return os.environ.get("HARBOR_FIXER_BASE_URL") or os.environ.get("BASE_URL") or ""
+    return base_url_from_env("HARBOR_FIXER")
 
 
 def build_pi_config(args: argparse.Namespace) -> PiInvocationConfig:
-    if not os.environ.get(args.pi_api_key_env) and os.environ.get("API_KEY"):
-        os.environ[args.pi_api_key_env] = os.environ["API_KEY"]
     return PiInvocationConfig(
         pi_bin=args.pi_bin,
         provider=args.pi_provider,
@@ -43,7 +42,7 @@ def build_pi_config(args: argparse.Namespace) -> PiInvocationConfig:
         base_url=args.pi_base_url,
         api_key_env=args.pi_api_key_env,
         timeout_seconds=args.timeout,
-    )
+    ).with_api_key_fallback()
 
 
 def parse_args() -> argparse.Namespace:

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/identity.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/identity.py
@@ -1,24 +1,5 @@
 """Shared task identity helpers for analyzer contracts and outputs."""
 
-from __future__ import annotations
+from harbor_runtime import task_identity, task_key
 
-from typing import Any
-
-
-def task_identity(task: dict[str, Any] | None) -> dict[str, Any]:
-    task = task or {}
-    return {
-        "task_index": str(task.get("task_index") or ""),
-        "task_name": str(task.get("task_name") or ""),
-        "attempt_id": task.get("attempt_id"),
-    }
-
-
-def task_key(task: dict[str, Any] | None) -> tuple[str, str, str]:
-    identity = task_identity(task)
-    attempt_id = identity["attempt_id"]
-    return (
-        identity["task_index"],
-        identity["task_name"],
-        "" if attempt_id is None else str(attempt_id),
-    )
+__all__ = ["task_identity", "task_key"]

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/io.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/io.py
@@ -2,50 +2,48 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
-import os
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from harbor_runtime import (
+    json_sha256,
+    read_json_object,
+)
+from harbor_runtime import (
+    utc_now as _runtime_utc_now,
+)
+from harbor_runtime import (
+    write_json_atomic as _write_json_atomic,
+)
+from harbor_runtime import (
+    write_text_atomic as _write_text_atomic,
+)
+
 
 def utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
-def canonical_json(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return _runtime_utc_now(zulu=False)
 
 
 def stable_hash(value: Any) -> str:
-    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+    return json_sha256(value)
 
 
 def load_json(path: Path) -> dict[str, Any]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = read_json_object(path)
     except FileNotFoundError as exc:
         raise ValueError(f"JSON file does not exist: {path}") from exc
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"Cannot read JSON file {path}: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected a JSON object in {path}")  # noqa: TRY004 - compatibility contract
+    except TypeError:
+        raise ValueError(f"Expected a JSON object in {path}")
     return payload
 
 
 def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    temp_path.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    temp_path.replace(path)
+    _write_json_atomic(path, payload)
 
 
 def write_text_atomic(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    temp_path.write_text(content, encoding="utf-8")
-    temp_path.replace(path)
+    _write_text_atomic(path, content)

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/pi.py
@@ -9,13 +9,14 @@ from typing import Any
 
 from harbor_pi_runtime import (
     PiProcessResult,
+    models_config,
+    normalized_base_url,
     run_pi_json_process,
     write_text_atomic,
 )
 from harbor_pi_runtime import (
     load_final_json_from_event_stream as _load_final_json_from_event_stream,
 )
-from harbor_pi_runtime.process import models_config, normalized_base_url
 
 PI_EXTENSION_PATH = Path(__file__).resolve().parent / "pi_extensions" / "analyzer_path_gate.ts"
 ANALYZER_SYSTEM_PROMPT = (

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/prompt.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/prompt.py
@@ -6,20 +6,13 @@ import json
 from pathlib import Path
 
 from . import PROMPT_VERSION, TAXONOMY_VERSION
+from .identity import task_identity as _task_identity
 from .taxonomy import (
     FAILURE_STAGES,
     FINAL_CLASSES,
     SCOPES,
     UNMAPPED_ROOT_CAUSE_BY_CLASS,
 )
-
-
-def _task_identity(task: dict) -> dict[str, object]:
-    return {
-        "task_index": str(task.get("task_index") or ""),
-        "task_name": str(task.get("task_name") or ""),
-        "attempt_id": task.get("attempt_id"),
-    }
 
 
 def build_task_prompt(

--- a/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_analyzer/runner.py
@@ -15,6 +15,8 @@ from harbor_pi_runtime import sleep_before_retry
 
 from . import PROMPT_VERSION, SCHEMA_VERSION, TAXONOMY_VERSION
 from .contract import validate_handover
+from .identity import task_identity as _task_identity
+from .identity import task_key as _task_key
 from .io import load_json, stable_hash, utc_now, write_json_atomic, write_text_atomic
 from .pi import dispatch_to_child
 from .prompt import (
@@ -111,24 +113,6 @@ def _retry_timeout_seconds(reason: str, timeout_seconds: int) -> int:
     if reason == "pi_dispatch_timeout":
         return _timeout_retry_seconds(timeout_seconds)
     return timeout_seconds
-
-
-def _task_identity(task: dict[str, Any] | None) -> dict[str, Any]:
-    task = task or {}
-    return {
-        "task_index": str(task.get("task_index") or ""),
-        "task_name": str(task.get("task_name") or ""),
-        "attempt_id": task.get("attempt_id"),
-    }
-
-
-def _task_key(task: dict[str, Any] | None) -> tuple[str, str, str]:
-    identity = _task_identity(task)
-    return (
-        identity["task_index"],
-        identity["task_name"],
-        "" if identity["attempt_id"] is None else str(identity["attempt_id"]),
-    )
 
 
 def _task_slug(task: dict[str, Any]) -> str:

--- a/Agents/utils/common/Harbor/scripts/harbor_controller/fixer.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_controller/fixer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
-import json
 import os
 import shlex
 import time
@@ -12,7 +11,6 @@ import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import replace
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +30,10 @@ from harbor_fixer.plan_generation import (
 from harbor_fixer.policy import run_policy_preflight
 from harbor_fixer.report import run_report_from_paths
 from harbor_fixer.verifier import run_verification_from_paths
+from harbor_pi_runtime import base_url_from_env, model_from_env
+from harbor_runtime import ProcessIdentity
+from harbor_runtime import json_sha256 as _json_sha256
+from harbor_runtime import utc_now as _utc_now
 from write_benchmark_summary import update_fixer_results
 
 ACTIVE_STATUSES = {
@@ -44,10 +46,6 @@ ACTIVE_STATUSES = {
     "cancelling",
 }
 OWNER_STATUSES = ACTIVE_STATUSES - {"awaiting_approval"}
-
-
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _fixer_dir(run_dir: Path) -> Path:
@@ -114,32 +112,11 @@ def _state_lock(run_dir: Path, inherited_fd: int | None = None) -> Iterator[None
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
-def _json_sha256(payload: Any) -> str:
-    encoded = json.dumps(
-        payload,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def _process_start_ticks(pid: int) -> int | None:
-    try:
-        stat_fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(
-            ")", 1
-        )[1].split()
-        return int(stat_fields[19])
-    except (IndexError, OSError, ValueError):
-        return None
-
-
 def _current_owner() -> dict[str, int]:
-    pid = os.getpid()
-    start_ticks = _process_start_ticks(pid)
-    if start_ticks is None:
+    identity = ProcessIdentity.capture(os.getpid())
+    if identity is None:
         raise ValueError("cannot identify the Fixer controller process")
-    return {"pid": pid, "start_ticks": start_ticks}
+    return identity.as_dict()
 
 
 def _owner_is_live(state: dict[str, Any]) -> bool:
@@ -147,11 +124,10 @@ def _owner_is_live(state: dict[str, Any]) -> bool:
     if not isinstance(owner, dict):
         return False
     try:
-        pid = int(owner["pid"])
-        start_ticks = int(owner["start_ticks"])
+        identity = ProcessIdentity.from_mapping(owner)
     except (KeyError, TypeError, ValueError):
         return False
-    return pid > 0 and _process_start_ticks(pid) == start_ticks
+    return identity.is_live()
 
 
 def _process_record_is_live(path: Path) -> bool:
@@ -161,16 +137,15 @@ def _process_record_is_live(path: Path) -> bool:
     if process.get("status") == "launching":
         return True
     try:
-        pid = int(process["pid"])
-        start_ticks = int(process["start_ticks"])
+        identity = ProcessIdentity.from_mapping(process)
     except (KeyError, TypeError, ValueError) as exc:
         raise ValueError(f"invalid active Fixer process record: {path}") from exc
-    if pid <= 0:
+    if identity.pid <= 0:
         raise ValueError("invalid active Fixer process pid")
-    if _process_start_ticks(pid) == start_ticks:
+    if identity.is_live():
         return True
     try:
-        os.killpg(pid, 0)
+        os.killpg(identity.pid, 0)
     except ProcessLookupError:
         return False
     except PermissionError:
@@ -219,9 +194,8 @@ def _runtime_config(
         "benchmark_model": benchmark_config["model"],
         "pi_bin": os.environ.get("HARBOR_FIXER_PI_BIN", "pi"),
         "pi_provider": os.environ.get("HARBOR_FIXER_PI_PROVIDER", "harbor-fixer"),
-        "pi_model": os.environ.get("HARBOR_FIXER_MODEL") or os.environ.get("MODEL", ""),
-        "pi_base_url": os.environ.get("HARBOR_FIXER_BASE_URL")
-        or os.environ.get("BASE_URL", ""),
+        "pi_model": model_from_env("HARBOR_FIXER"),
+        "pi_base_url": base_url_from_env("HARBOR_FIXER"),
         "pi_api_key_env": "HARBOR_FIXER_API_KEY",
         "agent_timeout": _positive_env_int("HARBOR_FIXER_AGENT_TIMEOUT", 900),
         "execution_timeout": _positive_env_int("HARBOR_FIXER_EXECUTION_TIMEOUT", 300),
@@ -245,17 +219,14 @@ def _runtime_config(
 
 
 def _pi_config(config: dict[str, Any]) -> PiInvocationConfig:
-    api_key_env = str(config["pi_api_key_env"])
-    if not os.environ.get(api_key_env) and os.environ.get("API_KEY"):
-        os.environ[api_key_env] = os.environ["API_KEY"]
     return PiInvocationConfig(
         pi_bin=str(config["pi_bin"]),
         provider=str(config["pi_provider"]),
         model=str(config["pi_model"]),
         base_url=str(config["pi_base_url"]),
-        api_key_env=api_key_env,
+        api_key_env=str(config["pi_api_key_env"]),
         timeout_seconds=int(config["agent_timeout"]),
-    )
+    ).with_api_key_fallback()
 
 
 def _notification(run_dir: Path) -> dict[str, Any]:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/agent_invocation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/agent_invocation.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-from harbor_pi_runtime import run_pi_json_process, write_text_atomic
+from harbor_pi_runtime import PiRuntimeConfig, run_pi_json_process, write_text_atomic
 
 FIXER_INPUT_MARKER = "HARBOR_FIXER_INPUT_JSON:"
 FIXER_SYSTEM_PROMPT = (
@@ -25,14 +25,9 @@ class AgentInvoker(Protocol):
 
 
 @dataclass(frozen=True)
-class PiInvocationConfig:
-    pi_bin: str = "pi"
+class PiInvocationConfig(PiRuntimeConfig):
     provider: str = "harbor-fixer"
-    model: str = ""
-    base_url: str = ""
     api_key_env: str = "HARBOR_FIXER_API_KEY"
-    timeout_seconds: int = 900
-    thinking_level: str | None = None
 
 
 def _safe_path_component(value: str) -> str:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/artifact_io.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/artifact_io.py
@@ -3,23 +3,30 @@
 from __future__ import annotations
 
 import json
-import os
-from contextlib import suppress
 from pathlib import Path
-from secrets import token_hex
 from typing import Any
+
+from harbor_runtime import (
+    read_json_object,
+)
+from harbor_runtime import (
+    write_json_atomic as _write_json_atomic,
+)
+from harbor_runtime import (
+    write_text_atomic as _write_text_atomic,
+)
 
 from .validation import ValidationError
 
 
 def read_json(path: Path) -> dict[str, Any]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = read_json_object(path)
     except FileNotFoundError as exc:
         raise ValidationError(f"missing JSON file: {path}") from exc
     except json.JSONDecodeError as exc:
         raise ValidationError(f"invalid JSON file {path}: {exc}") from exc
-    if not isinstance(payload, dict):
+    except TypeError:
         raise ValidationError(f"expected JSON object: {path}")
     return payload
 
@@ -53,46 +60,7 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
-    def _create_temp_path() -> Path:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        for _ in range(100):
-            candidate = path.with_name(
-                f".{path.name}.{os.getpid()}.{token_hex(8)}.tmp"
-            )
-            try:
-                fd = os.open(
-                    candidate,
-                    os.O_WRONLY
-                    | os.O_CREAT
-                    | os.O_EXCL
-                    | os.O_NOFOLLOW
-                    | os.O_CLOEXEC,
-                    0o600,
-                )
-            except FileExistsError:
-                continue
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                    handle.write(
-                        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
-                        + "\n"
-                    )
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                return candidate
-            except Exception:
-                with suppress(FileNotFoundError):
-                    Path(candidate).unlink()
-                raise
-        raise FileExistsError("could not allocate a temporary artifact file")
-
-    temp_path = _create_temp_path()
-    try:
-        temp_path.replace(path)
-    except Exception:
-        with suppress(FileNotFoundError):
-            temp_path.unlink()
-        raise
+    _write_json_atomic(path, payload, private=True)
 
 
 def write_text(path: Path, text: str) -> None:
@@ -101,24 +69,4 @@ def write_text(path: Path, text: str) -> None:
 
 
 def write_text_atomic(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.{token_hex(8)}.tmp")
-    try:
-        fd = os.open(
-            temp_path,
-            os.O_WRONLY
-            | os.O_CREAT
-            | os.O_EXCL
-            | os.O_NOFOLLOW
-            | os.O_CLOEXEC,
-            0o600,
-        )
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(text)
-            handle.flush()
-            os.fsync(handle.fileno())
-        temp_path.replace(path)
-    except Exception:
-        with suppress(FileNotFoundError):
-            temp_path.unlink()
-        raise
+    _write_text_atomic(path, text, private=True)

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/executor.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/executor.py
@@ -8,9 +8,11 @@ import signal
 import stat
 import subprocess
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from harbor_runtime import ProcessIdentity
+from harbor_runtime import utc_now as _utc_now
 
 from .agent_invocation import AgentInvoker
 from .artifact_io import read_json, write_json_atomic
@@ -54,20 +56,6 @@ def _safe_label(value: str, prefix: str) -> str:
     safe = safe[:60] or prefix
     digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
     return f"{safe}-{digest}"
-
-
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _process_start_ticks(pid: int) -> int | None:
-    try:
-        stat_fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(
-            ")", 1
-        )[1].split()
-        return int(stat_fields[19])
-    except (IndexError, OSError, ValueError):
-        return None
 
 
 def _tail_summary(value: str, *, limit: int) -> str:
@@ -380,8 +368,8 @@ def _run_command_action(
                     stderr=stderr_handle,
                     start_new_session=True,
                 )
-                start_ticks = _process_start_ticks(process.pid)
-                if start_ticks is None:
+                identity = ProcessIdentity.capture(process.pid)
+                if identity is None:
                     _terminate_process_group(process)
                     raise OSError("cannot identify the action process")
                 try:
@@ -389,8 +377,7 @@ def _run_command_action(
                         active_action_path,
                         {
                             "status": "running",
-                            "pid": process.pid,
-                            "start_ticks": start_ticks,
+                            **identity.as_dict(),
                         },
                     )
                 except OSError:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/preflight.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/policy/preflight.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 import shutil
 from pathlib import Path
 from typing import Any
+
+from harbor_runtime import json_sha256 as _json_sha256
 
 from ..agent_invocation import AgentInvoker
 from ..artifact_io import write_json_atomic
@@ -33,16 +33,6 @@ PATH_STABLE_T3_READ_COMMANDS = {
     "test",
     "wc",
 }
-
-
-def _json_sha256(value: Any) -> str:
-    serialized = json.dumps(
-        value,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def _resolved_cwd(action: dict[str, Any], workspace_root: Path) -> Path:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/report/generation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/report/generation.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from harbor_runtime import task_identity as _task_identity
+from harbor_runtime import utc_now as _utc_now
 
 from ..agent_invocation import AgentInvoker
 from ..analyzer_inputs import resolve_analyzer_paths
@@ -29,10 +31,6 @@ from ..verification.run_state import (
 from .runtime import generate_report_summary
 
 
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-
-
 def _prepare_report_output(output_dir: Path) -> None:
     try:
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -40,14 +38,6 @@ def _prepare_report_output(output_dir: Path) -> None:
         (output_dir / "fix-report-latest.md").unlink(missing_ok=True)
     except OSError as exc:
         raise ValidationError(f"cannot prepare report output: {exc}") from None
-
-
-def _task_identity(task: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "task_index": str(task.get("task_index") or ""),
-        "task_name": str(task.get("task_name") or ""),
-        "attempt_id": task.get("attempt_id"),
-    }
 
 
 def _explicit_status(env_task: dict[str, Any]) -> tuple[str, str]:

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/validation.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import math
 import shlex
 from typing import Any
+
+from harbor_runtime import json_sha256, task_key
 
 
 class ValidationError(ValueError):
@@ -76,16 +77,6 @@ REPORT_RERUN_FIELDS = (
     "monitor_available",
     "monitor_timed_out",
 )
-
-
-def json_sha256(value: Any) -> str:
-    serialized = json.dumps(
-        value,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def require_dict(value: Any, name: str) -> dict[str, Any]:
@@ -196,15 +187,6 @@ def _validate_fix_action(value: Any, name: str) -> str:
     if replacements < 1:
         raise ValidationError(f"{name}.edit.expected_replacements must be positive")
     return action_id
-
-
-def task_key(task: dict[str, Any]) -> tuple[str, str, str]:
-    attempt_id = task.get("attempt_id")
-    return (
-        str(task.get("task_index") or ""),
-        str(task.get("task_name") or ""),
-        "" if attempt_id is None else str(attempt_id),
-    )
 
 
 def _require_exact_task_identity(

--- a/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_fixer/verification/rerun.py
@@ -9,9 +9,10 @@ import signal
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from harbor_runtime import utc_now as _utc_now
 
 from ..validation import ValidationError, task_key
 from .run_state import generate_monitor_snapshot
@@ -78,10 +79,6 @@ GENERATED_MONITOR_FILES = {
     "analyzer-handover-latest.json",
     "runner-action-latest.json",
 }
-
-
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _read_log_tail(stream: Any) -> str:

--- a/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/__init__.py
@@ -1,6 +1,14 @@
 """Small shared helper for isolated Harbor Pi subprocesses."""
 
 from .backoff import retry_delay_seconds, sleep_before_retry
+from .config import (
+    PiRuntimeConfig,
+    base_url_from_env,
+    inherit_api_key,
+    model_from_env,
+    models_config,
+    normalized_base_url,
+)
 from .process import (
     PiProcessResult,
     load_final_json_from_event_stream,
@@ -10,7 +18,13 @@ from .process import (
 
 __all__ = [
     "PiProcessResult",
+    "PiRuntimeConfig",
+    "base_url_from_env",
+    "inherit_api_key",
     "load_final_json_from_event_stream",
+    "model_from_env",
+    "models_config",
+    "normalized_base_url",
     "retry_delay_seconds",
     "run_pi_json_process",
     "sleep_before_retry",

--- a/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/config.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/config.py
@@ -1,0 +1,91 @@
+"""Shared Pi connection configuration for Harbor components."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PiRuntimeConfig:
+    pi_bin: str = "pi"
+    provider: str = ""
+    model: str = ""
+    base_url: str = ""
+    api_key_env: str = ""
+    timeout_seconds: int = 900
+    thinking_level: str | None = None
+
+    def with_api_key_fallback(
+        self, fallback_env: str = "API_KEY"
+    ) -> PiRuntimeConfig:
+        inherit_api_key(self.api_key_env, fallback_env=fallback_env)
+        return self
+
+
+def inherit_api_key(api_key_env: str, *, fallback_env: str = "API_KEY") -> None:
+    if api_key_env and not os.environ.get(api_key_env) and os.environ.get(fallback_env):
+        os.environ[api_key_env] = os.environ[fallback_env]
+
+
+def model_from_env(component_prefix: str) -> str:
+    return os.environ.get(f"{component_prefix}_MODEL") or os.environ.get("MODEL") or ""
+
+
+def base_url_from_env(component_prefix: str, *, normalize: bool = False) -> str:
+    value = (
+        os.environ.get(f"{component_prefix}_BASE_URL")
+        or os.environ.get("BASE_URL")
+        or ""
+    )
+    return normalized_base_url(value) if normalize else value
+
+
+def normalized_base_url(base_url: str) -> str:
+    value = base_url.strip().rstrip("/")
+    if value and not value.endswith("/v1"):
+        value = f"{value}/v1"
+    return value
+
+
+def models_config(
+    *,
+    provider: str,
+    model: str,
+    base_url: str,
+    api_key_env: str,
+    display_name: str,
+    auth_header: bool | None = None,
+) -> dict[str, Any]:
+    provider_config: dict[str, Any] = {
+        "baseUrl": base_url,
+        "api": "openai-completions",
+        "apiKey": f"${api_key_env}",
+        "compat": {
+            "supportsDeveloperRole": False,
+            "supportsReasoningEffort": False,
+            "supportsUsageInStreaming": True,
+            "maxTokensField": "max_tokens",
+            "thinkingFormat": "zai",
+        },
+        "models": [
+            {
+                "id": model,
+                "name": display_name,
+                "reasoning": True,
+                "input": ["text"],
+                "contextWindow": 204800,
+                "maxTokens": 32768,
+                "cost": {
+                    "input": 0,
+                    "output": 0,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                },
+            }
+        ],
+    }
+    if auth_header is not None:
+        provider_config["authHeader"] = auth_header
+    return {"providers": {provider: provider_config}}

--- a/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/process.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_pi_runtime/process.py
@@ -15,6 +15,10 @@ from pathlib import Path
 from typing import Any, BinaryIO
 from urllib.parse import urlparse
 
+from harbor_runtime import ProcessIdentity, canonical_json, write_text_atomic
+
+from .config import models_config, normalized_base_url
+
 ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 MESSAGE_UPDATE_RE = re.compile(br'^\s*\{\s*"type"\s*:\s*"message_update"\s*[,}]')
 THINKING_LEVELS = {"off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
@@ -86,17 +90,6 @@ def _consume_compact_stream(
         state.stream_error = exc
 
 
-def canonical_json(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-
-def normalized_base_url(base_url: str) -> str:
-    value = base_url.strip().rstrip("/")
-    if value and not value.endswith("/v1"):
-        value = f"{value}/v1"
-    return value
-
-
 def reason_code(message: str) -> str:
     value = re.sub(r"[^A-Za-z0-9]+", "_", message.strip().lower()).strip("_")
     return value[:80] or "unknown_error"
@@ -156,48 +149,6 @@ def pi_environment(
             entries.append(hostname)
         environment[key] = ",".join(entries)
     return environment, True
-
-
-def models_config(
-    *,
-    provider: str,
-    model: str,
-    base_url: str,
-    api_key_env: str,
-    display_name: str,
-    auth_header: bool | None = None,
-) -> dict[str, Any]:
-    provider_config: dict[str, Any] = {
-        "baseUrl": base_url,
-        "api": "openai-completions",
-        "apiKey": f"${api_key_env}",
-        "compat": {
-            "supportsDeveloperRole": False,
-            "supportsReasoningEffort": False,
-            "supportsUsageInStreaming": True,
-            "maxTokensField": "max_tokens",
-            "thinkingFormat": "zai",
-        },
-        "models": [
-            {
-                "id": model,
-                "name": display_name,
-                "reasoning": True,
-                "input": ["text"],
-                "contextWindow": 204800,
-                "maxTokens": 32768,
-                "cost": {
-                    "input": 0,
-                    "output": 0,
-                    "cacheRead": 0,
-                    "cacheWrite": 0,
-                },
-            }
-        ],
-    }
-    if auth_header is not None:
-        provider_config["authHeader"] = auth_header
-    return {"providers": {provider: provider_config}}
 
 
 def parse_jsonl(raw: str) -> tuple[list[dict[str, Any]], int]:
@@ -388,31 +339,14 @@ def pi_version(binary: str, environment: dict[str, str], cwd: Path) -> str | Non
     return value or None
 
 
-def write_text_atomic(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    temp_path.write_text(content, encoding="utf-8")
-    temp_path.replace(path)
-
-
-def _process_start_ticks(pid: int) -> int | None:
-    try:
-        stat_fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(
-            ")", 1
-        )[1].split()
-        return int(stat_fields[19])
-    except (IndexError, OSError, ValueError):
-        return None
-
-
 def _write_process_record(path: Path, process: subprocess.Popen[Any]) -> None:
-    start_ticks = _process_start_ticks(process.pid)
-    if start_ticks is None:
+    identity = ProcessIdentity.capture(process.pid)
+    if identity is None:
         raise OSError("cannot identify the Pi process")
     write_text_atomic(
         path,
         json.dumps(
-            {"status": "running", "pid": process.pid, "start_ticks": start_ticks},
+            {"status": "running", **identity.as_dict()},
             sort_keys=True,
         )
         + "\n",

--- a/Agents/utils/common/Harbor/scripts/harbor_runtime/__init__.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_runtime/__init__.py
@@ -1,0 +1,24 @@
+"""Shared low-level helpers for Harbor workflow components."""
+
+from .artifacts import (
+    canonical_json,
+    json_sha256,
+    read_json_object,
+    utc_now,
+    write_json_atomic,
+    write_text_atomic,
+)
+from .identity import task_identity, task_key
+from .process_identity import ProcessIdentity
+
+__all__ = [
+    "ProcessIdentity",
+    "canonical_json",
+    "json_sha256",
+    "read_json_object",
+    "task_identity",
+    "task_key",
+    "utc_now",
+    "write_json_atomic",
+    "write_text_atomic",
+]

--- a/Agents/utils/common/Harbor/scripts/harbor_runtime/artifacts.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_runtime/artifacts.py
@@ -1,0 +1,82 @@
+"""Canonical serialization and atomic artifact writes for Harbor workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from contextlib import suppress
+from datetime import datetime, timezone
+from pathlib import Path
+from secrets import token_hex
+from typing import Any
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def json_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def utc_now(*, zulu: bool = True) -> str:
+    value = datetime.now(timezone.utc).isoformat()
+    return value.replace("+00:00", "Z") if zulu else value
+
+
+def read_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError("expected a JSON object")
+    return payload
+
+
+def _write_private(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for _ in range(100):
+        temp_path = path.with_name(f".{path.name}.{os.getpid()}.{token_hex(8)}.tmp")
+        try:
+            fd = os.open(
+                temp_path,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | os.O_NOFOLLOW
+                | os.O_CLOEXEC,
+                0o600,
+            )
+        except FileExistsError:
+            continue
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            temp_path.replace(path)
+        except Exception:
+            with suppress(FileNotFoundError):
+                temp_path.unlink()
+            raise
+        return
+    raise FileExistsError("could not allocate a temporary artifact file")
+
+
+def write_text_atomic(path: Path, content: str, *, private: bool = False) -> None:
+    if private:
+        _write_private(path, content)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temp_path.write_text(content, encoding="utf-8")
+    temp_path.replace(path)
+
+
+def write_json_atomic(
+    path: Path, payload: dict[str, Any], *, private: bool = False
+) -> None:
+    write_text_atomic(
+        path,
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        private=private,
+    )

--- a/Agents/utils/common/Harbor/scripts/harbor_runtime/identity.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_runtime/identity.py
@@ -1,0 +1,24 @@
+"""Canonical task identity shared across Harbor workflow stages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def task_identity(task: dict[str, Any] | None) -> dict[str, Any]:
+    task = task or {}
+    return {
+        "task_index": str(task.get("task_index") or ""),
+        "task_name": str(task.get("task_name") or ""),
+        "attempt_id": task.get("attempt_id"),
+    }
+
+
+def task_key(task: dict[str, Any] | None) -> tuple[str, str, str]:
+    identity = task_identity(task)
+    attempt_id = identity["attempt_id"]
+    return (
+        identity["task_index"],
+        identity["task_name"],
+        "" if attempt_id is None else str(attempt_id),
+    )

--- a/Agents/utils/common/Harbor/scripts/harbor_runtime/process_identity.py
+++ b/Agents/utils/common/Harbor/scripts/harbor_runtime/process_identity.py
@@ -1,0 +1,34 @@
+"""Stable Linux process identity for Harbor workflow ownership records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    start_ticks: int
+
+    @classmethod
+    def capture(cls, pid: int) -> ProcessIdentity | None:
+        try:
+            stat_fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(
+                ")", 1
+            )[1].split()
+            start_ticks = int(stat_fields[19])
+        except (IndexError, OSError, ValueError):
+            return None
+        return cls(pid=pid, start_ticks=start_ticks)
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any]) -> ProcessIdentity:
+        return cls(pid=int(value["pid"]), start_ticks=int(value["start_ticks"]))
+
+    def as_dict(self) -> dict[str, int]:
+        return {"pid": self.pid, "start_ticks": self.start_ticks}
+
+    def is_live(self) -> bool:
+        return self.pid > 0 and self.capture(self.pid) == self

--- a/Agents/utils/common/Harbor/tests/test_harbor_pi_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_pi_runtime.py
@@ -16,8 +16,13 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from harbor_analyzer.pi import dispatch_to_child
-from harbor_pi_runtime import load_final_json_from_event_stream, run_pi_json_process
-from harbor_pi_runtime.process import models_config
+from harbor_pi_runtime import (
+    PiRuntimeConfig,
+    base_url_from_env,
+    load_final_json_from_event_stream,
+    models_config,
+    run_pi_json_process,
+)
 
 
 def write_fixture_pi(path: Path) -> Path:
@@ -121,6 +126,16 @@ class HarborPiRuntimeTest(unittest.TestCase):
 
         self.assertTrue(explicit["providers"]["analyzer"]["authHeader"])
         self.assertNotIn("authHeader", omitted["providers"]["fixer"])
+
+    def test_connection_config_reuses_environment_fallbacks(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"BASE_URL": "https://example.test", "API_KEY": "fake"},
+            clear=True,
+        ):
+            config = PiRuntimeConfig(api_key_env="FIXTURE_API_KEY").with_api_key_fallback()
+            self.assertEqual(base_url_from_env("HARBOR_FIXER"), "https://example.test")
+            self.assertEqual(os.environ[config.api_key_env], "fake")
 
     def test_compact_events_and_stdin_prompt(self) -> None:
         result = self.run_runtime(

--- a/Agents/utils/common/Harbor/tests/test_harbor_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_runtime.py
@@ -1,0 +1,69 @@
+"""Focused tests for shared Harbor workflow runtime helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from harbor_runtime import (
+    ProcessIdentity,
+    json_sha256,
+    read_json_object,
+    task_identity,
+    task_key,
+    utc_now,
+    write_json_atomic,
+)
+
+
+class HarborRuntimeTest(unittest.TestCase):
+    def test_canonical_hash_and_timestamp_formats(self) -> None:
+        self.assertEqual(
+            json_sha256({"b": 2, "a": 1}),
+            json_sha256({"a": 1, "b": 2}),
+        )
+        self.assertTrue(utc_now().endswith("Z"))
+        self.assertTrue(utc_now(zulu=False).endswith("+00:00"))
+
+    def test_atomic_json_preserves_legacy_and_private_modes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            legacy = root / "legacy.json"
+            private = root / "private.json"
+            old_umask = os.umask(0o022)
+            try:
+                write_json_atomic(legacy, {"ok": True})
+                write_json_atomic(private, {"ok": True}, private=True)
+            finally:
+                os.umask(old_umask)
+
+            self.assertEqual(read_json_object(legacy), {"ok": True})
+            self.assertEqual(legacy.stat().st_mode & 0o777, 0o644)
+            self.assertEqual(private.stat().st_mode & 0o777, 0o600)
+
+    def test_process_identity_round_trips_and_checks_liveness(self) -> None:
+        identity = ProcessIdentity.capture(os.getpid())
+        self.assertIsNotNone(identity)
+        assert identity is not None
+        self.assertEqual(ProcessIdentity.from_mapping(identity.as_dict()), identity)
+        self.assertTrue(identity.is_live())
+        self.assertIsNone(ProcessIdentity.capture(999_999_999))
+
+    def test_task_identity_normalizes_the_cross_stage_key(self) -> None:
+        task = {"task_index": 7, "task_name": "fixture", "attempt_id": None}
+        self.assertEqual(
+            task_identity(task),
+            {"task_index": "7", "task_name": "fixture", "attempt_id": None},
+        )
+        self.assertEqual(task_key(task), ("7", "fixture", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Harbor controller, analyzer, fixer, and Pi runtime evolved as connected components while retaining duplicate low-level implementations for artifact handling, process ownership, task identity, and Pi configuration. Consolidating these shared concerns reduces maintenance overhead and keeps their behavior consistent without moving component-specific workflows out of their existing packages and entrypoints.

## 2. Summary of the change

- Add harbor_runtime helpers for canonical artifact serialization and atomic writes, stable process identity, and task identity.
- Move shared Pi environment, endpoint, model, and provider configuration into harbor_pi_runtime.
- Adapt Harbor controller, analyzer, and fixer callers while preserving component-specific exceptions, artifact permissions, paths, and entrypoints.
- Update STRUCT.md for the new module layout and add compact coverage for the shared behavior.

## 3. Other details

Validation completed:

- Harbor test suite: 424/424 passed.
- Repository Ruff checks passed.
- The refactor is contained in one commit and is intended to preserve functional behavior.