### PR TITLE
fix(config): derive TRACE_TO_OPIK from OPIK_URL when unset

### DIFF
--- a/Agents/Harbor-opencode/enable_track_harbor.py
+++ b/Agents/Harbor-opencode/enable_track_harbor.py
@@ -41,7 +41,7 @@ import sys
 
 
 def _trace_to_opik_enabled() -> bool:
-    return os.environ.get("TRACE_TO_OPIK", "true") not in {"false", "0"}
+    return os.environ.get("TRACE_TO_OPIK", "false") not in {"false", "0"}
 
 
 def _clean_tags(tags: object) -> list[str]:

--- a/Agents/Harbor-opencode/finalize_opencode_sessions.py
+++ b/Agents/Harbor-opencode/finalize_opencode_sessions.py
@@ -125,7 +125,7 @@ def _fallback_timeout_trace(logs_dir: Path, status: str) -> int:
 def _trace_to_opik_enabled() -> bool:
     if os.environ.get("OPIK_TRACK_DISABLE", "").lower() in {"true", "1"}:
         return False
-    return os.environ.get("TRACE_TO_OPIK", "true") not in {"false", "0"}
+    return os.environ.get("TRACE_TO_OPIK", "false") not in {"false", "0"}
 
 
 def main() -> int:

--- a/Agents/Harbor-opencode/opik_opencode_harbor.py
+++ b/Agents/Harbor-opencode/opik_opencode_harbor.py
@@ -86,7 +86,7 @@ def _trace_to_opik_enabled(extra_env: dict[str, str] | None = None) -> bool:
     if extra_env is not None:
         value = extra_env.get("TRACE_TO_OPIK")
     if value is None:
-        value = os.environ.get("TRACE_TO_OPIK", "true")
+        value = os.environ.get("TRACE_TO_OPIK", "false")
     return value not in {"false", "0"}
 
 

--- a/Agents/Openclaw/GUIDE.md
+++ b/Agents/Openclaw/GUIDE.md
@@ -75,7 +75,7 @@ DEFAULT_PORTS_OFFSET="100" \
 | `WORKSPACE_ONLY` | `true` | Default value for `tools.fs.workspaceOnly`; set `false` to let skills read outside the workspace (e.g. plugin/extension dirs) |
 | `DOCKER_COMPOSE_READ_ONLY` | `true` | Default value for generated Compose `read_only` |
 | `OPENCLAW_IMAGE` | `openclaw:local` | Docker image to use |
-| `TRACE_TO_OPIK` | `true` | Fleet-wide tracing switch; `false` forces the OpenClaw plugin off |
+| `TRACE_TO_OPIK` | _(follows `OPIK_URL`)_ | Fleet-wide tracing switch; unset means on only when `OPIK_URL` is set. `false` forces the OpenClaw plugin off |
 | `OPIK_PLUGIN` | `disabled` | Set to `enabled` to activate opik tracing |
 | `OPIK_URL` | _(none)_ | Opik API endpoint (required when `OPIK_PLUGIN=enabled`) |
 | `OPIK_PROJECT_NAME` | _(none)_ | Opik project name (required when `OPIK_PLUGIN=enabled`) |

--- a/Agents/Openclaw/config/ansible/templates/fleet.env.j2
+++ b/Agents/Openclaw/config/ansible/templates/fleet.env.j2
@@ -4,7 +4,7 @@ BASE_URL={{ base_url }}
 API_KEY={{ api_key }}
 MODEL={{ model }}
 OPENCLAW_IMAGE={{ openclaw_image }}
-TRACE_TO_OPIK={{ 'false' if (trace_to_opik | default(true) | string | lower) in ['false', '0'] else 'true' }}
+TRACE_TO_OPIK={{ 'false' if (trace_to_opik | default(false) | string | lower) in ['false', '0'] else 'true' }}
 CONFIG_BASE={{ config_base | default('$HOME/openclaw-instances') }}
 WORKSPACE_BASE={{ workspace_base | default('$HOME/openclaw-workspaces') }}
 {% if npm_config_registry is defined and npm_config_registry %}

--- a/Agents/Openclaw/scripts/build-openclaw-image.sh
+++ b/Agents/Openclaw/scripts/build-openclaw-image.sh
@@ -32,11 +32,17 @@ done
 eval "$__caller_env"
 unset __caller_env config_file
 
+# This script keeps its own precedence chain (it layers in fleet.env), so
+# resolve the tracing switch here rather than through agent_fleet_load_config.
+# shellcheck source=../../../scripts/config_loader.sh
+. "$REPO_ROOT/scripts/config_loader.sh"
+agent_fleet_resolve_trace_to_opik
+
 OPENCLAW_REPO="${OPENCLAW_REPO:-https://github.com/openclaw/openclaw.git}"
 
 # Keep the top-level tracing switch authoritative over stale fleet/plugin
 # configuration, matching setup.py and the benchmark launchers.
-case "${TRACE_TO_OPIK:-true}" in
+case "$TRACE_TO_OPIK" in
   false|0)
     if [ "${OPIK_PLUGIN:-}" = "enabled" ]; then
       echo "TRACE_TO_OPIK=false overrides OPIK_PLUGIN=enabled; tracing plugin disabled" >&2

--- a/Agents/Openclaw/scripts/setup.py
+++ b/Agents/Openclaw/scripts/setup.py
@@ -71,7 +71,23 @@ def _build_arg_parser(defaults: dict[str, str]) -> argparse.ArgumentParser:
 
 def trace_to_opik_enabled(value: str | None) -> bool:
     """Return whether fleet-wide tracing is enabled."""
-    return (value or "true") not in {"false", "0"}
+    return (value or "false") not in {"false", "0"}
+
+
+def resolve_trace_to_opik(env: dict[str, str]) -> str:
+    """Resolve the fleet-wide switch the way scripts/config_loader.sh does.
+
+    Opik is optional, so an absent switch must not demand an Opik server.
+    A configured OPIK_URL means tracing was wanted, no endpoint means it
+    was not."""
+    value = env.get("TRACE_TO_OPIK", "")
+    if value.strip():
+        return value
+    if env.get("OPIK_URL", "").strip():
+        print("[INFO] TRACE_TO_OPIK unset; OPIK_URL present -> tracing on", file=sys.stderr)
+        return "true"
+    print("[INFO] TRACE_TO_OPIK unset; no OPIK_URL -> tracing off", file=sys.stderr)
+    return "false"
 
 
 def resolve_config(env: dict[str, str], argv: list[str]) -> dict[str, Any]:
@@ -108,7 +124,7 @@ def resolve_config(env: dict[str, str], argv: list[str]) -> dict[str, Any]:
         "COUNT": env.get("COUNT", "2"),
         "BASE_URL": env.get("BASE_URL", ""),
         "API_KEY": env.get("API_KEY", ""),
-        "TRACE_TO_OPIK": env.get("TRACE_TO_OPIK", "true"),
+        "TRACE_TO_OPIK": resolve_trace_to_opik(env),
         "OPIK_PLUGIN": env.get("OPIK_PLUGIN", "disabled"),
         "OPIK_URL": env.get("OPIK_URL", ""),
         "OPIK_API_KEY": env.get("OPIK_API_KEY", ""),

--- a/Agents/Openclaw/tests/test_build_openclaw_image.sh
+++ b/Agents/Openclaw/tests/test_build_openclaw_image.sh
@@ -2,11 +2,13 @@
 set -euo pipefail
 
 OPENCLAW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$OPENCLAW_DIR/../.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 PROJECT_DIR="$TMP_DIR/Agents/Openclaw"
-mkdir -p "$PROJECT_DIR/scripts" \
+mkdir -p "$TMP_DIR/scripts" \
+         "$PROJECT_DIR/scripts" \
          "$PROJECT_DIR/cache/openclaw/.git" \
          "$TMP_DIR/third_party/agent-opik-plugin/harness/openclaw" \
          "$TMP_DIR/third_party/agent-opik-plugin/src/sii_opik_plugin/openclaw" \
@@ -16,6 +18,8 @@ touch "$TMP_DIR/third_party/agent-opik-plugin/requirements.txt"
 printf '{"scripts":{"build":"true"}}\n' > "$TMP_DIR/third_party/agent-opik-plugin/harness/openclaw/package.json"
 
 cp "$OPENCLAW_DIR/scripts/build-openclaw-image.sh" "$PROJECT_DIR/scripts/build-openclaw-image.sh"
+# The build script resolves the tracing switch through the shared config lib.
+cp "$REPO_ROOT/scripts/config_loader.sh" "$TMP_DIR/scripts/config_loader.sh"
 cp "$OPENCLAW_DIR/Dockerfile.opik" "$PROJECT_DIR/Dockerfile.opik"
 chmod +x "$PROJECT_DIR/scripts/build-openclaw-image.sh"
 
@@ -48,6 +52,7 @@ chmod +x "$TMP_DIR/bin/git" "$TMP_DIR/bin/docker" "$TMP_DIR/bin/npm"
 
 PATH="$TMP_DIR/bin:$PATH" \
 LOG="$LOG" \
+TRACE_TO_OPIK=true \
 OPIK_PLUGIN=enabled \
 NPM_CONFIG_REGISTRY="https://registry.npmmirror.com" \
 PIP_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple" \
@@ -108,3 +113,30 @@ OPIK_PLUGIN=enabled \
 "$PROJECT_DIR/scripts/build-openclaw-image.sh" >/dev/null
 
 grep -q -- 'openclaw:local-opik' "$LOG"
+
+# Without the switch, a configured Opik endpoint is what turns tracing on.
+rm -f "$TMP_DIR/config.local.env"
+: > "$LOG"
+env -u TRACE_TO_OPIK \
+  PATH="$TMP_DIR/bin:$PATH" \
+  LOG="$LOG" \
+  OPIK_URL="https://opik.example.invalid/api" \
+  OPIK_PLUGIN=enabled \
+  "$PROJECT_DIR/scripts/build-openclaw-image.sh" >/dev/null
+
+grep -q -- 'openclaw:local-opik' "$LOG"
+
+# Without the switch and without an endpoint, tracing stays off.
+: > "$LOG"
+env -u TRACE_TO_OPIK -u OPIK_URL \
+  PATH="$TMP_DIR/bin:$PATH" \
+  LOG="$LOG" \
+  OPIK_PLUGIN=enabled \
+  TRACE_PLUGIN_SOURCE_DIR="$TMP_DIR/missing-opik-plugin" \
+  "$PROJECT_DIR/scripts/build-openclaw-image.sh" >/dev/null 2>&1
+
+grep -q -- 'build --load -t openclaw:local ' "$LOG"
+if grep -q -- 'openclaw:local-opik' "$LOG"; then
+  echo "derived trace-off unexpectedly built the Opik image" >&2
+  exit 1
+fi

--- a/Agents/Openclaw/tests/test_setup_py.py
+++ b/Agents/Openclaw/tests/test_setup_py.py
@@ -42,7 +42,7 @@ class AnsibleFleetTemplateTests(unittest.TestCase):
             trace_lines,
             [
                 (
-                    "TRACE_TO_OPIK={{ 'false' if (trace_to_opik | default(true) | string | lower) "
+                    "TRACE_TO_OPIK={{ 'false' if (trace_to_opik | default(false) | string | lower) "
                     "in ['false', '0'] else 'true' }}"
                 ),
             ],
@@ -262,6 +262,39 @@ class ResolveConfigTests(unittest.TestCase):
         self.assertEqual(cfg["TRACE_TO_OPIK"], "false")
         self.assertEqual(cfg["OPIK_PLUGIN"], "disabled")
         setup.validate_required(cfg)
+
+    def test_absent_trace_switch_follows_configured_opik_url(self):
+        env = {
+            "BASE_URL": "u",
+            "API_KEY": "k",
+            "HOME": "/h",
+            "OPIK_URL": "https://opik.example.invalid/api",
+        }
+
+        cfg = setup.resolve_config(env, [])
+
+        self.assertEqual(cfg["TRACE_TO_OPIK"], "true")
+
+    def test_absent_trace_switch_without_opik_url_disables_tracing(self):
+        env = {"BASE_URL": "u", "API_KEY": "k", "HOME": "/h"}
+
+        cfg = setup.resolve_config(env, [])
+
+        self.assertEqual(cfg["TRACE_TO_OPIK"], "false")
+        self.assertEqual(cfg["OPIK_PLUGIN"], "disabled")
+
+    def test_explicit_trace_switch_wins_over_opik_url(self):
+        env = {
+            "BASE_URL": "u",
+            "API_KEY": "k",
+            "HOME": "/h",
+            "OPIK_URL": "https://opik.example.invalid/api",
+            "TRACE_TO_OPIK": "false",
+        }
+
+        cfg = setup.resolve_config(env, [])
+
+        self.assertEqual(cfg["TRACE_TO_OPIK"], "false")
 
     def test_cli_count_overrides_env(self):
         env = {"COUNT": "2", "BASE_URL": "u", "API_KEY": "k", "HOME": "/h"}

--- a/Agents/utils/common/Harbor/README.md
+++ b/Agents/utils/common/Harbor/README.md
@@ -86,7 +86,7 @@ provider derives from `BASE_URL` when `PI_PROVIDER` is unset. Rollout mode
 keeps its separate `RL_TEMPERATURE`, `RL_TOP_P`, and `RL_MAX_NEW_TOKENS`
 interface.
 
-When `TRACE_TO_OPIK=true` (the default), the Opik tracing plugin is loaded from
+When `TRACE_TO_OPIK=true`, the Opik tracing plugin is loaded from
 the `third_party/agent-opik-plugin` submodule. Initialize it before a traced run:
 
 ```bash

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -133,12 +133,14 @@ HARBOR_FIXER_SUMMARY_LIMIT="${HARBOR_FIXER_SUMMARY_LIMIT:-4000}"
 HARBOR_FIXER_MAX_CONCURRENCY="${HARBOR_FIXER_MAX_CONCURRENCY:-4}"
 HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS="${HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS:-24000}"
 HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS="${HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS:-400000}"
-TRACE_TO_OPIK="${TRACE_TO_OPIK:-true}"
+# agent_fleet_load_config already resolved this from OPIK_URL when the switch
+# was absent. The floor below only covers env.sh being sourced without it.
+TRACE_TO_OPIK="${TRACE_TO_OPIK:-false}"
 # The single switch for running without Opik, shared by every script that
 # sources env.sh (harboropik.sh, run_harbor_worker.sh). Anything except an
-# explicit false/0 keeps tracing on, so default behavior is unchanged.
+# explicit false/0 keeps tracing on.
 harbor_trace_to_opik_enabled() {
-  case "${TRACE_TO_OPIK:-true}" in
+  case "${TRACE_TO_OPIK:-false}" in
     false|0) return 1 ;;
     *) return 0 ;;
   esac
@@ -342,7 +344,7 @@ HARBOR_FORCE_BUILD="${HARBOR_FORCE_BUILD:-0}"
 HARBOR_DEBUG="${HARBOR_DEBUG:-0}"
 # The realtime hook default follows the tracing switch: without an Opik
 # server there is nothing for the hook to talk to. An explicit value wins.
-case "${TRACE_TO_OPIK:-true}" in
+case "${TRACE_TO_OPIK:-false}" in
   false|0) HARBOR_CC_OPIK_ENABLE_HOOK="${HARBOR_CC_OPIK_ENABLE_HOOK:-0}" ;;
   *) HARBOR_CC_OPIK_ENABLE_HOOK="${HARBOR_CC_OPIK_ENABLE_HOOK:-1}" ;;
 esac

--- a/Agents/utils/common/Harbor/scripts/controller.py
+++ b/Agents/utils/common/Harbor/scripts/controller.py
@@ -26,8 +26,11 @@ def _exec_with_repository_config() -> None:
     if os.environ.get("AGENT_FLEET_CONFIG_LOADED_ROOT") == str(repo_root):
         return
     loader = repo_root / "scripts" / "config_loader.sh"
+    # Controller output is parsed as JSON by monitor_harbor.sh and the fixer, so
+    # config loading must stay silent even when it derives a value.
     command = (
-        'set -euo pipefail; source "$1"; agent_fleet_load_config "$2"; '
+        'set -euo pipefail; export AGENT_FLEET_CONFIG_QUIET=1; '
+        'source "$1"; agent_fleet_load_config "$2"; '
         'python_bin="$3"; shift 3; exec "$python_bin" "$@"'
     )
     os.execvp(

--- a/Agents/utils/common/Harbor/tests/test_harboropik_e2b_smoke.py
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_e2b_smoke.py
@@ -174,6 +174,9 @@ class HarborOpikE2BSmokeTest(unittest.TestCase):
                     "RL_AGENT": "oracle",
                     "ROLLOUT": "1",
                     "RUNTIME_DIR": root,
+                    # These assert on exact output; pin the switch so env.sh has
+                    # nothing to derive and report.
+                    "TRACE_TO_OPIK": "false",
                 }
             )
             command = (
@@ -205,6 +208,7 @@ class HarborOpikE2BSmokeTest(unittest.TestCase):
                     "RL_ENVIRONMENT_TYPE": "e2b",
                     "HARBOR_ENVIRONMENT_TYPE": "e2b",
                     "RUNTIME_DIR": root,
+                    "TRACE_TO_OPIK": "false",
                 }
             )
             command = (
@@ -234,6 +238,7 @@ class HarborOpikE2BSmokeTest(unittest.TestCase):
                     "DATASET_NAME": "auto",
                     "DATASET_PATH": root,
                     "OUTPUT_PATH": str(Path(root) / "output"),
+                    "TRACE_TO_OPIK": "false",
                 }
             )
             completed = subprocess.run(

--- a/Tasks/Pinchbench/Dockerfile
+++ b/Tasks/Pinchbench/Dockerfile
@@ -1,4 +1,4 @@
-ARG OPENCLAW_BASE_IMAGE=openclaw:local-opik
+ARG OPENCLAW_BASE_IMAGE=openclaw:local
 FROM ${OPENCLAW_BASE_IMAGE}
 
 LABEL org.opencontainers.image.source="https://github.com/pinchbench/skill"
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.description="PinchBench runner with OpenClaw CLI"
 ARG PIP_INDEX_URL=""
 ARG PIP_EXTRA_INDEX_URL=""
 ARG PIP_TRUSTED_HOST=""
-ARG TRACE_TO_OPIK=true
+ARG TRACE_TO_OPIK=false
 
 USER root
 

--- a/Tasks/Pinchbench/README.md
+++ b/Tasks/Pinchbench/README.md
@@ -194,7 +194,7 @@ The runner reads defaults from [`config/pinchbench.env`](./config/pinchbench.env
 | `JUDGE_MODEL` | _(benchmark.py default)_ | Judge model override |
 | `API_KEY` | _(none)_ | Generic provider API key; the runner maps it to PinchBench's expected env var when needed |
 | `OPENROUTER_API_KEY` | _(none)_ | Compatibility env var used by upstream PinchBench; usually you can just set `API_KEY` |
-| `TRACE_TO_OPIK` | `true` | Shared fleet tracing switch; set `false` for the Opik-free worker and gateway path |
+| `TRACE_TO_OPIK` | _(follows `OPIK_URL`)_ | Shared fleet tracing switch; unset means on only when `OPIK_URL` is set. Set `false` for the Opik-free worker and gateway path |
 | `PINCHBENCH_DIR` | `/tmp/pinchbench-skill` | PinchBench checkout path |
 | `PINCHBENCH_REF` | `f3f1cb560c252541cef6a106c05ba4f2e8068be0` | Upstream PinchBench git ref pinned by this runner |
 | `PINCHBENCH_OUTPUT_DIR` | `Tasks/Pinchbench/.pinchbench-results-docker` | Output root |

--- a/Tasks/Pinchbench/scripts/run-parallel-workers.py
+++ b/Tasks/Pinchbench/scripts/run-parallel-workers.py
@@ -77,7 +77,22 @@ def config_bool(value: str | None, default: bool) -> bool:
 
 def trace_to_opik_enabled(value: str | None) -> bool:
     """Match the fleet-wide trace switch used by the Harbor/OpenClaw runners."""
-    return (value or "true") not in {"false", "0"}
+    return (value or "false") not in {"false", "0"}
+
+
+def resolve_trace_to_opik(value: str | None, opik_url: str | None) -> str:
+    """Resolve the fleet-wide switch the way scripts/config_loader.sh does.
+
+    Opik is optional, so an absent switch must not demand an Opik server.
+    A configured OPIK_URL means tracing was wanted, no endpoint means it
+    was not."""
+    if value and value.strip():
+        return value
+    if opik_url and opik_url.strip():
+        print("[INFO] TRACE_TO_OPIK unset; OPIK_URL present -> tracing on", file=sys.stderr)
+        return "true"
+    print("[INFO] TRACE_TO_OPIK unset; no OPIK_URL -> tracing off", file=sys.stderr)
+    return "false"
 
 
 def positive_int(value: str) -> int:
@@ -129,7 +144,7 @@ def load_runner_config() -> dict[str, str]:
         "MODEL": shared_model(),
         "BASE_URL": shared("BASE_URL"),
         "API_KEY": shared("API_KEY"),
-        "TRACE_TO_OPIK": shared("TRACE_TO_OPIK", "true"),
+        "TRACE_TO_OPIK": shared("TRACE_TO_OPIK"),
         "PINCHBENCH_MODEL_PROVIDER": "auto",
         "PINCHBENCH_TIMEOUT_MULTIPLIER": "1.0",
         "JUDGE_MODEL": "",
@@ -158,10 +173,15 @@ def load_runner_config() -> dict[str, str]:
     # This is a fleet-wide switch, not a PinchBench-specific setting. Keep it
     # on the shared config precedence chain even if an old runner file happens
     # to contain a conflicting key; the caller environment still wins below.
-    config["TRACE_TO_OPIK"] = shared("TRACE_TO_OPIK", "true")
+    config["TRACE_TO_OPIK"] = shared("TRACE_TO_OPIK")
     for key in config:
         if key in os.environ:
             config[key] = os.environ[key]
+    # OPIK_URL follows the same precedence but is not part of the worker config.
+    config["TRACE_TO_OPIK"] = resolve_trace_to_opik(
+        config["TRACE_TO_OPIK"],
+        os.environ.get("OPIK_URL") or shared("OPIK_URL"),
+    )
     for key in ("PINCHBENCH_DIR", "PINCHBENCH_OUTPUT_DIR", "PINCHBENCH_UV_CACHE_DIR"):
         config[key] = expand_path(config[key], relative_to=REPO_ROOT)
     for key in ("CONFIG_BASE", "WORKSPACE_BASE"):

--- a/Tasks/Pinchbench/tests/test_run_parallel_workers.py
+++ b/Tasks/Pinchbench/tests/test_run_parallel_workers.py
@@ -349,6 +349,62 @@ class BenchmarkCommandTests(unittest.TestCase):
         self.assertEqual(config["MODEL"], "shared-model")
         self.assertEqual(config["TRACE_TO_OPIK"], "false")
 
+    def resolve_trace_switch_from_configs(self, shared_config, env):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_env = tmp_path / "config.env"
+            config_local_env = tmp_path / "config.local.env"
+            fleet_env = tmp_path / "fleet.env"
+            generated_env = tmp_path / ".env"
+            pinchbench_env = tmp_path / "pinchbench.env"
+            config_env.write_text(shared_config, encoding="utf-8")
+            config_local_env.write_text("", encoding="utf-8")
+            fleet_env.write_text("", encoding="utf-8")
+            generated_env.write_text("", encoding="utf-8")
+            pinchbench_env.write_text("", encoding="utf-8")
+
+            with mock.patch.object(self.runner, "CONFIG_ENV_FILE", config_env), \
+                 mock.patch.object(self.runner, "CONFIG_LOCAL_ENV_FILE", config_local_env), \
+                 mock.patch.object(self.runner, "FLEET_ENV_FILE", fleet_env), \
+                 mock.patch.object(self.runner, "ENV_FILE", generated_env), \
+                 mock.patch.object(self.runner, "PINCHBENCH_ENV_FILE", pinchbench_env), \
+                 mock.patch.dict(self.runner.os.environ, env, clear=True):
+                return self.runner.load_runner_config()["TRACE_TO_OPIK"]
+
+    def test_absent_trace_switch_follows_configured_opik_url(self):
+        self.assertEqual(
+            self.resolve_trace_switch_from_configs(
+                "OPIK_URL=https://opik.example.invalid/api\n", {}
+            ),
+            "true",
+        )
+
+    def test_absent_trace_switch_without_opik_url_disables_tracing(self):
+        self.assertEqual(self.resolve_trace_switch_from_configs("", {}), "false")
+
+    def test_caller_opik_url_enables_tracing_over_empty_config(self):
+        self.assertEqual(
+            self.resolve_trace_switch_from_configs(
+                "", {"OPIK_URL": "https://opik.example.invalid/api"}
+            ),
+            "true",
+        )
+
+    def test_explicit_trace_switch_wins_over_opik_url(self):
+        self.assertEqual(
+            self.resolve_trace_switch_from_configs(
+                "OPIK_URL=https://opik.example.invalid/api\nTRACE_TO_OPIK=false\n", {}
+            ),
+            "false",
+        )
+        self.assertEqual(
+            self.resolve_trace_switch_from_configs(
+                "OPIK_URL=https://opik.example.invalid/api\n",
+                {"TRACE_TO_OPIK": "false"},
+            ),
+            "false",
+        )
+
     def test_runner_config_resolves_relative_local_repo_url_from_repo_root(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -446,9 +502,11 @@ class BenchmarkCommandTests(unittest.TestCase):
         )
 
         self.assertIn("/opt/opik-venv", dockerfile)
-        self.assertIn("ARG OPENCLAW_BASE_IMAGE=openclaw:local-opik", dockerfile)
+        # Opik is opt-in, so a manual build without --build-arg must produce the
+        # untraced pair. The runner always passes both args explicitly.
+        self.assertIn("ARG OPENCLAW_BASE_IMAGE=openclaw:local", dockerfile)
         self.assertIn("FROM ${OPENCLAW_BASE_IMAGE}", dockerfile)
-        self.assertIn('ARG TRACE_TO_OPIK=true', dockerfile)
+        self.assertIn('ARG TRACE_TO_OPIK=false', dockerfile)
         self.assertIn("/opt/pinchbench-trace-to-opik", dockerfile)
         self.assertNotIn("cache/" + "sii-opik", dockerfile)
         self.assertIn("opik>=1.0.0", dockerfile)

--- a/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
+++ b/Tasks/clawBio/scripts/run-openclaw-clawbio.sh
@@ -197,11 +197,17 @@ Use it only for the generated ClawBio fleet. The profile remains active until
 that fleet is stopped or regenerated.
 EOF
 
+# This launcher keeps its own precedence chain (fleet.env and the ClawBio
+# profile layer on top), so resolve the tracing switch once it is complete.
+# shellcheck source=../../../scripts/config_loader.sh
+. "$REPO_ROOT/scripts/config_loader.sh"
+agent_fleet_resolve_trace_to_opik
+
 # TRACE_TO_OPIK is the authoritative switch documented in the root README:
 # tracing off forces the plugin off, even over an explicit
 # OPIK_PLUGIN=enabled lingering in fleet.env or another config file. With
 # tracing on, an explicit OPIK_PLUGIN still wins and the default is enabled.
-case "${TRACE_TO_OPIK:-true}" in
+case "$TRACE_TO_OPIK" in
   false|0)
     if [[ "$OPIK_PLUGIN" == "enabled" ]]; then
       echo "TRACE_TO_OPIK=false overrides OPIK_PLUGIN=enabled; tracing plugin disabled" >&2
@@ -259,7 +265,7 @@ elif [[ "$OPIK_PLUGIN" == "enabled" ]] && ! image_exists "openclaw:local-opik"; 
 fi
 
 if [[ "$need_build" -eq 1 ]]; then
-  TRACE_TO_OPIK="${TRACE_TO_OPIK:-true}" \
+  TRACE_TO_OPIK="$TRACE_TO_OPIK" \
     OPIK_PLUGIN="$OPIK_PLUGIN" \
     "$OPENCLAW_DIR/scripts/build-openclaw-image.sh"
 elif [[ "$OPIK_PLUGIN" == "enabled" ]]; then
@@ -271,7 +277,7 @@ fi
 "$BENCH_DIR/scripts/prewarm-cache.sh" --cache-dir "$PLUGIN_CACHE_DIR"
 
 env_args=(
-  "TRACE_TO_OPIK=${TRACE_TO_OPIK:-true}"
+  "TRACE_TO_OPIK=$TRACE_TO_OPIK"
   "OPIK_PLUGIN=$OPIK_PLUGIN"
   "OPENCLAW_UID=$OPENCLAW_UID"
   "OPENCLAW_GID=$OPENCLAW_GID"

--- a/config.env
+++ b/config.env
@@ -160,6 +160,9 @@ YICLOUD_SANDBOX_FAST_UPLOAD_ORIGIN=https://sandbox.yicloud.com.cn
 
 # ── Opik (optional) ──────────────────────────────────────────────────
 # setup.sh asks for this endpoint and persists whether Opik should be used.
+# Without setup, tracing follows OPIK_URL: an endpoint here turns it on, no
+# endpoint turns it off. Set the fleet-wide switch explicitly to override that.
+# TRACE_TO_OPIK=false
 # OPIK_URL=https://opik.example.com/api
 # OPIK_PROJECT_NAME=
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -506,11 +506,12 @@ interfaces:
 - `--detach` is redundant for multi-run input: Harbor runs always detach there
   (an informational notice is printed), while OpenClaw runners stay in the
   foreground and ignore `--detach` with a warning in every mode.
-- If `TRACE_TO_OPIK` is absent, benchmark runners retain their historical
-  tracing-on default and require `OPIK_URL`. Interactive setup avoids that
-  ambiguity by always persisting an explicit state: a supplied `OPIK_URL`
-  derives `TRACE_TO_OPIK=true`, while an empty optional URL derives
-  `TRACE_TO_OPIK=false`.
+- If `TRACE_TO_OPIK` is absent, every host entry point derives it from
+  `OPIK_URL`: a configured endpoint turns tracing on, no endpoint turns it off.
+  The derivation logs one line to stderr; an explicit switch stays silent.
+  Interactive setup avoids the question entirely by always persisting an
+  explicit state: a supplied `OPIK_URL` derives `TRACE_TO_OPIK=true`, while an
+  empty optional URL derives `TRACE_TO_OPIK=false`.
 - `TRACE_TO_OPIK` remains the advanced fleet-wide switch for Harbor, workers,
   rollouts, DinD, ClawBio, and PinchBench. A caller-supplied switch takes
   precedence over a caller-supplied URL, which in turn takes precedence over

--- a/scripts/config_loader.sh
+++ b/scripts/config_loader.sh
@@ -40,6 +40,37 @@ agent_fleet_load_config() {
 
   AGENT_FLEET_CONFIG_LOADED_ROOT="$repo_root"
   export AGENT_FLEET_CONFIG_LOADED_ROOT
+
+  agent_fleet_resolve_trace_to_opik
+}
+
+# Opik is optional, so an absent switch must not demand an Opik server. Derive
+# it from OPIK_URL instead: a configured endpoint means tracing was wanted, no
+# endpoint means it was not. Callers that load their own config files (the
+# OpenClaw image build, the ClawBio launcher) source this library for the helper
+# and call it once their own precedence chain has been applied.
+#
+# Only the derivation is announced; an explicit switch stays silent. Tools whose
+# output is parsed rather than read (the Harbor controller emits JSON) set
+# AGENT_FLEET_CONFIG_QUIET=1 so a repeated diagnostic cannot reach their callers.
+agent_fleet_resolve_trace_to_opik() {
+  if [[ -n "${TRACE_TO_OPIK:-}" ]]; then
+    export TRACE_TO_OPIK
+    return 0
+  fi
+
+  local reason
+  if [[ -n "${OPIK_URL:-}" ]]; then
+    TRACE_TO_OPIK=true
+    reason="OPIK_URL present -> tracing on"
+  else
+    TRACE_TO_OPIK=false
+    reason="no OPIK_URL -> tracing off"
+  fi
+  if [[ "${AGENT_FLEET_CONFIG_QUIET:-0}" != "1" ]]; then
+    echo "[INFO] TRACE_TO_OPIK unset; $reason" >&2
+  fi
+  export TRACE_TO_OPIK
 }
 
 # AUTH_TOKEN is a documented fleet-runner credential alias, not a general

--- a/scripts/run_fleet.sh
+++ b/scripts/run_fleet.sh
@@ -65,7 +65,7 @@ validate_run_config() {
   for required in BASE_URL API_KEY MODEL; do
     [[ -n "${!required:-}" ]] || missing+=("$required")
   done
-  case "${TRACE_TO_OPIK:-true}" in
+  case "${TRACE_TO_OPIK:-false}" in
     false|0) ;;
     *) [[ -n "${OPIK_URL:-}" ]] || missing+=("OPIK_URL (required when TRACE_TO_OPIK=true)") ;;
   esac

--- a/scripts/tests/test_config_loader.py
+++ b/scripts/tests/test_config_loader.py
@@ -20,6 +20,8 @@ CONFIG_NAMES = (
     "HARBOR_ANTHROPIC_AUTH_TOKEN",
     "HARBOR_ANALYZER_BASE_URL",
     "HARBOR_ANALYZER_MODEL",
+    "TRACE_TO_OPIK",
+    "OPIK_URL",
     "ROLLOUT",
     "RL_ENV_FILE",
     "RL_API_BASE",
@@ -100,6 +102,59 @@ class ConfigLoaderTest(unittest.TestCase):
             runtime.stdout,
             "https://runtime.example.invalid|fake-runtime-key|runtime-model",
         )
+
+    def test_absent_trace_switch_follows_configured_opik_url(self):
+        self.write_configs("", "OPIK_URL=https://opik.example.invalid/api\n")
+
+        result = self.run_loader(
+            'agent_fleet_load_config "$2"; printf "%s" "$TRACE_TO_OPIK"'
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "true")
+        self.assertIn("OPIK_URL present -> tracing on", result.stderr)
+
+    def test_absent_trace_switch_without_opik_url_disables_tracing(self):
+        self.write_configs("", "")
+
+        result = self.run_loader(
+            'agent_fleet_load_config "$2"; printf "%s" "$TRACE_TO_OPIK"'
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "false")
+        self.assertIn("no OPIK_URL -> tracing off", result.stderr)
+
+    def test_explicit_trace_switch_wins_over_opik_url(self):
+        self.write_configs(
+            "",
+            "OPIK_URL=https://opik.example.invalid/api\nTRACE_TO_OPIK=false\n",
+        )
+
+        saved = self.run_loader(
+            'agent_fleet_load_config "$2"; printf "%s" "$TRACE_TO_OPIK"'
+        )
+        runtime = self.run_loader(
+            'agent_fleet_load_config "$2"; printf "%s" "$TRACE_TO_OPIK"',
+            extra_env={"TRACE_TO_OPIK": "true"},
+        )
+
+        self.assertEqual(saved.returncode, 0, saved.stderr)
+        self.assertEqual(saved.stdout, "false")
+        self.assertNotIn("TRACE_TO_OPIK unset", saved.stderr)
+        self.assertEqual(runtime.returncode, 0, runtime.stderr)
+        self.assertEqual(runtime.stdout, "true")
+
+    def test_resolved_trace_switch_is_exported_to_children(self):
+        self.write_configs("", "OPIK_URL=https://opik.example.invalid/api\n")
+
+        result = self.run_loader(
+            'agent_fleet_load_config "$2"; '
+            'bash -c "printf %s \\"\\$TRACE_TO_OPIK\\""'
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "true")
 
     def test_tool_aliases_do_not_override_saved_canonical_config(self):
         self.write_configs(

--- a/scripts/tests/test_run_fleet.py
+++ b/scripts/tests/test_run_fleet.py
@@ -132,6 +132,46 @@ exit "${STUB_EXIT:-0}"
         self.assertIn("HARBOR_N_CONCURRENT=3", result.stdout)
         self.assertIn("RUN_ID=\n", result.stdout)
 
+    def write_local_config(self, trailer=""):
+        (self.repo / "config.local.env").write_text(
+            "BASE_URL=https://gateway.example.invalid\n"
+            "API_KEY=fake-runner-key\n"
+            "MODEL=test-model\n" + trailer,
+            encoding="utf-8",
+        )
+
+    def test_absent_trace_switch_without_opik_url_does_not_require_opik(self):
+        self.write_local_config()
+
+        result = self.run_fleet(
+            "--taskset", "terminal-bench/terminal-bench-2-1", "--agent", "claude-code"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("runner=harbor", result.stdout)
+        self.assertNotIn("missing required configuration", result.stderr)
+        self.assertIn("no OPIK_URL -> tracing off", result.stderr)
+
+    def test_absent_trace_switch_with_opik_url_enables_tracing(self):
+        self.write_local_config("OPIK_URL=https://opik.example.invalid/api\n")
+
+        result = self.run_fleet(
+            "--taskset", "terminal-bench/terminal-bench-2-1", "--agent", "claude-code"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("OPIK_URL present -> tracing on", result.stderr)
+
+    def test_explicit_trace_switch_without_opik_url_still_fails(self):
+        self.write_local_config("TRACE_TO_OPIK=true\n")
+
+        result = self.run_fleet(
+            "--taskset", "terminal-bench/terminal-bench-2-1", "--agent", "claude-code"
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("OPIK_URL (required when TRACE_TO_OPIK=true)", result.stderr)
+
     def test_explicit_local_taskset_maps_only_path_inputs(self):
         result = self.run_fleet("--taskset", "./tasks", "--agent", "opencode")
         self.assertEqual(result.returncode, 0, result.stderr)


### PR DESCRIPTION
## Problem

Opik is optional — `scripts/setup.sh` persists `TRACE_TO_OPIK=false` when you press Enter at the `OPIK_URL` prompt, and the README documents it as optional. But every consumer defaulted the switch to `true` when it was **absent**, so any checkout that did not go through `scripts/setup.sh` demanded an Opik server:

- `scripts/run_fleet.sh` refused to start: `missing required configuration: OPIK_URL (required when TRACE_TO_OPIK=true)`
- `harboropik.sh` exited 1 on an empty `OPIK_URL`
- PinchBench/OpenClaw builds baked in the Opik runtime, and the Claude realtime hook was enabled

That hit hand-written `config.local.env` files (the `config.env` template stopped documenting the switch in #69), CI/DinD hosts, and direct `harboropik.sh` / PinchBench invocations.

## Change

Host entry points now derive the switch from `OPIK_URL` when it is absent — a configured endpoint means tracing was wanted, no endpoint means it was not — and log that one decision to stderr. An explicit value stays silent and authoritative, including explicit `TRACE_TO_OPIK=true` with no URL, which still fails loudly as a real misconfiguration.

| Input | Result |
| --- | --- |
| `TRACE_TO_OPIK` set | used verbatim, silently |
| unset, `OPIK_URL` set | `true` + `[INFO] TRACE_TO_OPIK unset; OPIK_URL present -> tracing on` |
| unset, no `OPIK_URL` | `false` + `[INFO] TRACE_TO_OPIK unset; no OPIK_URL -> tracing off` |

**Host tier** — `agent_fleet_resolve_trace_to_opik()` in `scripts/config_loader.sh` (covers `env.sh`, `run_fleet.sh`, `dind-run.sh`, `fleet_prompt.sh`, `controller.py`); `build-openclaw-image.sh` and `run-openclaw-clawbio.sh` source it and resolve after their own precedence chains; `run-parallel-workers.py` and `Openclaw/scripts/setup.py` mirror the rule locally, matching the existing per-subsystem convention in those files.

**Downstream tier** — bare fallbacks flip to off in `Pinchbench/Dockerfile`, `fleet.env.j2`, `env.sh`, `run_fleet.sh`, and the three `Harbor-opencode` helpers. These only ever see an already-resolved value; the flip makes direct invocation fail safe. `Harbor-claude-code/sitecustomize.py` needed no change — `_is_true(None)` already returned `False`.

Two decisions worth calling out:

1. **`AGENT_FLEET_CONFIG_QUIET=1`** — `controller.py` emits JSON on stdout and is polled by `monitor_harbor.sh`, so it sets this flag during config load. Everything human-facing still logs.
2. **`OPENCLAW_BASE_IMAGE` default** paired to `openclaw:local` — left at `local-opik`, a manual `docker build` would produce an Opik base image with no Opik runtime, which the runner's own probe (`test ! -e /opt/openclaw-plugins/openclaw-opik-tracer`) rejects. The runner always passes both build args explicitly, so this only affects manual builds.

## Tests

New coverage for derivation on/off, explicit-wins, and export-to-children in `test_config_loader.py`; the same three at the `run_fleet.sh` level, which pins the original bug; equivalents for the PinchBench and OpenClaw resolvers; two new cases in `test_build_openclaw_image.sh`.

`test_build_openclaw_image.sh:53-66` had silently changed meaning — it passed `OPIK_PLUGIN=enabled` with no switch, so it used to exercise the plugin-enabled build path via the old default and would have kept passing while testing the opposite. Its intent is now pinned explicitly.

Ran locally (macOS): shell syntax over all 68 `*.sh`; `tests/` (5), `scripts/tests/` (148), `.github/scripts/tests/` (267), PinchBench (35), clawBio (10), OpenClaw (43), Harbor-opencode (13), Harbor-claude-code (4), Harbor-pi (5), and all 18 shell test scripts.

Pre-existing failures, each confirmed by running the identical suite on untouched `main` and diffing the failure sets — not touched by this PR:

- `scripts/tests/test_run_fleet.py::test_explicit_local_taskset_maps_only_path_inputs` — macOS `/var` vs `/private/var` realpath
- `Agents/utils/common/Harbor/tests` (49) and `Agents/utils/rl/tests` (3) — failure sets identical to `main`
- 6 shell tests requiring Docker/Linux — same pass/fail set as `main`
