### PR TITLE
Refactor Harbor package environment arguments

### DIFF
--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -204,6 +204,32 @@ append_rust_package_mirror_env() {
   fi
 }
 
+append_package_environment_args() {
+  local env_name
+  for env_name in \
+    PIP_INDEX_URL \
+    PIP_EXTRA_INDEX_URL \
+    PIP_TRUSTED_HOST \
+    UV_INDEX_URL \
+    UV_DEFAULT_INDEX \
+    NPM_CONFIG_REGISTRY
+  do
+    if [[ -n "${!env_name:-}" ]]; then
+      cmd+=( --ae "$env_name=${!env_name}" --ve "$env_name=${!env_name}" )
+    fi
+  done
+  if [[ -n "${HARBOR_CC_NODE_DIST_URL:-}" ]]; then
+    cmd+=( --ae "CC_NODE_DIST_URL=$HARBOR_CC_NODE_DIST_URL" )
+  fi
+  for env_name in GO111MODULE GOPROXY GOSUMDB; do
+    if [[ -n "${!env_name:-}" ]]; then
+      cmd+=( --ae "$env_name=${!env_name}" --ve "$env_name=${!env_name}" )
+    fi
+  done
+  append_rust_package_mirror_env --ae
+  append_rust_package_mirror_env --ve
+}
+
 append_harbor_unprivileged_docker_compose() {
   if [[ "${HARBOR_ENVIRONMENT_TYPE:-docker}" != "docker" ]]; then
     if [[ "${HARBOR_DRY_RUN:-0}" == "1" ]]; then
@@ -1171,39 +1197,7 @@ run_harbor() {
     )
   fi
 
-  if [[ -n "${PIP_INDEX_URL:-}" ]]; then
-    cmd+=( --ae "PIP_INDEX_URL=$PIP_INDEX_URL" --ve "PIP_INDEX_URL=$PIP_INDEX_URL" )
-  fi
-  if [[ -n "${PIP_EXTRA_INDEX_URL:-}" ]]; then
-    cmd+=( --ae "PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL" --ve "PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL" )
-  fi
-  if [[ -n "${PIP_TRUSTED_HOST:-}" ]]; then
-    cmd+=( --ae "PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST" --ve "PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST" )
-  fi
-  if [[ -n "${UV_INDEX_URL:-}" ]]; then
-    # SWE-smith verifier scripts run `uv add ...`; pip env alone is ignored by uv.
-    cmd+=( --ae "UV_INDEX_URL=$UV_INDEX_URL" --ve "UV_INDEX_URL=$UV_INDEX_URL" )
-  fi
-  if [[ -n "${UV_DEFAULT_INDEX:-}" ]]; then
-    cmd+=( --ae "UV_DEFAULT_INDEX=$UV_DEFAULT_INDEX" --ve "UV_DEFAULT_INDEX=$UV_DEFAULT_INDEX" )
-  fi
-  if [[ -n "${NPM_CONFIG_REGISTRY:-}" ]]; then
-    cmd+=( --ae "NPM_CONFIG_REGISTRY=$NPM_CONFIG_REGISTRY" --ve "NPM_CONFIG_REGISTRY=$NPM_CONFIG_REGISTRY" )
-  fi
-  if [[ -n "${HARBOR_CC_NODE_DIST_URL:-}" ]]; then
-    cmd+=( --ae "CC_NODE_DIST_URL=$HARBOR_CC_NODE_DIST_URL" )
-  fi
-  if [[ -n "${GO111MODULE:-}" ]]; then
-    cmd+=( --ae "GO111MODULE=$GO111MODULE" --ve "GO111MODULE=$GO111MODULE" )
-  fi
-  if [[ -n "${GOPROXY:-}" ]]; then
-    cmd+=( --ae "GOPROXY=$GOPROXY" --ve "GOPROXY=$GOPROXY" )
-  fi
-  if [[ -n "${GOSUMDB:-}" ]]; then
-    cmd+=( --ae "GOSUMDB=$GOSUMDB" --ve "GOSUMDB=$GOSUMDB" )
-  fi
-  append_rust_package_mirror_env --ae
-  append_rust_package_mirror_env --ve
+  append_package_environment_args
 
   if [[ "$HARBOR_DEBUG" == "1" ]]; then
     cmd+=( --debug )
@@ -1487,38 +1481,7 @@ run_opencode_task() {
       fi
     done
 
-    if [[ -n "${PIP_INDEX_URL:-}" ]]; then
-      cmd+=( --ae "PIP_INDEX_URL=$PIP_INDEX_URL" --ve "PIP_INDEX_URL=$PIP_INDEX_URL" )
-    fi
-    if [[ -n "${PIP_EXTRA_INDEX_URL:-}" ]]; then
-      cmd+=( --ae "PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL" --ve "PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL" )
-    fi
-    if [[ -n "${PIP_TRUSTED_HOST:-}" ]]; then
-      cmd+=( --ae "PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST" --ve "PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST" )
-    fi
-    if [[ -n "${UV_INDEX_URL:-}" ]]; then
-      cmd+=( --ae "UV_INDEX_URL=$UV_INDEX_URL" --ve "UV_INDEX_URL=$UV_INDEX_URL" )
-    fi
-    if [[ -n "${UV_DEFAULT_INDEX:-}" ]]; then
-      cmd+=( --ae "UV_DEFAULT_INDEX=$UV_DEFAULT_INDEX" --ve "UV_DEFAULT_INDEX=$UV_DEFAULT_INDEX" )
-    fi
-    if [[ -n "${NPM_CONFIG_REGISTRY:-}" ]]; then
-      cmd+=( --ae "NPM_CONFIG_REGISTRY=$NPM_CONFIG_REGISTRY" --ve "NPM_CONFIG_REGISTRY=$NPM_CONFIG_REGISTRY" )
-    fi
-    if [[ -n "${HARBOR_CC_NODE_DIST_URL:-}" ]]; then
-      cmd+=( --ae "CC_NODE_DIST_URL=$HARBOR_CC_NODE_DIST_URL" )
-    fi
-    if [[ -n "${GO111MODULE:-}" ]]; then
-      cmd+=( --ae "GO111MODULE=$GO111MODULE" --ve "GO111MODULE=$GO111MODULE" )
-    fi
-    if [[ -n "${GOPROXY:-}" ]]; then
-      cmd+=( --ae "GOPROXY=$GOPROXY" --ve "GOPROXY=$GOPROXY" )
-    fi
-    if [[ -n "${GOSUMDB:-}" ]]; then
-      cmd+=( --ae "GOSUMDB=$GOSUMDB" --ve "GOSUMDB=$GOSUMDB" )
-    fi
-    append_rust_package_mirror_env --ae
-    append_rust_package_mirror_env --ve
+    append_package_environment_args
 
     if [[ -n "$INCLUDE_TASKS" ]]; then
       IFS=',' read -r -a include_arr <<< "$INCLUDE_TASKS"

--- a/Agents/utils/common/Harbor/tests/test_harboropik_package_environment.py
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_package_environment.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+HARBOROPIK = Path(__file__).resolve().parents[1] / "harboropik.sh"
+
+
+def function_source(script: str, name: str) -> str:
+    start_match = re.search(rf"^{name}\(\) \{{\n", script, re.MULTILINE)
+    if start_match is None:
+        raise AssertionError(f"missing shell function: {name}")
+    next_match = re.search(
+        r"^[a-zA-Z_][a-zA-Z0-9_]*\(\) \{\n",
+        script[start_match.end() :],
+        re.MULTILINE,
+    )
+    end = len(script) if next_match is None else start_match.end() + next_match.start()
+    return script[start_match.start() : end]
+
+
+class HarborPackageEnvironmentTest(unittest.TestCase):
+    def test_package_environment_arguments_use_one_shared_helper(self) -> None:
+        script = HARBOROPIK.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            len(
+                re.findall(
+                    r"^append_package_environment_args\(\) \{$",
+                    script,
+                    re.MULTILINE,
+                )
+            ),
+            1,
+        )
+        self.assertEqual(
+            len(
+                re.findall(
+                    r"^\s+append_package_environment_args$",
+                    script,
+                    re.MULTILINE,
+                )
+            ),
+            2,
+        )
+
+        definitions = "\n".join(
+            function_source(script, name)
+            for name in (
+                "cargo_registry_env_suffix",
+                "append_rust_package_mirror_env",
+                "append_package_environment_args",
+            )
+        )
+        command = (
+            f"{definitions}\n"
+            "cmd=()\n"
+            "append_package_environment_args\n"
+            "printf '%s\\n' \"${cmd[@]}\"\n"
+        )
+        environment = {
+            "PATH": "/usr/bin:/bin",
+            "PIP_INDEX_URL": "https://pip.example/simple",
+            "PIP_EXTRA_INDEX_URL": "https://extra.example/simple",
+            "PIP_TRUSTED_HOST": "pip.example",
+            "UV_INDEX_URL": "https://uv.example/simple",
+            "UV_DEFAULT_INDEX": "https://uv-default.example/simple",
+            "NPM_CONFIG_REGISTRY": "https://npm.example",
+            "HARBOR_CC_NODE_DIST_URL": "https://node.example",
+            "GO111MODULE": "on",
+            "GOPROXY": "https://go.example",
+            "GOSUMDB": "off",
+        }
+        result = subprocess.run(
+            ["bash", "-c", command],
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        arguments = result.stdout.splitlines()
+        for name, value in environment.items():
+            if name == "PATH":
+                continue
+            expected_name = "CC_NODE_DIST_URL" if name == "HARBOR_CC_NODE_DIST_URL" else name
+            expected = f"{expected_name}={value}"
+            self.assertIn(expected, arguments)
+            self.assertEqual(arguments[arguments.index(expected) - 1], "--ae")
+            if name != "HARBOR_CC_NODE_DIST_URL":
+                self.assertIn(
+                    ["--ve", expected],
+                    [arguments[index : index + 2] for index in range(len(arguments) - 1)],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Claude and OpenCode command builders carried separate copies of the same package and mirror environment argument block. Any new mirror variable or correction had to be applied twice, creating avoidable drift risk.

## 2. Summary of the change

- add one `append_package_environment_args` helper
- preserve the existing agent and verifier argument mappings and ordering
- call the helper from both Claude and OpenCode command construction
- add focused regression coverage for helper ownership and rendered arguments

## 3. Other details

Verification:

- `python3 Agents/utils/common/Harbor/tests/test_harboropik_package_environment.py`
- `bash -n Agents/utils/common/Harbor/harboropik.sh`
- `uvx ruff@0.16.0 check --config .github/ruff.toml Agents/utils/common/Harbor/tests/test_harboropik_package_environment.py`
- `git diff --check`

The broader `test_harboropik_extra_compose.sh` fixture was also run; on macOS it fails identically on upstream `main` because the expected `.verifier-tools` artifact is not produced.
