### PR TITLE
Refactor model-fusion proxy helpers

### DIFF
--- a/Agents/utils/common/Harbor/model-fusion/harboropik.sh
+++ b/Agents/utils/common/Harbor/model-fusion/harboropik.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # binary directly and never pass through model-fusion code.
 REAL_OPIK_BIN="${MODEL_FUSION_REAL_HARBOR_OPIK_BIN:?missing real Opik CLI path}"
 MODEL_FUSION_DIR="${MODEL_FUSION_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+. "$MODEL_FUSION_DIR/proxy_common.sh"
 
 if [[ "$REAL_OPIK_BIN" == "$0" ]]; then
   echo "[ERROR] model-fusion Opik proxy points to itself" >&2
@@ -14,17 +15,7 @@ fi
 
 # Version and help probes must remain transparent so the shared pinned-runner
 # validation sees the real CLI without requiring a prepared fusion task.
-inject_fusion=0
-if [[ "${1:-}" == "harbor" && "${2:-}" == "run" ]]; then
-  inject_fusion=1
-  for arg in "$@"; do
-    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-      inject_fusion=0
-      break
-    fi
-  done
-fi
-if [[ "$inject_fusion" != "1" ]]; then
+if ! model_fusion_proxy_is_injectable "$@"; then
   exec "$REAL_OPIK_BIN" "$@"
 fi
 
@@ -48,61 +39,13 @@ args=("$@")
 # gateways must be reached directly from the task container. The shared Harbor
 # command already carries NO_PROXY for Opik and wheel hosts; retain that value
 # and add the model gateway host for this scoped integration.
-gateway_host="$(
-  python3 "$MODEL_FUSION_DIR/../harbor_shell_utils.py" url-hostname \
-    "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
-)"
-if [[ -n "$gateway_host" ]]; then
-  found_upper=0
-  found_lower=0
-  for ((i = 0; i + 1 < ${#args[@]}; i++)); do
-    [[ "${args[$i]}" == "--ae" ]] || continue
-    case "${args[$((i + 1))]}" in
-      NO_PROXY=*)
-        found_upper=1
-        value="${args[$((i + 1))]#NO_PROXY=}"
-        [[ ",$value," == *",$gateway_host,"* ]] \
-          || args[$((i + 1))]="NO_PROXY=${value:+$value,}$gateway_host"
-        ;;
-      no_proxy=*)
-        found_lower=1
-        value="${args[$((i + 1))]#no_proxy=}"
-        [[ ",$value," == *",$gateway_host,"* ]] \
-          || args[$((i + 1))]="no_proxy=${value:+$value,}$gateway_host"
-        ;;
-    esac
-  done
-  [[ "$found_upper" == "1" ]] || args+=(--ae "NO_PROXY=$gateway_host")
-  [[ "$found_lower" == "1" ]] || args+=(--ae "no_proxy=$gateway_host")
-fi
-
-mount_value_index=-1
-for ((i = 0; i < ${#args[@]}; i++)); do
-  if [[ "${args[$i]}" == "--mounts-json" ]]; then
-    if ((i + 1 >= ${#args[@]})); then
-      echo "[ERROR] --mounts-json is missing its value" >&2
-      exit 2
-    fi
-    mount_value_index=$((i + 1))
-    break
-  fi
-done
-
-mounts_json="[]"
-if ((mount_value_index >= 0)); then
-  mounts_json="${args[$mount_value_index]}"
-fi
-mounts_json="$(
-  python3 "$MODEL_FUSION_DIR/harbor_worker_utils.py" \
-    append-readonly-mounts "$mounts_json" \
-    --mount "$HARBOR_FUSION_ROUND_ROUTER_DIR" "$HARBOR_FUSION_ROUND_ROUTER_MOUNT_PATH" \
-    --mount "$HARBOR_FUSION_TASK_FILE_SOURCE" "$HARBOR_FUSION_TASK_FILE"
-)"
-if ((mount_value_index >= 0)); then
-  args[$mount_value_index]="$mounts_json"
-else
-  args+=(--mounts-json "$mounts_json")
-fi
+model_fusion_proxy_append_gateway_no_proxy \
+  "$MODEL_FUSION_DIR/../harbor_shell_utils.py" \
+  "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
+model_fusion_proxy_merge_readonly_mounts \
+  "$MODEL_FUSION_DIR/harbor_worker_utils.py" \
+  --mount "$HARBOR_FUSION_ROUND_ROUTER_DIR" "$HARBOR_FUSION_ROUND_ROUTER_MOUNT_PATH" \
+  --mount "$HARBOR_FUSION_TASK_FILE_SOURCE" "$HARBOR_FUSION_TASK_FILE"
 
 args+=(
   --ae "HARBOR_CLAUDE_CODE_AGENTS_JSON=${HARBOR_CLAUDE_CODE_AGENTS_JSON:-}"

--- a/Agents/utils/common/Harbor/model-fusion/mimo-code/harboropik.sh
+++ b/Agents/utils/common/Harbor/model-fusion/mimo-code/harboropik.sh
@@ -3,23 +3,14 @@ set -euo pipefail
 
 REAL_OPIK_BIN="${MIMO_CODE_REAL_HARBOR_OPIK_BIN:?missing real Opik CLI path}"
 MIMO_CODE_DIR="${MIMO_CODE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+. "$MIMO_CODE_DIR/../proxy_common.sh"
 
 if [[ "$REAL_OPIK_BIN" == "$0" ]]; then
   echo "[ERROR] MimoCode Opik proxy points to itself" >&2
   exit 2
 fi
 
-inject_mimo=0
-if [[ "${1:-}" == "harbor" && "${2:-}" == "run" ]]; then
-  inject_mimo=1
-  for arg in "$@"; do
-    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-      inject_mimo=0
-      break
-    fi
-  done
-fi
-if [[ "$inject_mimo" != "1" ]]; then
+if ! model_fusion_proxy_is_injectable "$@"; then
   exec "$REAL_OPIK_BIN" "$@"
 fi
 
@@ -37,61 +28,13 @@ fi
 
 args=("$@")
 
-gateway_host="$(
-  python3 "$MIMO_CODE_DIR/../../harbor_shell_utils.py" url-hostname \
-    "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
-)"
-if [[ -n "$gateway_host" ]]; then
-  found_upper=0
-  found_lower=0
-  for ((i = 0; i + 1 < ${#args[@]}; i++)); do
-    [[ "${args[$i]}" == "--ae" ]] || continue
-    case "${args[$((i + 1))]}" in
-      NO_PROXY=*)
-        found_upper=1
-        value="${args[$((i + 1))]#NO_PROXY=}"
-        [[ ",$value," == *",$gateway_host,"* ]] \
-          || args[$((i + 1))]="NO_PROXY=${value:+$value,}$gateway_host"
-        ;;
-      no_proxy=*)
-        found_lower=1
-        value="${args[$((i + 1))]#no_proxy=}"
-        [[ ",$value," == *",$gateway_host,"* ]] \
-          || args[$((i + 1))]="no_proxy=${value:+$value,}$gateway_host"
-        ;;
-    esac
-  done
-  [[ "$found_upper" == "1" ]] || args+=(--ae "NO_PROXY=$gateway_host")
-  [[ "$found_lower" == "1" ]] || args+=(--ae "no_proxy=$gateway_host")
-fi
-
-mount_value_index=-1
-for ((i = 0; i < ${#args[@]}; i++)); do
-  if [[ "${args[$i]}" == "--mounts-json" ]]; then
-    ((i + 1 < ${#args[@]})) || {
-      echo "[ERROR] --mounts-json is missing its value" >&2
-      exit 2
-    }
-    mount_value_index=$((i + 1))
-    break
-  fi
-done
-
-mounts_json="[]"
-if ((mount_value_index >= 0)); then
-  mounts_json="${args[$mount_value_index]}"
-fi
-mounts_json="$(
-  python3 "$MIMO_CODE_DIR/../harbor_worker_utils.py" \
-    append-readonly-mounts "$mounts_json" \
-    --mount "$MIMO_ROUTER_WHEEL" "$MIMO_ROUTER_WHEEL_MOUNT_PATH" \
-    --mount "$MIMO_ROUTER_CONFIG" "$MIMO_ROUTER_CONFIG_MOUNT_PATH"
-)"
-if ((mount_value_index >= 0)); then
-  args[$mount_value_index]="$mounts_json"
-else
-  args+=(--mounts-json "$mounts_json")
-fi
+model_fusion_proxy_append_gateway_no_proxy \
+  "$MIMO_CODE_DIR/../../harbor_shell_utils.py" \
+  "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
+model_fusion_proxy_merge_readonly_mounts \
+  "$MIMO_CODE_DIR/../harbor_worker_utils.py" \
+  --mount "$MIMO_ROUTER_WHEEL" "$MIMO_ROUTER_WHEEL_MOUNT_PATH" \
+  --mount "$MIMO_ROUTER_CONFIG" "$MIMO_ROUTER_CONFIG_MOUNT_PATH"
 
 args+=(
   --ae "MIMO_ROUTER_ENABLED=1"
@@ -103,13 +46,5 @@ args+=(
   --ae "MIMO_ROUTER_SUMMARY_PATH=${MIMO_ROUTER_SUMMARY_PATH:-/logs/agent/router-run-summary.json}"
 )
 
-if [[ "${MODEL_FUSION_PROXY_RENDER_ONLY:-0}" == "1" ]]; then
-  rendered_command="$(
-    python3 "$MIMO_CODE_DIR/../harbor_worker_utils.py" \
-      render-command "$REAL_OPIK_BIN" "${args[@]}"
-  )"
-  printf '[mimo-code] proxy command: %s\n' "$rendered_command"
-  exit 0
-fi
-
-exec "$REAL_OPIK_BIN" "${args[@]}"
+model_fusion_proxy_render_or_exec \
+  "mimo-code" "$REAL_OPIK_BIN" "$MIMO_CODE_DIR/../harbor_worker_utils.py"

--- a/Agents/utils/common/Harbor/model-fusion/openrouter/harboropik.sh
+++ b/Agents/utils/common/Harbor/model-fusion/openrouter/harboropik.sh
@@ -3,20 +3,16 @@ set -euo pipefail
 
 REAL_OPIK_BIN="${OPENROUTER_REAL_HARBOR_OPIK_BIN:?missing real Opik CLI path}"
 OPENROUTER_DIR="${OPENROUTER_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+. "$OPENROUTER_DIR/../proxy_common.sh"
 
 if [[ "$REAL_OPIK_BIN" == "$0" ]]; then
   echo "[ERROR] OpenRouter Opik proxy points to itself" >&2
   exit 2
 fi
 
-inject=0
-if [[ "${1:-}" == "harbor" && "${2:-}" == "run" ]]; then
-  inject=1
-  for arg in "$@"; do
-    [[ "$arg" != "--help" && "$arg" != "-h" ]] || inject=0
-  done
+if ! model_fusion_proxy_is_injectable "$@"; then
+  exec "$REAL_OPIK_BIN" "$@"
 fi
-[[ "$inject" == "1" ]] || exec "$REAL_OPIK_BIN" "$@"
 
 : "${OPENROUTER_WHEEL:?missing Router wheel}"
 : "${OPENROUTER_CONFIG:?missing Router config}"
@@ -25,53 +21,13 @@ fi
 [[ -f "$OPENROUTER_CONFIG" ]] || { echo "[ERROR] Router config not found" >&2; exit 2; }
 
 args=("$@")
-gateway_host="$(
-  python3 "$OPENROUTER_DIR/../../harbor_shell_utils.py" url-hostname \
-    "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
-)"
-if [[ -n "$gateway_host" ]]; then
-  found_upper=0
-  found_lower=0
-  for ((i = 0; i + 1 < ${#args[@]}; i++)); do
-    [[ "${args[$i]}" == "--ae" ]] || continue
-    case "${args[$((i + 1))]}" in
-      NO_PROXY=*)
-        found_upper=1
-        value="${args[$((i + 1))]#NO_PROXY=}"
-        [[ ",$value," == *",$gateway_host,"* ]] || args[$((i + 1))]="NO_PROXY=${value:+$value,}$gateway_host"
-        ;;
-      no_proxy=*)
-        found_lower=1
-        value="${args[$((i + 1))]#no_proxy=}"
-        [[ ",$value," == *",$gateway_host,"* ]] || args[$((i + 1))]="no_proxy=${value:+$value,}$gateway_host"
-        ;;
-    esac
-  done
-  [[ "$found_upper" == "1" ]] || args+=(--ae "NO_PROXY=$gateway_host")
-  [[ "$found_lower" == "1" ]] || args+=(--ae "no_proxy=$gateway_host")
-fi
-
-mount_index=-1
-for ((i = 0; i < ${#args[@]}; i++)); do
-  if [[ "${args[$i]}" == "--mounts-json" ]]; then
-    ((i + 1 < ${#args[@]})) || { echo "[ERROR] --mounts-json missing value" >&2; exit 2; }
-    mount_index=$((i + 1))
-    break
-  fi
-done
-mounts_json="[]"
-((mount_index < 0)) || mounts_json="${args[$mount_index]}"
-mounts_json="$(
-  python3 "$OPENROUTER_DIR/../harbor_worker_utils.py" append-readonly-mounts \
-    "$mounts_json" \
-    --mount "$OPENROUTER_WHEEL" "$OPENROUTER_WHEEL_MOUNT_PATH" \
-    --mount "$OPENROUTER_CONFIG" "$OPENROUTER_CONFIG_MOUNT_PATH"
-)"
-if ((mount_index < 0)); then
-  args+=(--mounts-json "$mounts_json")
-else
-  args[$mount_index]="$mounts_json"
-fi
+model_fusion_proxy_append_gateway_no_proxy \
+  "$OPENROUTER_DIR/../../harbor_shell_utils.py" \
+  "${HARBOR_ANTHROPIC_BASE_URL:-${BASE_URL:-}}"
+model_fusion_proxy_merge_readonly_mounts \
+  "$OPENROUTER_DIR/../harbor_worker_utils.py" \
+  --mount "$OPENROUTER_WHEEL" "$OPENROUTER_WHEEL_MOUNT_PATH" \
+  --mount "$OPENROUTER_CONFIG" "$OPENROUTER_CONFIG_MOUNT_PATH"
 
 args+=(
   --ae "OPENROUTER_ENABLED=1"
@@ -81,12 +37,5 @@ args+=(
   --ae "OPENROUTER_ARTIFACT_ROOT=${OPENROUTER_ARTIFACT_ROOT:-/logs/agent/router}"
   --ae "OPENROUTER_SUMMARY_PATH=${OPENROUTER_SUMMARY_PATH:-/logs/agent/router-run-summary.json}"
 )
-if [[ "${MODEL_FUSION_PROXY_RENDER_ONLY:-0}" == "1" ]]; then
-  rendered_command="$(
-    python3 "$OPENROUTER_DIR/../harbor_worker_utils.py" \
-      render-command "$REAL_OPIK_BIN" "${args[@]}"
-  )"
-  printf '[openrouter] proxy command: %s\n' "$rendered_command"
-  exit 0
-fi
-exec "$REAL_OPIK_BIN" "${args[@]}"
+model_fusion_proxy_render_or_exec \
+  "openrouter" "$REAL_OPIK_BIN" "$OPENROUTER_DIR/../harbor_worker_utils.py"

--- a/Agents/utils/common/Harbor/model-fusion/proxy_common.sh
+++ b/Agents/utils/common/Harbor/model-fusion/proxy_common.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+model_fusion_proxy_is_injectable() {
+  [[ "${1:-}" == "harbor" && "${2:-}" == "run" ]] || return 1
+  local arg
+  for arg in "$@"; do
+    [[ "$arg" != "--help" && "$arg" != "-h" ]] || return 1
+  done
+}
+
+model_fusion_proxy_append_gateway_no_proxy() {
+  local hostname_helper="$1"
+  local base_url="$2"
+  local gateway_host found_upper=0 found_lower=0 value i
+  gateway_host="$(python3 "$hostname_helper" url-hostname "$base_url")"
+  [[ -n "$gateway_host" ]] || return 0
+
+  for ((i = 0; i + 1 < ${#args[@]}; i++)); do
+    [[ "${args[$i]}" == "--ae" ]] || continue
+    case "${args[$((i + 1))]}" in
+      NO_PROXY=*)
+        found_upper=1
+        value="${args[$((i + 1))]#NO_PROXY=}"
+        [[ ",$value," == *",$gateway_host,"* ]] \
+          || args[$((i + 1))]="NO_PROXY=${value:+$value,}$gateway_host"
+        ;;
+      no_proxy=*)
+        found_lower=1
+        value="${args[$((i + 1))]#no_proxy=}"
+        [[ ",$value," == *",$gateway_host,"* ]] \
+          || args[$((i + 1))]="no_proxy=${value:+$value,}$gateway_host"
+        ;;
+    esac
+  done
+  [[ "$found_upper" == "1" ]] || args+=(--ae "NO_PROXY=$gateway_host")
+  [[ "$found_lower" == "1" ]] || args+=(--ae "no_proxy=$gateway_host")
+}
+
+model_fusion_proxy_merge_readonly_mounts() {
+  local worker_utils="$1"
+  shift
+  local mount_value_index=-1 mounts_json="[]" i
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "--mounts-json" ]]; then
+      if ((i + 1 >= ${#args[@]})); then
+        echo "[ERROR] --mounts-json is missing its value" >&2
+        return 2
+      fi
+      mount_value_index=$((i + 1))
+      break
+    fi
+  done
+  if ((mount_value_index >= 0)); then
+    mounts_json="${args[$mount_value_index]}"
+  fi
+  mounts_json="$(
+    python3 "$worker_utils" append-readonly-mounts "$mounts_json" "$@"
+  )"
+  if ((mount_value_index >= 0)); then
+    args[$mount_value_index]="$mounts_json"
+  else
+    args+=(--mounts-json "$mounts_json")
+  fi
+}
+
+model_fusion_proxy_render_or_exec() {
+  local label="$1"
+  local real_opik_bin="$2"
+  local worker_utils="$3"
+  if [[ "${MODEL_FUSION_PROXY_RENDER_ONLY:-0}" == "1" ]]; then
+    local rendered_command
+    rendered_command="$(
+      python3 "$worker_utils" render-command "$real_opik_bin" "${args[@]}"
+    )"
+    printf '[%s] proxy command: %s\n' "$label" "$rendered_command"
+    return 0
+  fi
+  exec "$real_opik_bin" "${args[@]}"
+}

--- a/Agents/utils/common/Harbor/tests/test_model_fusion_wrapper.py
+++ b/Agents/utils/common/Harbor/tests/test_model_fusion_wrapper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 import textwrap
@@ -9,10 +10,33 @@ import unittest
 from pathlib import Path
 
 HARBOR_DIR = Path(__file__).resolve().parents[1]
-WRAPPER = HARBOR_DIR / "model-fusion" / "run_one_tb21_task.sh"
+MODEL_FUSION_DIR = HARBOR_DIR / "model-fusion"
+WRAPPER = MODEL_FUSION_DIR / "run_one_tb21_task.sh"
+PROXY_COMMON = MODEL_FUSION_DIR / "proxy_common.sh"
+PROXY_WRAPPERS = (
+    MODEL_FUSION_DIR / "harboropik.sh",
+    MODEL_FUSION_DIR / "mimo-code" / "harboropik.sh",
+    MODEL_FUSION_DIR / "openrouter" / "harboropik.sh",
+)
 
 
 class ModelFusionWrapperTest(unittest.TestCase):
+    def test_proxy_wrappers_share_common_shell_helpers(self) -> None:
+        self.assertTrue(PROXY_COMMON.is_file())
+        for wrapper in PROXY_WRAPPERS:
+            with self.subTest(wrapper=wrapper):
+                script = wrapper.read_text(encoding="utf-8")
+                self.assertRegex(
+                    script,
+                    re.compile(r'^\. ".*proxy_common\.sh"$', re.MULTILINE),
+                )
+                for helper in (
+                    "model_fusion_proxy_is_injectable",
+                    "model_fusion_proxy_append_gateway_no_proxy",
+                    "model_fusion_proxy_merge_readonly_mounts",
+                ):
+                    self.assertIn(helper, script)
+
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()
         self.root = Path(self.temp_dir.name)


### PR DESCRIPTION
## 1. Why the change?

The model-fusion, MimoCode, and OpenRouter Harbor proxies independently implemented the same command classification, gateway `NO_PROXY` injection, and `--mounts-json` merge behavior. The copies had already diverged in control flow and error wording.

## 2. Summary of the change

- add a Bash 3-compatible `proxy_common.sh` library
- share injectable-command detection, gateway bypass injection, and readonly mount merging
- share render-or-exec handling for MimoCode and OpenRouter while preserving the general proxy's direct execution behavior
- keep provider-specific validation, mounts, and environment contracts in each wrapper
- add focused ownership coverage and retain all proxy behavior tests

## 3. Other details

Verification:

- `python3 Agents/utils/common/Harbor/tests/test_model_fusion_wrapper.py`
- `python3 Agents/utils/common/Harbor/tests/test_model_fusion_harboropik.py`
- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_mimo_code_glue.py' -k MimoCodeProxyTest`
- `python3 -m unittest discover -s Agents/utils/common/Harbor/tests -p 'test_openrouter_glue.py' -k OpenRouterProxyTest`
- `bash -n` on the common helper and all three proxy wrappers
- `uvx ruff@0.16.0 check --config .github/ruff.toml Agents/utils/common/Harbor/tests/test_model_fusion_wrapper.py`
- `git diff --check`

The full MimoCode/OpenRouter files were also run; their unrelated Claude overlay tests fail identically on upstream `main` on this host because `e2b_runtime` is not importable. All four proxy tests in each file pass.
