### PR TITLE
Unify Harbor Opik tracing gate

### DIFF
--- a/Agents/Harbor-claude-code/sitecustomize.py
+++ b/Agents/Harbor-claude-code/sitecustomize.py
@@ -30,8 +30,16 @@
 import json
 import os
 import shlex
+import sys
 from pathlib import Path
 from types import MethodType
+
+HARBOR_RUNTIME_DIR = (
+    Path(__file__).resolve().parents[1] / "utils" / "common" / "Harbor"
+)
+sys.path.append(str(HARBOR_RUNTIME_DIR))
+
+from opik_trace_gate import _is_true, opik_tracing_enabled  # noqa: E402
 
 _HOOK_EVENTS = [
     "UserPromptSubmit",
@@ -43,12 +51,6 @@ _HOOK_EVENTS = [
     "SubagentStop",
     "SessionEnd",
 ]
-
-
-def _is_true(value: str | None) -> bool:
-    if value is None:
-        return False
-    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _rust_package_mirror_bootstrap(extra_env: dict[str, str] | None) -> str:
@@ -128,12 +130,9 @@ def _fix_unquoted_append_system_prompt(command: str) -> str:
 def _hook_enabled(extra_env: dict[str, str] | None) -> bool:
     if not extra_env:
         return False
-    # If CC_OPIK_ENABLE_HOOK is explicitly set, it takes precedence (including
-    # explicit false).  Otherwise follow OPIK_URL, which the host forwards only
-    # when tracing is on.
-    if "CC_OPIK_ENABLE_HOOK" in extra_env:
-        return _is_true(extra_env["CC_OPIK_ENABLE_HOOK"])
-    return bool(extra_env.get("OPIK_URL", "").strip())
+    if not opik_tracing_enabled(extra_env):
+        return False
+    return _is_true(extra_env.get("CC_OPIK_ENABLE_HOOK", "true"))
 
 
 def _hook_mount_path(extra_env: dict[str, str] | None) -> str:

--- a/Agents/Harbor-claude-code/tests/test_sitecustomize.py
+++ b/Agents/Harbor-claude-code/tests/test_sitecustomize.py
@@ -33,6 +33,32 @@ def load_module():
 
 
 class ClaudeCommandPatchTest(unittest.TestCase):
+    def test_opik_hook_requires_shared_trace_gate(self) -> None:
+        module = load_module()
+        endpoint = "https://opik.example.invalid/api"
+
+        self.assertFalse(
+            module._hook_enabled(
+                {"CC_OPIK_ENABLE_HOOK": "true", "OPIK_URL": ""}
+            )
+        )
+        for value in ("1", "true", "TRUE", " yes ", "On"):
+            with self.subTest(value=value):
+                self.assertFalse(
+                    module._hook_enabled(
+                        {
+                            "CC_OPIK_ENABLE_HOOK": "true",
+                            "OPIK_URL": endpoint,
+                            "OPIK_TRACK_DISABLE": value,
+                        }
+                    )
+                )
+        self.assertTrue(
+            module._hook_enabled(
+                {"CC_OPIK_ENABLE_HOOK": "true", "OPIK_URL": endpoint}
+            )
+        )
+
     def test_quotes_append_system_prompt_when_opik_hook_is_disabled(self) -> None:
         module = load_module()
         captured: list[str] = []

--- a/Agents/Harbor-opencode/enable_track_harbor.py
+++ b/Agents/Harbor-opencode/enable_track_harbor.py
@@ -38,10 +38,14 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
+HARBOR_RUNTIME_DIR = (
+    Path(__file__).resolve().parents[1] / "utils" / "common" / "Harbor"
+)
+sys.path.append(str(HARBOR_RUNTIME_DIR))
 
-def _trace_to_opik_enabled() -> bool:
-    return bool(os.environ.get("OPIK_URL", "").strip())
+from opik_trace_gate import opik_tracing_enabled  # noqa: E402
 
 
 def _clean_tags(tags: object) -> list[str]:
@@ -119,7 +123,7 @@ def main() -> None:
         from e2b_runtime import patch_e2b_runtime_from_env
 
         patch_e2b_runtime_from_env()
-    if _trace_to_opik_enabled():
+    if opik_tracing_enabled():
         _patch_opik_batch_tags()
         _install_track_harbor()
         _patch_trial_decorator_with_harbor_tags()

--- a/Agents/Harbor-opencode/finalize_opencode_sessions.py
+++ b/Agents/Harbor-opencode/finalize_opencode_sessions.py
@@ -16,6 +16,15 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_HARBOR_RUNTIME_DIR = _SCRIPT_DIR.parent / "utils" / "common" / "Harbor"
+for _import_dir in (_SCRIPT_DIR, _HARBOR_RUNTIME_DIR):
+    if (_import_dir / "opik_trace_gate.py").is_file():
+        sys.path.append(str(_import_dir))
+        break
+
+from opik_trace_gate import opik_tracing_enabled  # noqa: E402
+
 
 def _resolve_timeout_hook() -> Path:
     """Locate the opencode realtime hook for host-side timeout replay."""
@@ -122,16 +131,10 @@ def _fallback_timeout_trace(logs_dir: Path, status: str) -> int:
         return 1
 
 
-def _trace_to_opik_enabled() -> bool:
-    if os.environ.get("OPIK_TRACK_DISABLE", "").lower() in {"true", "1"}:
-        return False
-    return bool(os.environ.get("OPIK_URL", "").strip())
-
-
 def main() -> int:
     # Defense in depth for the worker-side timeout replay: even if a caller
     # forgets the shell gate, a trace-off run must never write to Opik.
-    if not _trace_to_opik_enabled():
+    if not opik_tracing_enabled():
         print("[INFO] finalize skipped: Opik tracing disabled")
         return 0
 

--- a/Agents/Harbor-opencode/opik_opencode_harbor.py
+++ b/Agents/Harbor-opencode/opik_opencode_harbor.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import os
 import shlex
+import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
@@ -29,6 +30,11 @@ from harbor.models.agent.context import AgentContext
 
 ROOT = Path(__file__).resolve().parent
 REPO_ROOT = ROOT.parents[1]
+HARBOR_RUNTIME_DIR = REPO_ROOT / "Agents" / "utils" / "common" / "Harbor"
+sys.path.append(str(HARBOR_RUNTIME_DIR))
+
+from opik_trace_gate import opik_tracing_enabled  # noqa: E402
+
 TRACE_PLUGIN_SOURCE_DIR = Path(
     os.environ.get(
         "TRACE_PLUGIN_SOURCE_DIR",
@@ -52,6 +58,7 @@ HOOK_PY = Path(
     )
 ).expanduser()
 FINALIZER_PY = ROOT / "finalize_opencode_sessions.py"
+TRACE_GATE_PY = HARBOR_RUNTIME_DIR / "opik_trace_gate.py"
 
 CONTAINER_PLUGIN_REL = ".config/opencode/plugins"
 CONTAINER_STATE_REL = ".opencode/state"
@@ -79,17 +86,6 @@ def _load_opencode_runtime_secrets() -> dict[str, str]:
 
 
 OPENCODE_RUNTIME_SECRETS = _load_opencode_runtime_secrets()
-
-
-def _trace_to_opik_enabled(extra_env: dict[str, str] | None = None) -> bool:
-    """OPIK_URL is the single switch; the host forwards it only when tracing
-    is on, so an empty value means skip Opik entirely."""
-    value: str | None = None
-    if extra_env is not None:
-        value = extra_env.get("OPIK_URL")
-    if value is None:
-        value = os.environ.get("OPIK_URL", "")
-    return bool(value.strip())
 
 
 # ── url helpers ───────────────────────────────────────────────────────────────
@@ -453,9 +449,9 @@ class OpikOpenCodeHarbor(OpenCode):
             sanity_check=_opencode_present,
         )
 
-        if not _trace_to_opik_enabled(getattr(self, "_extra_env", None)):
+        if not opik_tracing_enabled(getattr(self, "_extra_env", None)):
             print(
-                "[opik-cold] OPIK_URL is empty: skip Opik hook dependencies "
+                "[opik-cold] Opik tracing disabled: skip hook dependencies "
                 "and plugin files",
                 flush=True,
             )
@@ -548,6 +544,7 @@ class OpikOpenCodeHarbor(OpenCode):
         await environment.upload_file(PLUGIN_TS, "/tmp/opik-trace.ts")
         await environment.upload_file(HOOK_PY, "/tmp/opencode_realtime_trace.py")
         await environment.upload_file(FINALIZER_PY, "/tmp/finalize_opencode_sessions.py")
+        await environment.upload_file(TRACE_GATE_PY, "/tmp/opik_trace_gate.py")
         await self.exec_as_agent(
             environment,
             command=(
@@ -558,7 +555,9 @@ class OpikOpenCodeHarbor(OpenCode):
                 "install -m 0755 /tmp/opencode_realtime_trace.py "
                 f'"$HOME/{CONTAINER_PLUGIN_REL}/opencode_realtime_trace.py"; '
                 "install -m 0755 /tmp/finalize_opencode_sessions.py "
-                f'"$HOME/{CONTAINER_PLUGIN_REL}/finalize_opencode_sessions.py"'
+                f'"$HOME/{CONTAINER_PLUGIN_REL}/finalize_opencode_sessions.py"; '
+                "install -m 0644 /tmp/opik_trace_gate.py "
+                f'"$HOME/{CONTAINER_PLUGIN_REL}/opik_trace_gate.py"'
             ),
         )
 
@@ -570,7 +569,7 @@ class OpikOpenCodeHarbor(OpenCode):
         context: AgentContext,
     ) -> None:
         escaped_instruction = shlex.quote(instruction)
-        trace_enabled = _trace_to_opik_enabled(getattr(self, "_extra_env", None))
+        trace_enabled = opik_tracing_enabled(getattr(self, "_extra_env", None))
 
         if not self.model_name:
             raise ValueError("Model name must not be empty")

--- a/Agents/Harbor-opencode/tests/test_trace_disabled.py
+++ b/Agents/Harbor-opencode/tests/test_trace_disabled.py
@@ -140,19 +140,41 @@ class OpenCodeTraceDisabledTests(unittest.TestCase):
         )
 
     def test_trace_switch_matches_shell_semantics(self) -> None:
-        self.assertFalse(self.module._trace_to_opik_enabled({"OPIK_URL": ""}))
-        self.assertFalse(self.module._trace_to_opik_enabled({"OPIK_URL": "   "}))
+        self.assertFalse(self.module.opik_tracing_enabled({"OPIK_URL": ""}))
+        self.assertFalse(self.module.opik_tracing_enabled({"OPIK_URL": "   "}))
         self.assertTrue(
-            self.module._trace_to_opik_enabled(
+            self.module.opik_tracing_enabled(
                 {"OPIK_URL": "https://opik.example.invalid/api"}
             )
         )
         # A retired switch must not turn tracing back on.
         self.assertFalse(
-            self.module._trace_to_opik_enabled(
+            self.module.opik_tracing_enabled(
                 {"OPIK_URL": "", "TRACE_TO_OPIK": "true"}
             )
         )
+
+    def test_trace_switch_honors_disable_truth_table(self) -> None:
+        for value in ("1", "true", "TRUE", " yes ", "On"):
+            with self.subTest(value=value):
+                self.assertFalse(
+                    self.module.opik_tracing_enabled(
+                        {
+                            "OPIK_URL": "https://opik.example.invalid/api",
+                            "OPIK_TRACK_DISABLE": value,
+                        }
+                    )
+                )
+        for value in ("", "0", "false", "no", "off", "unexpected"):
+            with self.subTest(value=value):
+                self.assertTrue(
+                    self.module.opik_tracing_enabled(
+                        {
+                            "OPIK_URL": "https://opik.example.invalid/api",
+                            "OPIK_TRACK_DISABLE": value,
+                        }
+                    )
+                )
 
     def test_install_skips_opik_dependencies_and_missing_plugin_files(self) -> None:
         agent = self.make_agent("false")
@@ -223,12 +245,28 @@ class OpenCodeTraceDisabledTests(unittest.TestCase):
                 "/tmp/opik-trace.ts",
                 "/tmp/opencode_realtime_trace.py",
                 "/tmp/finalize_opencode_sessions.py",
+                "/tmp/opik_trace_gate.py",
             ],
         )
         commands = "\n".join(
             str(item.get("command", "")) for item in agent.agent_commands
         )
         self.assertIn("mods = ('opik', 'uuid6', 'socksio')", commands)
+
+    def test_runtime_disable_skips_trace_install_and_run(self) -> None:
+        agent = self.make_agent("true")
+        environment = FakeEnvironment()
+
+        with mock.patch.dict(os.environ, {"OPIK_TRACK_DISABLE": "true"}):
+            asyncio.run(agent.install(environment))
+            asyncio.run(agent.run("solve the task", environment, object()))
+
+        self.assertEqual(environment.uploads, [])
+        commands = "\n".join(
+            str(item.get("command", "")) for item in agent.agent_commands
+        )
+        self.assertNotIn("opik-trace.ts", commands)
+        self.assertNotIn("finalize_opencode_sessions.py", commands)
 
     def test_run_skips_plugin_registration_and_finalizer(self) -> None:
         agent = self.make_agent("false")
@@ -381,7 +419,12 @@ class EnableTrackHarborTests(unittest.TestCase):
     def tearDownClass(cls) -> None:
         sys.modules.pop(cls.module_name, None)
 
-    def run_main(self, trace: str, environment_type: str = "docker"):
+    def run_main(
+        self,
+        trace: str,
+        environment_type: str = "docker",
+        track_disable: str = "",
+    ):
         app = mock.Mock()
         patch_e2b_runtime = mock.Mock()
         harbor = types.ModuleType("harbor")
@@ -407,6 +450,7 @@ class EnableTrackHarborTests(unittest.TestCase):
                         "" if trace in {"false", "0", ""}
                         else "https://opik.example.invalid/api"
                     ),
+                    "OPIK_TRACK_DISABLE": track_disable,
                     "HARBOR_ENVIRONMENT_TYPE": environment_type,
                 },
                 clear=True,
@@ -436,6 +480,13 @@ class EnableTrackHarborTests(unittest.TestCase):
         for call in tracking_calls:
             call.assert_called_once_with()
         patch_e2b_runtime.assert_not_called()
+
+    def test_track_disable_truthy_values_skip_host_tracking(self) -> None:
+        for value in ("1", "true", "TRUE", " yes ", "On"):
+            with self.subTest(value=value):
+                tracking_calls, _ = self.run_main("true", track_disable=value)
+                for call in tracking_calls:
+                    call.assert_not_called()
 
     def test_e2b_compatible_backends_apply_runtime_patches(self) -> None:
         for environment_type in ("e2b", "qz"):
@@ -476,10 +527,17 @@ class FinalizerTraceGateTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("finalize skipped", result.stdout)
 
-    def test_opik_track_disable_skips_timeout_finalization(self) -> None:
-        result = self.run_finalizer({"OPIK_TRACK_DISABLE": "true"})
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("finalize skipped", result.stdout)
+    def test_opik_track_disable_truthy_values_skip_timeout_finalization(self) -> None:
+        for value in ("1", "true", "TRUE", " yes ", "On"):
+            with self.subTest(value=value):
+                result = self.run_finalizer(
+                    {
+                        "OPIK_URL": "https://opik.example.invalid/api",
+                        "OPIK_TRACK_DISABLE": value,
+                    }
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("finalize skipped", result.stdout)
 
 
 if __name__ == "__main__":

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -134,11 +134,11 @@ HARBOR_FIXER_MAX_CONCURRENCY="${HARBOR_FIXER_MAX_CONCURRENCY:-4}"
 HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS="${HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS:-24000}"
 HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS="${HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS:-400000}"
 OPIK_URL="${OPIK_URL:-}"
-# OPIK_URL is the single switch for running with or without Opik, shared by
-# every script that sources env.sh (harboropik.sh, run_harbor_worker.sh):
-# an endpoint uploads traces, an empty value skips them entirely.
+# OPIK_URL is the operator switch for running with or without Opik. The shared
+# gate also honors OPIK_TRACK_DISABLE as a runtime safety override.
 harbor_trace_to_opik_enabled() {
-  [[ -n "${OPIK_URL:-}" ]]
+  OPIK_URL="${OPIK_URL:-}" OPIK_TRACK_DISABLE="${OPIK_TRACK_DISABLE:-}" \
+    python3 "$SCRIPT_DIR/opik_trace_gate.py"
 }
 OPIK_URL_OVERRIDE="${OPIK_URL_OVERRIDE:-$OPIK_URL}"
 OPIK_BASE="${OPIK_BASE:-${OPIK_URL_OVERRIDE%/api}}"

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -930,7 +930,7 @@ run_harbor() {
   if [[ "$HARBOR_DRY_RUN" == "1" ]]; then
     echo "[INFO] HARBOR_DRY_RUN=1, skip Opik project preflight check"
   elif ! harbor_trace_to_opik_enabled; then
-    echo "[INFO] OPIK_URL is empty, skip Opik project preflight check"
+    echo "[INFO] Opik tracing disabled, skip project preflight check"
   else
     local _projects_status
     _projects_status="$(
@@ -1581,7 +1581,7 @@ main() {
     ensure_environment_backend
 
     if ! harbor_trace_to_opik_enabled; then
-      echo "[INFO] OPIK_URL is empty, skip Opik readiness checks"
+      echo "[INFO] Opik tracing disabled, skip readiness checks"
     fi
     prepare_local_dataset_if_needed
 
@@ -1625,7 +1625,7 @@ main() {
   fi
 
   if ! harbor_trace_to_opik_enabled; then
-    echo "[INFO] OPIK_URL is empty, skip Opik readiness checks"
+    echo "[INFO] Opik tracing disabled, skip readiness checks"
   fi
   prepare_local_dataset_if_needed
   if harbor_trace_to_opik_enabled; then

--- a/Agents/utils/common/Harbor/opik_trace_gate.py
+++ b/Agents/utils/common/Harbor/opik_trace_gate.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _is_true(value: str | None) -> bool:
+    return bool(value and value.strip().lower() in _TRUE_VALUES)
+
+
+def opik_tracing_enabled(
+    extra_env: Mapping[str, str] | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    values = os.environ if environ is None else environ
+    if extra_env is not None and "OPIK_URL" in extra_env:
+        opik_url = extra_env["OPIK_URL"]
+    else:
+        opik_url = values.get("OPIK_URL", "")
+
+    disabled = _is_true(values.get("OPIK_TRACK_DISABLE"))
+    if extra_env is not None:
+        disabled = disabled or _is_true(extra_env.get("OPIK_TRACK_DISABLE"))
+    return bool(opik_url.strip()) and not disabled
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if opik_tracing_enabled() else 1)

--- a/Agents/utils/common/Harbor/run_harbor_worker.sh
+++ b/Agents/utils/common/Harbor/run_harbor_worker.sh
@@ -105,7 +105,7 @@ finalize_timeout_trace() {
   # Timeout finalization replays hook backups into Opik. With tracing off
   # there is no server to write to, for either agent's fallback path.
   if ! harbor_trace_to_opik_enabled; then
-    log_msg "timeout finalize skipped: OPIK_URL is empty"
+    log_msg "timeout finalize skipped: Opik tracing disabled"
     return 0
   fi
   local logs_dir py

--- a/Agents/utils/common/Harbor/tests/test_opik_trace_gate.py
+++ b/Agents/utils/common/Harbor/tests/test_opik_trace_gate.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import unittest
+
+from Agents.utils.common.Harbor.opik_trace_gate import (
+    _is_true,
+    opik_tracing_enabled,
+)
+
+
+class OpikTraceGateTests(unittest.TestCase):
+    def test_is_true_uses_one_boolean_truth_table(self) -> None:
+        for value in ("1", "true", "TRUE", " yes ", "On"):
+            with self.subTest(value=value):
+                self.assertTrue(_is_true(value))
+        for value in (None, "", "0", "false", "no", "off", "unexpected"):
+            with self.subTest(value=value):
+                self.assertFalse(_is_true(value))
+
+    def test_url_enables_tracing_unless_disable_is_truthy(self) -> None:
+        endpoint = "https://opik.example.invalid/api"
+        self.assertFalse(opik_tracing_enabled(environ={}))
+        self.assertTrue(opik_tracing_enabled(environ={"OPIK_URL": endpoint}))
+        for value in ("1", "true", "TRUE", " yes ", "On"):
+            with self.subTest(value=value):
+                self.assertFalse(
+                    opik_tracing_enabled(
+                        environ={
+                            "OPIK_URL": endpoint,
+                            "OPIK_TRACK_DISABLE": value,
+                        }
+                    )
+                )
+
+    def test_process_disable_cannot_be_overridden_by_agent_environment(self) -> None:
+        endpoint = "https://opik.example.invalid/api"
+        self.assertFalse(
+            opik_tracing_enabled(
+                {"OPIK_URL": endpoint, "OPIK_TRACK_DISABLE": "false"},
+                environ={"OPIK_TRACK_DISABLE": "true"},
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_worker_timeout_trace_gate.sh
+++ b/Agents/utils/common/Harbor/tests/test_worker_timeout_trace_gate.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # with tracing on it must keep its existing behavior. Extract the shared
 # helper and the function under test instead of running the worker loop.
 HARBOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$HARBOR_DIR"
 
 source /dev/stdin <<EOF
 $(sed -n '/^harbor_trace_to_opik_enabled()/,/^}/p' "$HARBOR_DIR/env.sh")
@@ -25,7 +26,7 @@ harbor_agent_is_opencode() {
 
 OPIK_URL=""
 finalize_timeout_trace "/tmp/trace-gate-result.json"
-[[ "$LOGGED" == *"OPIK_URL is empty"* ]] || {
+[[ "$LOGGED" == *"tracing disabled"* ]] || {
   echo "missing trace-off skip log, got: $LOGGED" >&2
   exit 1
 }
@@ -40,5 +41,15 @@ finalize_timeout_trace "/tmp/trace-gate-result.json"
   echo "trace-on path did not reach logs-dir resolution, got: $LOGGED" >&2
   exit 1
 }
+
+for disable in 1 true TRUE " yes " On; do
+  OPIK_TRACK_DISABLE="$disable"
+  LOGGED=""
+  finalize_timeout_trace "/tmp/trace-gate-result.json"
+  [[ "$LOGGED" == *"tracing disabled"* ]] || {
+    echo "OPIK_TRACK_DISABLE=$disable did not stop timeout finalization, got: $LOGGED" >&2
+    exit 1
+  }
+done
 
 echo "worker timeout trace gate OK"


### PR DESCRIPTION
## 1. Why the change?

Harbor decides whether Opik tracing is enabled in several shell and Python entrypoints. Those copies had different semantics: most checked only whether `OPIK_URL` was non-empty, while only timeout finalization honored the runtime `OPIK_TRACK_DISABLE` safety override. As a result, some host or agent paths could still initialize Opik writers after tracing had been disabled.

## 2. Summary of the change

- Add one shared `opik_tracing_enabled` helper and `_is_true` truth table for `1`, `true`, `yes`, and `on`.
- Route Harbor shell orchestration, host tracking, OpenCode install/run/finalization, and Claude realtime hooks through the shared gate.
- Ship the gate beside the OpenCode container finalizer so the same logic applies inside task containers.
- Add regressions for URL enablement, process and agent disable precedence, boolean variants, and every writer path.

## 3. Other details

Verification:

- Focused Python suite: 28 tests passed, 1 skipped because the optional Harbor runner dependency is not installed locally.
- `bash Agents/utils/common/Harbor/tests/test_worker_timeout_trace_gate.sh`
- `bash -n` on the changed shell entrypoints and test.
- Ruff 0.16.0 on all changed Python files.
- `git diff --check`.