### PR TITLE
Refactor Harbor process termination

### DIFF
--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -822,9 +822,25 @@ harbor_online_analysis_pid_matches_run() {
   [[ "$script_seen" == 1 && "$run_seen" == 1 ]]
 }
 
+# Call only after the subsystem-specific PID identity check succeeds.
+harbor_terminate_validated_process() {
+  local pid="$1" wait_attempts="${2:-30}" sid signal_target attempt
+  sid="$(ps -o sid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  signal_target="$pid"
+  [[ "$sid" == "$pid" ]] && signal_target="-$pid"
+  kill -TERM -- "$signal_target" >/dev/null 2>&1 || true
+  for attempt in $(seq 1 "$wait_attempts"); do
+    kill -0 "$pid" >/dev/null 2>&1 || break
+    sleep 1
+  done
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    kill -KILL -- "$signal_target" >/dev/null 2>&1 || true
+  fi
+}
+
 harbor_stop_online_analysis() {
   [[ -f "$HARBOR_ONLINE_ANALYSIS_PID_FILE" ]] || return 0
-  local pid sid signal_target
+  local pid
   pid="$(cat "$HARBOR_ONLINE_ANALYSIS_PID_FILE" 2>/dev/null || true)"
   if [[ ! "$pid" =~ ^[0-9]+$ ]] || ! kill -0 "$pid" >/dev/null 2>&1; then
     rm -f "$HARBOR_ONLINE_ANALYSIS_PID_FILE"
@@ -834,23 +850,13 @@ harbor_stop_online_analysis() {
     echo "[ERROR] refusing to stop unrelated process from $HARBOR_ONLINE_ANALYSIS_PID_FILE: pid=$pid" >&2
     return 1
   fi
-  sid="$(ps -o sid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
-  signal_target="$pid"
-  [[ "$sid" == "$pid" ]] && signal_target="-$pid"
-  kill -TERM -- "$signal_target" >/dev/null 2>&1 || true
-  for _ in $(seq 1 30); do
-    kill -0 "$pid" >/dev/null 2>&1 || break
-    sleep 1
-  done
-  if kill -0 "$pid" >/dev/null 2>&1; then
-    kill -KILL -- "$signal_target" >/dev/null 2>&1 || true
-  fi
+  harbor_terminate_validated_process "$pid"
   rm -f "$HARBOR_ONLINE_ANALYSIS_PID_FILE"
 }
 
 harbor_stop_monitor() {
   [[ -f "$HARBOR_MONITOR_PID_FILE" ]] || return 0
-  local pid sid signal_target
+  local pid
   pid="$(cat "$HARBOR_MONITOR_PID_FILE" 2>/dev/null || true)"
   if [[ ! "$pid" =~ ^[0-9]+$ ]] || ! kill -0 "$pid" >/dev/null 2>&1; then
     rm -f "$HARBOR_MONITOR_PID_FILE"
@@ -860,17 +866,7 @@ harbor_stop_monitor() {
     echo "[ERROR] refusing to stop unrelated process from $HARBOR_MONITOR_PID_FILE: pid=$pid" >&2
     return 1
   fi
-  sid="$(ps -o sid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
-  signal_target="$pid"
-  [[ "$sid" == "$pid" ]] && signal_target="-$pid"
-  kill -TERM -- "$signal_target" >/dev/null 2>&1 || true
-  for _ in $(seq 1 30); do
-    kill -0 "$pid" >/dev/null 2>&1 || break
-    sleep 1
-  done
-  if kill -0 "$pid" >/dev/null 2>&1; then
-    kill -KILL -- "$signal_target" >/dev/null 2>&1 || true
-  fi
+  harbor_terminate_validated_process "$pid"
   rm -f "$HARBOR_MONITOR_PID_FILE"
 }
 
@@ -924,7 +920,7 @@ harbor_stop_analyzer_supervisor() {
 
 harbor_stop_analyzer() {
   [[ -f "$HARBOR_ANALYZER_PID_FILE" ]] || return 0
-  local expected_pid="${1:-}" current_pid pid sid signal_target
+  local expected_pid="${1:-}" current_pid pid
   current_pid="$(cat "$HARBOR_ANALYZER_PID_FILE" 2>/dev/null || true)"
   pid="${expected_pid:-$current_pid}"
   if [[ -n "$expected_pid" && "$current_pid" != "$expected_pid" ]]; then
@@ -938,17 +934,7 @@ harbor_stop_analyzer() {
     echo "[ERROR] refusing to stop unrelated process from $HARBOR_ANALYZER_PID_FILE: pid=$pid" >&2
     return 1
   fi
-  sid="$(ps -o sid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
-  signal_target="$pid"
-  [[ "$sid" == "$pid" ]] && signal_target="-$pid"
-  kill -TERM -- "$signal_target" >/dev/null 2>&1 || true
-  for _ in $(seq 1 30); do
-    kill -0 "$pid" >/dev/null 2>&1 || break
-    sleep 1
-  done
-  if kill -0 "$pid" >/dev/null 2>&1; then
-    kill -KILL -- "$signal_target" >/dev/null 2>&1 || true
-  fi
+  harbor_terminate_validated_process "$pid"
   [[ -z "$expected_pid" || "$current_pid" == "$expected_pid" ]] && rm -f "$HARBOR_ANALYZER_PID_FILE"
 }
 

--- a/Agents/utils/common/Harbor/tests/test_task_selection.py
+++ b/Agents/utils/common/Harbor/tests/test_task_selection.py
@@ -279,6 +279,31 @@ class HarborTaskSelectionTest(unittest.TestCase):
             self.assertEqual(probe.returncode, 1)
             self.assertEqual(process.returncode, 0, stderr or stdout)
 
+    def test_shared_process_terminator_stops_process(self) -> None:
+        process = subprocess.Popen(["sleep", "30"], start_new_session=True)
+
+        def cleanup() -> None:
+            if process.poll() is None:
+                process.kill()
+            process.wait(timeout=2)
+
+        self.addCleanup(cleanup)
+
+        result = self.run_env(
+            f"harbor_terminate_validated_process {process.pid} 1",
+            OPIK_URL="",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        process.wait(timeout=2)
+        self.assertLess(process.returncode, 0)
+        self.assertEqual(
+            ENV_SH.read_text(encoding="utf-8").count(
+                "harbor_terminate_validated_process"
+            ),
+            4,
+        )
+
     def test_start_passes_run_id_to_analyzer(self) -> None:
         self.assertIn('--run-id "$RUN_ID"', START_SH.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## 1. Why the change?

Online analysis, monitor, and analyzer shutdown paths independently implemented the same process-group detection, TERM, bounded wait, and KILL fallback. Maintaining three copies risks inconsistent shutdown behavior.

## 2. Summary of the change

- add `harbor_terminate_validated_process` for the shared signal/wait sequence
- retain each subsystem's PID-file handling and identity validation before the helper call
- retain analyzer expected-PID behavior and caller-specific cleanup
- add a focused process-level regression test and verify all three call sites use the helper

## 3. Other details

Verification:

- `python3 -m unittest Agents.utils.common.Harbor.tests.test_task_selection.HarborTaskSelectionTest.test_shared_process_terminator_stops_process`
- `bash Agents/utils/common/Harbor/tests/test_host_defaults.sh`
- `bash -n Agents/utils/common/Harbor/env.sh`
- `uvx ruff@0.16.0 check --config .github/ruff.toml Agents/utils/common/Harbor/tests/test_task_selection.py`
- `git diff --check`

The full task-selection suite was also run. On this macOS host, four existing Linux-only tests fail identically on upstream `main` because `flock` and `/proc` are unavailable; the remaining tests, including the new termination test, pass.
