### PR TITLE
Refactor shared Harbor container bootstrap

### DIFF
--- a/Agents/Harbor-claude-code/STRUCT.md
+++ b/Agents/Harbor-claude-code/STRUCT.md
@@ -8,6 +8,8 @@ Agents/Harbor-claude-code/
 ```
 
 `sitecustomize.py` contains Claude Code specific runtime hooks used by the Harbor runner.
+Its container runtime and package bootstrap commands come from
+`Agents/utils/common/Harbor/container_bootstrap.py`.
 
 The realtime Opik hook is loaded from the `third_party/agent-opik-plugin`
 submodule:

--- a/Agents/Harbor-claude-code/sitecustomize.py
+++ b/Agents/Harbor-claude-code/sitecustomize.py
@@ -309,7 +309,9 @@ def _patch_claude_code_realtime_hooks() -> None:
         wheel_url = (extra_env or {}).get("HARBOR_LOCAL_WHEEL_SERVER_URL", "")
         await self.exec_as_root(
             environment,
-            command=container_bootstrap.build_python_runtime_command(wheel_dir),
+            command=container_bootstrap.build_python_runtime_command(
+                wheel_dir, python_required=False
+            ),
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         await self.exec_as_agent(
@@ -318,6 +320,7 @@ def _patch_claude_code_realtime_hooks() -> None:
                 ("opik", "uuid6", "socksio"),
                 wheel_dir=wheel_dir,
                 wheel_url=wheel_url,
+                python_required=False,
             ),
         )
 

--- a/Agents/Harbor-claude-code/sitecustomize.py
+++ b/Agents/Harbor-claude-code/sitecustomize.py
@@ -39,6 +39,7 @@ HARBOR_RUNTIME_DIR = (
 )
 sys.path.append(str(HARBOR_RUNTIME_DIR))
 
+import container_bootstrap  # noqa: E402
 from opik_trace_gate import _is_true, opik_tracing_enabled  # noqa: E402
 
 _HOOK_EVENTS = [
@@ -227,141 +228,30 @@ def _patch_claude_code_realtime_hooks() -> None:
                 # Harbor's bootstrap.sh install passes the version as
                 # "bash -s -- 2.1.90" rather than in the npm spec format.
                 m = _re.search(r"bash -s --\s+([\d][^\s'\";]*)", command)
-            version_suffix = f"@{m.group(1)}" if m else ""
-            npm_prefix = (
-                f"NPM_CONFIG_REGISTRY={shlex.quote(npm_registry)} "
-                if npm_registry
-                else ""
+            version = m.group(1) if m else ""
+            wheel_dir = (extra_env or {}).get(
+                "CC_OPIK_PY_WHEEL_DIR", "/opt/tb-opik/python-wheels"
             )
-            claude_tgz_path = shlex.quote(
-                (extra_env or {}).get("CC_OPIK_CLAUDE_TGZ_PATH", "/opt/tb-opik/claude-code.tgz")
+            claude_tgz_path = (extra_env or {}).get(
+                "CC_OPIK_CLAUDE_TGZ_PATH", "/opt/tb-opik/claude-code.tgz"
             )
-            claude_tgz_url = shlex.quote((extra_env or {}).get("HARBOR_LOCAL_CLAUDE_TGZ_URL", ""))
-            node_runtime_path = shlex.quote(
-                (extra_env or {}).get("CC_OPIK_PY_WHEEL_DIR", "/opt/tb-opik/python-wheels")
-                + "/node-runtime.tar.xz"
-            )
-            npm_cache_path = shlex.quote(
-                (extra_env or {}).get("CC_OPIK_NPM_CACHE_DIR", "")
-                or (extra_env or {}).get("CC_OPIK_PY_WHEEL_DIR", "/opt/tb-opik/python-wheels")
-                + "/npm-cache"
-            )
-            node_dist_url = shlex.quote((extra_env or {}).get("CC_NODE_DIST_URL", ""))
-            return (
-                "set -euo pipefail; "
-                f"if [ ! -f {claude_tgz_path} ] && [ -n {claude_tgz_url} ]; then "
-                "  tmp_tgz=\"$(mktemp /tmp/claude-code-XXXXXX.tgz)\"; "
-                f"  python3 - <<'PY' {claude_tgz_url} \"$tmp_tgz\" >/dev/null 2>&1 || true\n"
-                "import sys, urllib.request\n"
-                "urllib.request.urlretrieve(sys.argv[1], sys.argv[2])\n"
-                "PY\n"
-                "  if [ -s \"$tmp_tgz\" ]; then claude_tgz_path=\"$tmp_tgz\"; else claude_tgz_path=\"\"; fi; "
-                "else "
-                f"  claude_tgz_path={claude_tgz_path}; "
-                "fi; "
-                # Prefer the offline Node runtime prepared by monitor_harbor.sh.
-                # SWE-bench task images often lack npm, and apt may be slow or
-                # unavailable inside the isolated task container.
-                "if ! command -v npm >/dev/null 2>&1 && [ -f "
-                f"{node_runtime_path}"
-                " ] && command -v python3 >/dev/null 2>&1; then "
-                "  node_dir=\"$(mktemp -d /tmp/tb-node-XXXXXX)\"; "
-                "  python3 - <<'PY' "
-                f"{node_runtime_path}"
-                " \"$node_dir\"\n"
-                "import sys, tarfile\n"
-                "with tarfile.open(sys.argv[1]) as archive:\n"
-                "    archive.extractall(sys.argv[2])\n"
-                "PY\n"
-                "  node_bin=\"$(find \"$node_dir\" -path '*/bin/npm' -print -quit 2>/dev/null)\"; "
-                "  if [ -n \"$node_bin\" ]; then "
-                "    node_runtime_bin=\"$(dirname \"$node_bin\")\"; "
-                "    mkdir -p \"$HOME/.local/bin\"; "
-                "    ln -sf \"$node_runtime_bin/node\" \"$HOME/.local/bin/node\" 2>/dev/null || true; "
-                "    ln -sf \"$node_runtime_bin/npm\" \"$HOME/.local/bin/npm\" 2>/dev/null || true; "
-                "    ln -sf \"$node_runtime_bin/npx\" \"$HOME/.local/bin/npx\" 2>/dev/null || true; "
-                "    export PATH=\"$HOME/.local/bin:$node_runtime_bin:$PATH\"; "
-                "  fi; "
-                "fi; "
-                # Sandboxes without host mounts can get Node from an explicitly
-                # configured, Sandbox-reachable dist endpoint instead of
-                # depending on the task image's package manager.
-                "if ! command -v npm >/dev/null 2>&1 && [ -n "
-                f"{node_dist_url}"
-                " ] && command -v python3 >/dev/null 2>&1; then "
-                "  node_dist_tgz=\"$(mktemp /tmp/tb-node-dist-XXXXXX.tgz)\"; "
-                f"  python3 - <<'PY' {node_dist_url} \"$node_dist_tgz\" || true\n"
-                "import shutil, sys, urllib.request\n"
-                "with urllib.request.urlopen(sys.argv[1], timeout=180) as r, open(sys.argv[2], 'wb') as f:\n"
-                "    shutil.copyfileobj(r, f)\n"
-                "PY\n"
-                "  if [ -s \"$node_dist_tgz\" ]; then "
-                "    node_dir=\"$(mktemp -d /tmp/tb-node-XXXXXX)\"; "
-                "    if python3 - <<'PY' \"$node_dist_tgz\" \"$node_dir\"\n"
-                "import sys, tarfile\n"
-                "with tarfile.open(sys.argv[1]) as archive:\n"
-                "    archive.extractall(sys.argv[2])\n"
-                "PY\n"
-                "    then "
-                "      node_bin=\"$(find \"$node_dir\" -path '*/bin/npm' -print -quit 2>/dev/null)\"; "
-                "      if [ -n \"$node_bin\" ]; then "
-                "        node_runtime_bin=\"$(dirname \"$node_bin\")\"; "
-                "        mkdir -p \"$HOME/.local/bin\"; "
-                "        ln -sf \"$node_runtime_bin/node\" \"$HOME/.local/bin/node\" 2>/dev/null || true; "
-                "        ln -sf \"$node_runtime_bin/npm\" \"$HOME/.local/bin/npm\" 2>/dev/null || true; "
-                "        ln -sf \"$node_runtime_bin/npx\" \"$HOME/.local/bin/npx\" 2>/dev/null || true; "
-                "        export PATH=\"$HOME/.local/bin:$node_runtime_bin:$PATH\"; "
-                "      fi; "
-                "    fi; "
-                "  fi; "
-                "fi; "
-                "export PATH=\"$HOME/.local/bin:$PATH\"; "
-                "claude_check() { "
-                "  hash -r 2>/dev/null || true; "
-                "  for attempt in 1 2 3; do "
-                "    if [ -x \"$HOME/.local/bin/claude\" ]; then "
-                "      \"$HOME/.local/bin/claude\" --version && return 0; "
-                "    elif command -v claude >/dev/null 2>&1; then "
-                "      claude --version && return 0; "
-                "    fi; "
-                "    sleep 1; "
-                "  done; "
-                "  return 1; "
-                "}; "
-                "if ! command -v npm >/dev/null 2>&1; then "
-                "  if command -v apk >/dev/null 2>&1; then "
-                "    apk add --no-cache nodejs npm bash curl; "
-                "  elif command -v apt-get >/dev/null 2>&1; then "
-                "    apt-get -o Acquire::ForceIPv4=true update -qq && "
-                "    apt-get install -y -qq nodejs npm; "
-                "  elif command -v yum >/dev/null 2>&1; then "
-                "    yum install -y nodejs npm; "
-                "  fi; "
-                "fi; "
-                "mkdir -p \"$HOME/.local/bin\"; "
-                "if command -v npm >/dev/null 2>&1; then npm config set prefix \"$HOME/.local\" >/dev/null 2>&1 || true; fi; "
-                "claude_installed=0; "
-                "if command -v npm >/dev/null 2>&1 && [ -n \"${claude_tgz_path:-}\" ]; then "
-                f"  if [ -d {npm_cache_path} ]; then "
-                "    npm_cache_tmp=\"$(mktemp -d /tmp/tb-npm-cache-XXXXXX)\"; "
-                # The shared cache is mounted read-only into task containers, but
-                # npm still writes tmp/index metadata even for --offline installs.
-                f"    if cp -a {npm_cache_path}/. \"$npm_cache_tmp\"/ && "
-                "npm install -g --offline --cache \"$npm_cache_tmp\" \"${claude_tgz_path}\" && claude_check; then "
-                "      claude_installed=1; "
-                "    fi; "
-                "  fi; "
-                "  if [ \"$claude_installed\" != 1 ] && "
-                "npm install -g \"${claude_tgz_path}\" && claude_check; then "
-                "    claude_installed=1; "
-                "  fi; "
-                "fi; "
-                "if [ \"$claude_installed\" != 1 ]; then "
-                f"  {npm_prefix}npm install -g @anthropic-ai/claude-code{version_suffix} && "
-                "  echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc && "
-                "  export PATH=\"$HOME/.local/bin:$PATH\" && "
-                "  claude_check; "
-                "fi"
+            return container_bootstrap.build_npm_tool_install_command(
+                container_bootstrap.NpmToolSpec(
+                    executable="claude",
+                    package="@anthropic-ai/claude-code",
+                    version=version,
+                    archive_path=claude_tgz_path,
+                    archive_url=(extra_env or {}).get(
+                        "HARBOR_LOCAL_CLAUDE_TGZ_URL", ""
+                    ),
+                    archive_basename=Path(claude_tgz_path).name,
+                    npm_cache_dir=(extra_env or {}).get("CC_OPIK_NPM_CACHE_DIR", "")
+                    or f"{wheel_dir}/npm-cache",
+                    npm_registry=npm_registry,
+                ),
+                wheel_dir=wheel_dir,
+                wheel_url=(extra_env or {}).get("HARBOR_LOCAL_WHEEL_SERVER_URL", ""),
+                node_dist_url=(extra_env or {}).get("CC_NODE_DIST_URL", ""),
             )
 
         _apt_fix = (
@@ -386,7 +276,10 @@ def _patch_claude_code_realtime_hooks() -> None:
         async def _exec_as_agent_install_fix(
             _self, environment, command=None, env=None, cwd=None, timeout_sec=None,
         ):
-            if command and ("claude.ai/install.sh" in command or "downloads.claude.ai/claude-code-releases/bootstrap.sh" in command):
+            if command and (
+                "claude.ai/install.sh" in command
+                or "downloads.claude.ai/claude-code-releases/bootstrap.sh" in command
+            ):
                 command = _make_claude_install_command(command)
             return await original_exec_as_agent(
                 environment, command=command, env=env, cwd=cwd, timeout_sec=timeout_sec,
@@ -410,92 +303,21 @@ def _patch_claude_code_realtime_hooks() -> None:
         if not _is_true((extra_env or {}).get("CC_OPIK_INSTALL_DEPS", "true")):
             return
 
+        wheel_dir = (extra_env or {}).get(
+            "CC_OPIK_PY_WHEEL_DIR", "/opt/tb-opik/python-wheels"
+        )
+        wheel_url = (extra_env or {}).get("HARBOR_LOCAL_WHEEL_SERVER_URL", "")
         await self.exec_as_root(
             environment,
-            command=(
-                "set -euo pipefail; "
-                f"wheel_dir={shlex.quote((extra_env or {}).get('CC_OPIK_PY_WHEEL_DIR', '/opt/tb-opik/python-wheels'))}; "
-                "if ! command -v python3 >/dev/null 2>&1; then "
-                "if command -v apk >/dev/null 2>&1; then "
-                "apk add --no-cache python3 py3-pip; "
-                "elif command -v apt-get >/dev/null 2>&1; then "
-                "apt-get update && apt-get install -y python3 python3-pip; "
-                "elif command -v yum >/dev/null 2>&1; then "
-                "yum install -y python3 python3-pip; "
-                "else "
-                "echo '[WARN] no known package manager, skip python dependency install' >&2; "
-                "fi; "
-                "fi; "
-                "if ! command -v python3.12 >/dev/null 2>&1 "
-                "&& [ -f \"$wheel_dir/python3.12-runtime.tar.gz\" ] "
-                "&& command -v python3 >/dev/null 2>&1; then "
-                "rm -rf /opt/python3.12-runtime; "
-                "mkdir -p /opt; "
-                "python3 - <<'PY' \"$wheel_dir/python3.12-runtime.tar.gz\" /opt\n"
-                "import sys, tarfile\n"
-                "with tarfile.open(sys.argv[1], 'r:gz') as archive:\n"
-                "    archive.extractall(sys.argv[2])\n"
-                "PY\n"
-                "fi"
-            ),
+            command=container_bootstrap.build_python_runtime_command(wheel_dir),
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
-
         await self.exec_as_agent(
             environment,
-            command=(
-                "set -euo pipefail; "
-                "py_bin=\"$(command -v python3.12 || true)\"; "
-                "py_bin=\"\"; "
-                "for candidate in /opt/python3.12-runtime/bin/python3.12 python3.12 python3; do "
-                "([ -x \"$candidate\" ] || command -v \"$candidate\" >/dev/null 2>&1) || continue; "
-                "\"$candidate\" - <<'PY' >/dev/null 2>&1 || continue\n"
-                "import sys\n"
-                "print(sys.version)\n"
-                "PY\n"
-                "py_bin=\"$candidate\"; "
-                "break; "
-                "done; "
-                "if [ -z \"$py_bin\" ]; then "
-                "echo '[WARN] python missing, skip opik hook deps' >&2; "
-                "exit 0; "
-                "fi; "
-                f"wheel_dir={shlex.quote((extra_env or {}).get('CC_OPIK_PY_WHEEL_DIR', '/opt/tb-opik/python-wheels'))}; "
-                f"wheel_url={shlex.quote((extra_env or {}).get('HARBOR_LOCAL_WHEEL_SERVER_URL', ''))}; "
-                "missing=$(\"$py_bin\" - <<'PY'\n"
-                "import importlib.util\n"
-                "mods = ('opik', 'uuid6', 'socksio')\n"
-                "missing = [m for m in mods if importlib.util.find_spec(m) is None]\n"
-                "print(' '.join(missing))\n"
-                "PY\n"
-                "); "
-                "if [ -z \"$missing\" ]; then exit 0; fi; "
-                "pip_opts=\"\"; "
-                "if [ -d \"$wheel_dir\" ]; then "
-                "pip_opts=\"--no-index --find-links $wheel_dir\"; "
-                "elif [ -n \"$wheel_url\" ]; then "
-                "trusted_host=\"$(printf %s \"$wheel_url\" | sed -E 's#^https?://([^/:]+).*#\\1#')\"; "
-                "pip_opts=\"--trusted-host $trusted_host --no-index --find-links $wheel_url\"; "
-                "fi; "
-                "if ! \"$py_bin\" -m pip --version >/dev/null 2>&1; then "
-                "if [ -f \"$wheel_dir/get-pip.py\" ]; then "
-                "\"$py_bin\" \"$wheel_dir/get-pip.py\" --break-system-packages $pip_opts pip setuptools wheel >/dev/null 2>&1 || true; "
-                "elif [ -n \"$wheel_url\" ]; then "
-                "tmp_get_pip=\"$(mktemp /tmp/get-pip-XXXXXX.py)\"; "
-                "\"$py_bin\" - <<'PY' \"$wheel_url/get-pip.py\" \"$tmp_get_pip\" >/dev/null 2>&1 || true\n"
-                "import sys, urllib.request\n"
-                "urllib.request.urlretrieve(sys.argv[1], sys.argv[2])\n"
-                "PY\n"
-                "if [ -s \"$tmp_get_pip\" ]; then \"$py_bin\" \"$tmp_get_pip\" --break-system-packages $pip_opts pip setuptools wheel >/dev/null 2>&1 || true; fi; "
-                "rm -f \"$tmp_get_pip\"; "
-                "fi; "
-                "fi; "
-                "\"$py_bin\" -m pip install --break-system-packages --ignore-installed $pip_opts $missing "
-                "|| \"$py_bin\" -m pip install --ignore-installed $pip_opts $missing "
-                "|| \"$py_bin\" -m pip install --user --ignore-installed $pip_opts $missing "
-                "|| \"$py_bin\" -m pip install --break-system-packages --ignore-installed $missing "
-                "|| \"$py_bin\" -m pip install --user --ignore-installed $missing "
-                "|| { echo '[WARN] failed to install python deps for opik hook' >&2; exit 1; }"
+            command=container_bootstrap.build_python_dependencies_command(
+                ("opik", "uuid6", "socksio"),
+                wheel_dir=wheel_dir,
+                wheel_url=wheel_url,
             ),
         )
 

--- a/Agents/Harbor-claude-code/tests/test_sitecustomize.py
+++ b/Agents/Harbor-claude-code/tests/test_sitecustomize.py
@@ -124,6 +124,7 @@ class ClaudeInstallCommandTest(unittest.TestCase):
             async def exec_as_root(
                 self, environment, command=None, env=None, cwd=None, timeout_sec=None
             ):
+                captured.append(command)
                 return command
 
             async def exec_as_agent(
@@ -232,6 +233,31 @@ class ClaudeInstallCommandTest(unittest.TestCase):
             check=False,
         )
         self.assertEqual(bash_check.returncode, 0, bash_check.stderr)
+
+    def test_missing_python_skips_hook_dependencies_without_aborting_install(self) -> None:
+        commands = self._install_commands(
+            {
+                "CC_OPIK_ENABLE_HOOK": "true",
+                "CC_OPIK_INSTALL_DEPS": "true",
+                "OPIK_URL": "https://opik.example.invalid/api",
+            }
+        )
+        runtime_command = next(
+            item for item in commands if "python_works()" in item
+        )
+        dependencies_command = next(
+            item
+            for item in commands
+            if "mods = ('opik', 'uuid6', 'socksio')" in item
+        )
+
+        warning = "echo '[WARN] python missing, skip opik hook deps' >&2"
+        self.assertIn(warning, runtime_command)
+        self.assertIn(warning, dependencies_command)
+        self.assertIn("exit 0", runtime_command[runtime_command.index(warning) :])
+        self.assertIn(
+            "exit 0", dependencies_command[dependencies_command.index(warning) :]
+        )
 
 
 class QzInstructionHookGateTest(unittest.TestCase):

--- a/Agents/Harbor-claude-code/tests/test_sitecustomize.py
+++ b/Agents/Harbor-claude-code/tests/test_sitecustomize.py
@@ -106,7 +106,7 @@ class ClaudeCommandPatchTest(unittest.TestCase):
 
 
 class ClaudeInstallCommandTest(unittest.TestCase):
-    def _install_command(self, extra_env: dict[str, str]) -> str:
+    def _install_commands(self, extra_env: dict[str, str]) -> list[str]:
         module = load_module()
         captured: list[str] = []
 
@@ -148,6 +148,10 @@ class ClaudeInstallCommandTest(unittest.TestCase):
             agent._extra_env = extra_env
             asyncio.run(agent.install(object()))
 
+        return captured
+
+    def _install_command(self, extra_env: dict[str, str]) -> str:
+        captured = self._install_commands(extra_env)
         self.assertEqual(len(captured), 1)
         return captured[0]
 
@@ -169,7 +173,8 @@ class ClaudeInstallCommandTest(unittest.TestCase):
 
     def test_node_dist_url_bootstrap_skipped_when_unset(self) -> None:
         command = self._install_command({"CC_OPIK_ENABLE_HOOK": "false"})
-        self.assertIn("[ -n '' ]", command)
+        self.assertIn("node_dist_url=''", command)
+        self.assertIn('[ -n "$node_dist_url" ]', command)
         bash_check = subprocess.run(
             ["bash", "-n"],
             input=command,
@@ -187,9 +192,7 @@ class ClaudeInstallCommandTest(unittest.TestCase):
             }
         )
 
-        guarded_extract = (
-            'if python3 - <<\'PY\' "$node_dist_tgz" "$node_dir"'
-        )
+        guarded_extract = 'if extract_archive "$node_dist_tgz" "$node_dir"; then'
         package_manager_fallback = "if ! command -v npm >/dev/null 2>&1; then"
         self.assertIn(guarded_extract, command)
         self.assertLess(
@@ -197,6 +200,30 @@ class ClaudeInstallCommandTest(unittest.TestCase):
             command.index(package_manager_fallback, command.index(guarded_extract)),
         )
 
+        bash_check = subprocess.run(
+            ["bash", "-n"],
+            input=command,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(bash_check.returncode, 0, bash_check.stderr)
+
+    def test_hook_dependencies_use_rich_shared_pip_fallbacks(self) -> None:
+        commands = self._install_commands(
+            {
+                "CC_OPIK_ENABLE_HOOK": "true",
+                "CC_OPIK_INSTALL_DEPS": "true",
+                "HARBOR_LOCAL_WHEEL_SERVER_URL": "https://cache.example/wheels",
+                "OPIK_URL": "https://opik.example.invalid/api",
+            }
+        )
+        command = next(item for item in commands if "mods = ('opik', 'uuid6', 'socksio')" in item)
+
+        self.assertIn("export PIP_BREAK_SYSTEM_PACKAGES=1", command)
+        self.assertIn("--retries 10 --timeout 120", command)
+        self.assertIn("command -v curl", command)
+        self.assertIn("command -v wget", command)
         bash_check = subprocess.run(
             ["bash", "-n"],
             input=command,

--- a/Agents/Harbor-opencode/STRUCT.md
+++ b/Agents/Harbor-opencode/STRUCT.md
@@ -13,6 +13,8 @@ Agents/Harbor-opencode/
 `enable_track_harbor.py` starts OpenCode runs through Harbor with tracing enabled.
 
 `opik_opencode_harbor.py` implements the OpenCode Harbor agent adapter.
+Its container runtime and package bootstrap commands come from
+`Agents/utils/common/Harbor/container_bootstrap.py`.
 
 `finalize_opencode_sessions.py` collects and finalizes OpenCode trace/session output after a worker finishes.
 

--- a/Agents/Harbor-opencode/opik_opencode_harbor.py
+++ b/Agents/Harbor-opencode/opik_opencode_harbor.py
@@ -33,6 +33,7 @@ REPO_ROOT = ROOT.parents[1]
 HARBOR_RUNTIME_DIR = REPO_ROOT / "Agents" / "utils" / "common" / "Harbor"
 sys.path.append(str(HARBOR_RUNTIME_DIR))
 
+import container_bootstrap  # noqa: E402
 from opik_trace_gate import opik_tracing_enabled  # noqa: E402
 
 TRACE_PLUGIN_SOURCE_DIR = Path(
@@ -229,68 +230,12 @@ class OpikOpenCodeHarbor(OpenCode):
 
     async def install(self, environment: BaseEnvironment) -> None:
         async def _prepare_python_runtime() -> None:
-            # Do not run apt unless Python is actually missing. Several Seta
-            # images intentionally contain broken dpkg state; a no-op apt
-            # install still reconfigures those packages and breaks setup.
+            wheel_dir = self._extra_env.get(
+                "CC_OPIK_PY_WHEEL_DIR", "/opt/tb-opik/python-wheels"
+            )
             await self.exec_as_root(
                 environment,
-                command=(
-                    "set -euo pipefail; "
-                    "wheel_dir=\"${CC_OPIK_PY_WHEEL_DIR:-/opt/tb-opik/python-wheels}\"; "
-                    # Some task images contain a python3 wrapper whose target
-                    # is missing. Treat Python as present only if it executes.
-                    "if command -v python3 >/dev/null 2>&1 && python3 - <<'PY' >/dev/null 2>&1\n"
-                    "import sys\n"
-                    "print(sys.version)\n"
-                    "PY\n"
-                    "then exit 0; fi; "
-                    "if [ -f \"$wheel_dir/python3.12-runtime.tar.gz\" ] && command -v tar >/dev/null 2>&1; then "
-                      "  rm -rf /opt/python3.12-runtime; "
-                      "  mkdir -p /opt; "
-                      "  tar -xzf \"$wheel_dir/python3.12-runtime.tar.gz\" -C /opt; "
-                    "  if [ -x /opt/python3.12-runtime/bin/python3.12 ] "
-                    "    && /opt/python3.12-runtime/bin/python3.12 - <<'PY' >/dev/null 2>&1\n"
-                    "import sys\n"
-                    "print(sys.version)\n"
-                    "PY\n"
-                    "  then "
-                    # Do not symlink the cached wrapper. It derives runtime
-                    # paths from $0, so a /usr/local/bin symlink makes it look
-                    # for /usr/local/bin/python3.12.real and breaks hooks.
-                    "    printf '%s\n' '#!/bin/sh' 'exec /opt/python3.12-runtime/bin/python3.12 \"$@\"' > /usr/local/bin/python3; "
-                    "    printf '%s\n' '#!/bin/sh' 'exec /opt/python3.12-runtime/bin/python3.12 \"$@\"' > /usr/local/bin/python3.12; "
-                    "    chmod +x /usr/local/bin/python3 /usr/local/bin/python3.12; "
-                      "    exit 0; "
-                      "  fi; "
-                    # A corrupt cached runtime leaves a wrapper that points at
-                    # a missing python3.12.real. Remove it so later hook startup
-                    # cannot silently spawn a broken /usr/local/bin/python3.
-                    "  rm -rf /opt/python3.12-runtime; "
-                    "  rm -f /usr/local/bin/python3 /usr/local/bin/python3.12; "
-                    "fi; "
-                    "if command -v apk >/dev/null 2>&1; then "
-                    "  apk add --no-cache python3 py3-pip; "
-                    "elif command -v apt-get >/dev/null 2>&1; then "
-                    "  apt-get update && apt-get install -y python3 python3-pip; "
-                    "elif command -v yum >/dev/null 2>&1; then "
-                    "  yum install -y python3 python3-pip; "
-                    "else "
-                    "  echo '[WARN] no known package manager for python install' >&2; "
-                    "fi; "
-                    # Keep later agent commands away from broken /usr/local/bin
-                    # wrappers by pointing python3 at the package-manager copy.
-                    "if [ -x /usr/bin/python3 ] && /usr/bin/python3 - <<'PY' >/dev/null 2>&1\n"
-                    "import sys\n"
-                    "print(sys.version)\n"
-                    "PY\n"
-                    "then ln -sf /usr/bin/python3 /usr/local/bin/python3; fi; "
-                    # The realtime plugin spawns `python3` with stderr hidden.
-                    # Fail install here instead of losing all opencode traces.
-                    "python3 - <<'PY' >/dev/null\n"
-                    "import sys\n"
-                    "print(sys.version)\n"
-                    "PY\n"
-                ),
+                command=container_bootstrap.build_python_runtime_command(wheel_dir),
                 env={"DEBIAN_FRONTEND": "noninteractive"},
             )
 
@@ -321,123 +266,43 @@ class OpikOpenCodeHarbor(OpenCode):
             if callable(raw_version):
                 raw_version = raw_version()
             version = str(raw_version or os.environ.get("OPENCODE_VERSION", "latest"))
-            version_q = shlex.quote(version)
+            wheel_dir = self._extra_env.get(
+                "CC_OPIK_PY_WHEEL_DIR", "/opt/tb-opik/python-wheels"
+            )
+            archive_basename = f"opencode-ai-{version}.tgz"
+            platform_basename = f"opencode-linux-x64-{version}.tgz"
             await self.exec_as_agent(
                 environment,
-                command=(
-                    "set -euo pipefail; "
-                    "export PATH=\"$HOME/.local/bin:$PATH\"; "
-                    f"opencode_version={version_q}; "
-                    "download_file() { "
-                    "  url=\"$1\"; dest=\"$2\"; "
-                    "  if command -v curl >/dev/null 2>&1; then curl -fsSL \"$url\" -o \"$dest\"; "
-                    "  elif command -v wget >/dev/null 2>&1; then wget -qO \"$dest\" \"$url\"; "
-                    "  elif command -v python3 >/dev/null 2>&1; then python3 - <<'PY' \"$url\" \"$dest\"\n"
-                    "import sys, urllib.request\n"
-                    "urllib.request.urlretrieve(sys.argv[1], sys.argv[2])\n"
-                    "PY\n"
-                    "  else return 1; fi; "
-                    "}; "
-                    "extract_archive() { "
-                    "  archive=\"$1\"; dest=\"$2\"; "
-                    "  mkdir -p \"$dest\"; "
-                    "  if command -v tar >/dev/null 2>&1 && tar -xf \"$archive\" -C \"$dest\"; then return 0; fi; "
-                    "  if command -v python3 >/dev/null 2>&1; then python3 - <<'PY' \"$archive\" \"$dest\"\n"
-                    "import sys, tarfile\n"
-                    "with tarfile.open(sys.argv[1]) as archive:\n"
-                    "    archive.extractall(sys.argv[2])\n"
-                    "PY\n"
-                    "  else return 1; fi; "
-                    "}; "
-                    "wheel_dir=\"${CC_OPIK_PY_WHEEL_DIR:-/opt/tb-opik/python-wheels}\"; "
-                    "wheel_url=\"${HARBOR_LOCAL_WHEEL_SERVER_URL:-}\"; "
-                    "node_tgz=\"$wheel_dir/node-runtime.tar.xz\"; "
-                    "opencode_tgz=\"${OPENCODE_TGZ_PATH:-}\"; "
-                    "opencode_linux_x64_tgz=\"${OPENCODE_LINUX_X64_TGZ_PATH:-}\"; "
-                    "opencode_name=\"opencode-ai-${opencode_version}.tgz\"; "
-                    "opencode_linux_x64_name=\"opencode-linux-x64-${opencode_version}.tgz\"; "
-                    "if [ -z \"$opencode_tgz\" ]; then opencode_tgz=\"$wheel_dir/$opencode_name\"; fi; "
-                    "if [ -z \"$opencode_linux_x64_tgz\" ]; then opencode_linux_x64_tgz=\"$wheel_dir/$opencode_linux_x64_name\"; fi; "
-                    "if [ ! -f \"$opencode_tgz\" ] && [ -n \"${HARBOR_LOCAL_OPENCODE_TGZ_URL:-}\" ]; then "
-                    "  tmp_tgz=\"$(mktemp /tmp/opencode-ai-XXXXXX.tgz)\"; "
-                    "  download_file \"$HARBOR_LOCAL_OPENCODE_TGZ_URL\" \"$tmp_tgz\" >/dev/null 2>&1 || true; "
-                    "  if [ -s \"$tmp_tgz\" ]; then opencode_tgz=\"$tmp_tgz\"; fi; "
-                    "fi; "
-                    "if [ ! -f \"$opencode_tgz\" ] && [ -n \"$wheel_url\" ]; then "
-                    "  tmp_tgz=\"$(mktemp /tmp/opencode-ai-XXXXXX.tgz)\"; "
-                    "  download_file \"${wheel_url%/}/$opencode_name\" \"$tmp_tgz\" >/dev/null 2>&1 || true; "
-                    "  if [ -s \"$tmp_tgz\" ]; then opencode_tgz=\"$tmp_tgz\"; fi; "
-                    "fi; "
-                    "if [ ! -f \"$opencode_linux_x64_tgz\" ] && [ -n \"${HARBOR_LOCAL_OPENCODE_LINUX_X64_TGZ_URL:-}\" ]; then "
-                    "  tmp_platform_tgz=\"$(mktemp /tmp/opencode-linux-x64-XXXXXX.tgz)\"; "
-                    "  download_file \"$HARBOR_LOCAL_OPENCODE_LINUX_X64_TGZ_URL\" \"$tmp_platform_tgz\" >/dev/null 2>&1 || true; "
-                    "  if [ -s \"$tmp_platform_tgz\" ]; then opencode_linux_x64_tgz=\"$tmp_platform_tgz\"; fi; "
-                    "fi; "
-                    "if [ ! -f \"$opencode_linux_x64_tgz\" ] && [ -n \"$wheel_url\" ]; then "
-                    "  tmp_platform_tgz=\"$(mktemp /tmp/opencode-linux-x64-XXXXXX.tgz)\"; "
-                    "  download_file \"${wheel_url%/}/$opencode_linux_x64_name\" \"$tmp_platform_tgz\" >/dev/null 2>&1 || true; "
-                    "  if [ -s \"$tmp_platform_tgz\" ]; then opencode_linux_x64_tgz=\"$tmp_platform_tgz\"; fi; "
-                    "fi; "
-                    "mkdir -p \"$HOME/.local/bin\"; "
-                    "if ! command -v npm >/dev/null 2>&1 && [ -f \"$node_tgz\" ]; then "
-                    "  node_dir=\"$(mktemp -d /tmp/tb-node-XXXXXX)\"; "
-                    "  extract_archive \"$node_tgz\" \"$node_dir\"; "
-                    "  node_bin=\"$(find \"$node_dir\" -path '*/bin/npm' -print -quit 2>/dev/null)\"; "
-                    "  if [ -n \"$node_bin\" ]; then "
-                    "    node_runtime_bin=\"$(dirname \"$node_bin\")\"; "
-                    "    mkdir -p \"$HOME/.local/bin\"; "
-                    "    ln -sf \"$node_runtime_bin/node\" \"$HOME/.local/bin/node\" 2>/dev/null || true; "
-                    "    ln -sf \"$node_runtime_bin/npm\" \"$HOME/.local/bin/npm\" 2>/dev/null || true; "
-                    "    ln -sf \"$node_runtime_bin/npx\" \"$HOME/.local/bin/npx\" 2>/dev/null || true; "
-                    "    export PATH=\"$HOME/.local/bin:$node_runtime_bin:$PATH\"; "
-                    "  fi; "
-                    "fi; "
-                    # qz has no mount or route back to the runner. Use the same
-                    # sandbox-reachable Node dist mirror as Claude Code.
-                    "if ! command -v npm >/dev/null 2>&1 && [ -n \"${CC_NODE_DIST_URL:-}\" ]; then "
-                    "  node_dist_tgz=\"$(mktemp /tmp/tb-node-dist-XXXXXX.tgz)\"; "
-                    "  if download_file \"$CC_NODE_DIST_URL\" \"$node_dist_tgz\" "
-                    "    && [ -s \"$node_dist_tgz\" ]; then "
-                    "    node_dir=\"$(mktemp -d /tmp/tb-node-XXXXXX)\"; "
-                    "    if extract_archive \"$node_dist_tgz\" \"$node_dir\"; then "
-                    "      node_bin=\"$(find \"$node_dir\" -path '*/bin/npm' -print -quit 2>/dev/null)\"; "
-                    "      if [ -n \"$node_bin\" ]; then "
-                    "        node_runtime_bin=\"$(dirname \"$node_bin\")\"; "
-                    "        ln -sf \"$node_runtime_bin/node\" \"$HOME/.local/bin/node\" 2>/dev/null || true; "
-                    "        ln -sf \"$node_runtime_bin/npm\" \"$HOME/.local/bin/npm\" 2>/dev/null || true; "
-                    "        ln -sf \"$node_runtime_bin/npx\" \"$HOME/.local/bin/npx\" 2>/dev/null || true; "
-                    "        export PATH=\"$HOME/.local/bin:$node_runtime_bin:$PATH\"; "
-                    "      fi; "
-                    "    fi; "
-                    "  fi; "
-                    "fi; "
-                    "if ! command -v npm >/dev/null 2>&1; then "
-                    "  if command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y nodejs npm; "
-                    "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache nodejs npm; "
-                    "  elif command -v yum >/dev/null 2>&1; then yum install -y nodejs npm; fi; "
-                    "fi; "
-                    "npm config set prefix \"$HOME/.local\" >/dev/null 2>&1 || true; "
-                    "use_linux_x64_platform=0; "
-                    # Only use the cached glibc x64 binary on matching images.
-                    # Alpine/musl keeps the existing npm fallback so optional
-                    # package selection can pick the compatible binary.
-                    "if [ \"$(uname -m 2>/dev/null)\" = \"x86_64\" ] "
-                    "  && command -v ldd >/dev/null 2>&1 "
-                    "  && ldd --version 2>&1 | grep -qi 'glibc\\|GNU libc' "
-                    "  && [ -f \"$opencode_linux_x64_tgz\" ]; then "
-                    "  use_linux_x64_platform=1; "
-                    "fi; "
-                    "if [ -f \"$opencode_tgz\" ]; then "
-                    "  if [ \"$use_linux_x64_platform\" = \"1\" ]; then "
-                    "    npm install -g \"$opencode_tgz\" \"$opencode_linux_x64_tgz\" && opencode --version; "
-                    "  else "
-                    "    npm install -g \"$opencode_tgz\" && opencode --version; "
-                    "  fi "
-                    "    || { npm install -g \"opencode-ai@${opencode_version}\"; opencode --version; }; "
-                    "else "
-                    "  npm install -g \"opencode-ai@${opencode_version}\"; "
-                    "  opencode --version; "
-                    "fi"
+                command=container_bootstrap.build_npm_tool_install_command(
+                    container_bootstrap.NpmToolSpec(
+                        executable="opencode",
+                        package="opencode-ai",
+                        version=version,
+                        archive_path=self._extra_env.get("OPENCODE_TGZ_PATH", "")
+                        or f"{wheel_dir}/{archive_basename}",
+                        archive_url=self._extra_env.get(
+                            "HARBOR_LOCAL_OPENCODE_TGZ_URL", ""
+                        ),
+                        archive_basename=archive_basename,
+                        platform_archive_path=self._extra_env.get(
+                            "OPENCODE_LINUX_X64_TGZ_PATH", ""
+                        )
+                        or f"{wheel_dir}/{platform_basename}",
+                        platform_archive_url=self._extra_env.get(
+                            "HARBOR_LOCAL_OPENCODE_LINUX_X64_TGZ_URL", ""
+                        ),
+                        platform_archive_basename=platform_basename,
+                        npm_cache_dir=self._extra_env.get(
+                            "CC_OPIK_NPM_CACHE_DIR", ""
+                        )
+                        or f"{wheel_dir}/npm-cache",
+                        npm_registry=self._extra_env.get("NPM_CONFIG_REGISTRY", ""),
+                    ),
+                    wheel_dir=wheel_dir,
+                    wheel_url=self._extra_env.get(
+                        "HARBOR_LOCAL_WHEEL_SERVER_URL", ""
+                    ),
+                    node_dist_url=self._extra_env.get("CC_NODE_DIST_URL", ""),
                 ),
             )
 
@@ -461,72 +326,17 @@ class OpikOpenCodeHarbor(OpenCode):
             # Keep the runtime install offline/cache-first. Only fall back to
             # public pip when neither the mounted cache nor the wheel HTTP
             # mirror is usable.
+            wheel_dir = self._extra_env.get(
+                "CC_OPIK_PY_WHEEL_DIR", "/opt/tb-opik/python-wheels"
+            )
             await self.exec_as_agent(
                 environment,
-                command=(
-                    "set -euo pipefail; "
-                    "py_bin=\"\"; "
-                    "for candidate in /opt/python3.12-runtime/bin/python3.12 python3.12 python3; do "
-                    "  ([ -x \"$candidate\" ] || command -v \"$candidate\" >/dev/null 2>&1) || continue; "
-                    "  \"$candidate\" - <<'PY' >/dev/null 2>&1 || continue\n"
-                    "import sys\n"
-                    "print(sys.version)\n"
-                    "PY\n"
-                    "  py_bin=\"$candidate\"; break; "
-                    "done; "
-                    "if [ -z \"$py_bin\" ]; then echo '[WARN] python missing for opik hook deps' >&2; exit 1; fi; "
-                    "wheel_dir=\"${CC_OPIK_PY_WHEEL_DIR:-/opt/tb-opik/python-wheels}\"; "
-                    "wheel_url=\"${HARBOR_LOCAL_WHEEL_SERVER_URL:-}\"; "
-                    "missing=$(\"$py_bin\" - <<'PY'\n"
-                    "import importlib.util\n"
-                    "mods = ('opik', 'uuid6', 'socksio')\n"
-                    "print(' '.join(m for m in mods if importlib.util.find_spec(m) is None))\n"
-                    "PY\n"
-                    "); "
-                    "if [ -z \"$missing\" ]; then exit 0; fi; "
-                    # Debian/Ubuntu task images often enable PEP 668. Set the
-                    # env override unconditionally so cached wheel installs do
-                    # not fail agent setup before the hook can be installed.
-                    "export PIP_BREAK_SYSTEM_PACKAGES=1; "
-                    "pip_opts=\"\"; "
-                    "if [ -d \"$wheel_dir\" ]; then "
-                    "  pip_opts=\"--no-index --find-links $wheel_dir\"; "
-                    "elif [ -n \"$wheel_url\" ]; then "
-                    "  trusted_host=\"$(printf %s \"$wheel_url\" | sed -E 's#^https?://([^/:]+).*#\\1#')\"; "
-                    "  pip_opts=\"--trusted-host $trusted_host --no-index --find-links $wheel_url\"; "
-                    "fi; "
-                    "if ! \"$py_bin\" -m pip --version >/dev/null 2>&1; then "
-                    "  if [ -f \"$wheel_dir/get-pip.py\" ]; then "
-                    "    \"$py_bin\" \"$wheel_dir/get-pip.py\" --user $pip_opts pip setuptools wheel >/dev/null 2>&1 "
-                    "      || \"$py_bin\" \"$wheel_dir/get-pip.py\" --break-system-packages $pip_opts pip setuptools wheel >/dev/null 2>&1 "
-                    "      || true; "
-                    "  elif [ -n \"$wheel_url\" ]; then "
-                    "    tmp_get_pip=\"$(mktemp /tmp/get-pip-XXXXXX.py)\"; "
-                    "    if command -v curl >/dev/null 2>&1; then curl -fsSL \"${wheel_url%/}/get-pip.py\" -o \"$tmp_get_pip\"; "
-                    "    elif command -v wget >/dev/null 2>&1; then wget -qO \"$tmp_get_pip\" \"${wheel_url%/}/get-pip.py\"; "
-                    "    elif command -v python3 >/dev/null 2>&1; then python3 - <<'PY' \"${wheel_url%/}/get-pip.py\" \"$tmp_get_pip\" >/dev/null 2>&1 || true\n"
-                    "import sys, urllib.request\n"
-                    "urllib.request.urlretrieve(sys.argv[1], sys.argv[2])\n"
-                    "PY\n"
-                    "    fi; "
-                    "    if [ -s \"$tmp_get_pip\" ]; then "
-                    "      \"$py_bin\" \"$tmp_get_pip\" --user $pip_opts pip setuptools wheel >/dev/null 2>&1 "
-                    "        || \"$py_bin\" \"$tmp_get_pip\" --break-system-packages $pip_opts pip setuptools wheel >/dev/null 2>&1 "
-                    "        || true; "
-                    "    fi; "
-                    "    rm -f \"$tmp_get_pip\"; "
-                    "  fi; "
-                    "fi; "
-                    "break_opt=\"\"; "
-                    "if \"$py_bin\" -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then "
-                    "  break_opt=\"--break-system-packages\"; "
-                    "fi; "
-                    "\"$py_bin\" -m pip install --retries 10 --timeout 120 $break_opt --ignore-installed $pip_opts $missing "
-                    "|| \"$py_bin\" -m pip install --retries 10 --timeout 120 --ignore-installed $pip_opts $missing "
-                    "|| \"$py_bin\" -m pip install --retries 10 --timeout 120 --user --ignore-installed $pip_opts $missing "
-                    "|| \"$py_bin\" -m pip install --retries 10 --timeout 120 $break_opt --ignore-installed $missing "
-                    "|| \"$py_bin\" -m pip install --retries 10 --timeout 120 --user --ignore-installed $missing "
-                    "|| { echo '[WARN] failed to install python deps for opik hook' >&2; exit 1; }"
+                command=container_bootstrap.build_python_dependencies_command(
+                    ("opik", "uuid6", "socksio"),
+                    wheel_dir=wheel_dir,
+                    wheel_url=self._extra_env.get(
+                        "HARBOR_LOCAL_WHEEL_SERVER_URL", ""
+                    ),
                 ),
             )
 

--- a/Agents/Harbor-opencode/tests/test_trace_disabled.py
+++ b/Agents/Harbor-opencode/tests/test_trace_disabled.py
@@ -14,15 +14,20 @@ from pathlib import Path
 from unittest import mock
 
 MODULE_DIR = Path(__file__).resolve().parents[1]
+HARBOR_RUNTIME_DIR = MODULE_DIR.parent / "utils" / "common" / "Harbor"
 
 
 def load_module(name: str, path: Path):
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
+    sys.path.insert(0, str(HARBOR_RUNTIME_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(HARBOR_RUNTIME_DIR))
 
 
 class FakeOpenCode:
@@ -197,23 +202,25 @@ class OpenCodeTraceDisabledTests(unittest.TestCase):
         install_command = next(
             str(item.get("command", ""))
             for item in agent.agent_commands
-            if "opencode_version=" in str(item.get("command", ""))
+            if "tool_executable=opencode" in str(item.get("command", ""))
         )
-        self.assertIn("${CC_NODE_DIST_URL:-}", install_command)
+        self.assertIn("node_dist_url=https://registry.npmmirror.com", install_command)
         self.assertIn(
-            'if download_file "$CC_NODE_DIST_URL" "$node_dist_tgz" '
-            '    && [ -s "$node_dist_tgz" ]; then',
+            'if download_file "$node_dist_url" "$node_dist_tgz" '
+            '&& [ -s "$node_dist_tgz" ]; then',
             install_command,
         )
         self.assertIn(
             'if extract_archive "$node_dist_tgz" "$node_dir"; then',
             install_command,
         )
+        self.assertIn("Acquire::ForceIPv4=true", install_command)
+        self.assertIn("npm install -g --offline --cache", install_command)
         self.assertLess(
-            install_command.index("CC_NODE_DIST_URL"),
-            install_command.index("apt-get update"),
+            install_command.index("node_dist_url="),
+            install_command.index("apt-get -o Acquire::ForceIPv4=true update"),
         )
-        self.assertIn('npm install -g "opencode-ai@${opencode_version}"', install_command)
+        self.assertIn("npm install -g opencode-ai@latest", install_command)
         bash_check = subprocess.run(
             ["bash", "-n"],
             input=install_command,

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -18,6 +18,7 @@ Agents/utils/common/Harbor/
 ├── run_harbor_registry.sh      # Registry runner with optional final-pane hold
 ├── harboropik.sh               # Harbor CLI orchestration with Opik setup
 ├── harbor_shell_utils.py       # Event, JSON, URL, and mount helpers
+├── container_bootstrap.py      # Shared Python/Node/npm/pip container shell builders
 ├── qz_repository_environment_plan.py # Repository/revision final-image plan producer
 ├── qz_task_instruction.py      # Exact QZ setup-prefix handoff before agent run
 ├── prepare_local_deps.sh       # Thin Python launcher
@@ -89,10 +90,11 @@ Shell entry points own environment composition and top-level process
 lifecycle. Their Python helpers own delegated parsing and data workflows,
 including external commands required to complete them:
 
-| Shell caller | Python helper | Delegated responsibility |
+| Caller | Python helper | Delegated responsibility |
 | --- | --- | --- |
 | `prepare_local_deps.sh` | `prepare_local_deps.py` | Downloads, runtime archives, npm caches, and manifest generation |
 | `harboropik.sh` and model-fusion wrappers | `harbor_shell_utils.py` | Structured events, JSON normalization, URL parsing, and read-only mount JSON |
+| Claude Code `sitecustomize.py` and OpenCode adapter | `container_bootstrap.py` | Python runtime, Node runtime, npm package/cache, and pip/get-pip fallback shell |
 | `monitor_harbor.sh` | `harbor_monitor_utils.py` | Reward, success, exception, and environment statistics |
 | `Agents/utils/rl/run_rl_rollout_server.sh`, `run_rl_rollout_worker.sh`, `monitor_rl_rollout.sh` | `Agents/utils/rl/rollout_worker_utils.py` | Request headers/JSON, LLM kwargs, result assembly, and monitor rendering |
 | Mimo/OpenRouter `run_tb21.sh` | `model-fusion/router_cli_utils.py` | Wheel metadata/extraction, doctor validation, and task-list conversion |

--- a/Agents/utils/common/Harbor/container_bootstrap.py
+++ b/Agents/utils/common/Harbor/container_bootstrap.py
@@ -22,8 +22,16 @@ class NpmToolSpec:
     npm_registry: str = ""
 
 
-def build_python_runtime_command(wheel_dir: str) -> str:
+def build_python_runtime_command(
+    wheel_dir: str, *, python_required: bool = True
+) -> str:
     wheel_dir_q = shlex.quote(wheel_dir)
+    missing_python_exit_code = 1 if python_required else 0
+    missing_python_message = (
+        "[ERROR] python missing after runtime setup"
+        if python_required
+        else "[WARN] python missing, skip opik hook deps"
+    )
     return textwrap.dedent(
         rf"""
         set -euo pipefail
@@ -71,7 +79,10 @@ def build_python_runtime_command(wheel_dir: str) -> str:
         if [ -x /usr/bin/python3 ] && python_works /usr/bin/python3; then
           ln -sf /usr/bin/python3 /usr/local/bin/python3
         fi
-        python_works python3
+        if ! python_works python3; then
+          echo {shlex.quote(missing_python_message)} >&2
+          exit {missing_python_exit_code}
+        fi
         """
     ).lstrip()
 
@@ -285,10 +296,17 @@ def build_python_dependencies_command(
     *,
     wheel_dir: str,
     wheel_url: str,
+    python_required: bool = True,
 ) -> str:
     wheel_dir_q = shlex.quote(wheel_dir)
     wheel_url_q = shlex.quote(wheel_url)
     modules_repr = repr(tuple(modules))
+    missing_python_exit_code = 1 if python_required else 0
+    missing_python_message = (
+        "[ERROR] python missing for hook dependencies"
+        if python_required
+        else "[WARN] python missing, skip opik hook deps"
+    )
     return textwrap.dedent(
         rf"""
         set -euo pipefail
@@ -304,8 +322,8 @@ def build_python_dependencies_command(
           break
         done
         if [ -z "$py_bin" ]; then
-          echo '[WARN] python missing for hook dependencies' >&2
-          exit 1
+          echo {shlex.quote(missing_python_message)} >&2
+          exit {missing_python_exit_code}
         fi
         wheel_dir={wheel_dir_q}
         wheel_url={wheel_url_q}

--- a/Agents/utils/common/Harbor/container_bootstrap.py
+++ b/Agents/utils/common/Harbor/container_bootstrap.py
@@ -1,0 +1,377 @@
+"""Build shared shell commands for Harbor agent container setup."""
+
+from __future__ import annotations
+
+import shlex
+import textwrap
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NpmToolSpec:
+    executable: str
+    package: str
+    version: str
+    archive_path: str
+    archive_url: str = ""
+    archive_basename: str = ""
+    platform_archive_path: str = ""
+    platform_archive_url: str = ""
+    platform_archive_basename: str = ""
+    npm_cache_dir: str = ""
+    npm_registry: str = ""
+
+
+def build_python_runtime_command(wheel_dir: str) -> str:
+    wheel_dir_q = shlex.quote(wheel_dir)
+    return textwrap.dedent(
+        rf"""
+        set -euo pipefail
+        wheel_dir={wheel_dir_q}
+        python_works() {{
+          "$1" - <<'PY' >/dev/null 2>&1
+        import sys
+        print(sys.version)
+        PY
+        }}
+        if python_works /opt/python3.12-runtime/bin/python3.12; then
+          exit 0
+        fi
+        runtime_tgz="$wheel_dir/python3.12-runtime.tar.gz"
+        if [ -f "$runtime_tgz" ] && command -v tar >/dev/null 2>&1; then
+          rm -rf /opt/python3.12-runtime
+          mkdir -p /opt
+          if tar -xzf "$runtime_tgz" -C /opt \
+            && python_works /opt/python3.12-runtime/bin/python3.12; then
+            printf '%s\n' '#!/bin/sh' \
+              'exec /opt/python3.12-runtime/bin/python3.12 "$@"' \
+              > /usr/local/bin/python3
+            printf '%s\n' '#!/bin/sh' \
+              'exec /opt/python3.12-runtime/bin/python3.12 "$@"' \
+              > /usr/local/bin/python3.12
+            chmod +x /usr/local/bin/python3 /usr/local/bin/python3.12
+            exit 0
+          fi
+          rm -rf /opt/python3.12-runtime
+          rm -f /usr/local/bin/python3 /usr/local/bin/python3.12
+        fi
+        if python_works python3; then
+          exit 0
+        fi
+        if command -v apk >/dev/null 2>&1; then
+          apk add --no-cache python3 py3-pip
+        elif command -v apt-get >/dev/null 2>&1; then
+          apt-get -o Acquire::ForceIPv4=true update
+          apt-get -o Acquire::ForceIPv4=true install -y python3 python3-pip
+        elif command -v yum >/dev/null 2>&1; then
+          yum install -y python3 python3-pip
+        else
+          echo '[WARN] no known package manager for python install' >&2
+        fi
+        if [ -x /usr/bin/python3 ] && python_works /usr/bin/python3; then
+          ln -sf /usr/bin/python3 /usr/local/bin/python3
+        fi
+        python_works python3
+        """
+    ).lstrip()
+
+
+def build_npm_tool_install_command(
+    spec: NpmToolSpec,
+    *,
+    wheel_dir: str,
+    wheel_url: str,
+    node_dist_url: str,
+) -> str:
+    wheel_dir_q = shlex.quote(wheel_dir)
+    wheel_url_q = shlex.quote(wheel_url)
+    node_dist_url_q = shlex.quote(node_dist_url)
+    executable_q = shlex.quote(spec.executable)
+    archive_path_q = shlex.quote(spec.archive_path)
+    archive_url_q = shlex.quote(spec.archive_url)
+    archive_basename_q = shlex.quote(spec.archive_basename)
+    platform_path_q = shlex.quote(spec.platform_archive_path)
+    platform_url_q = shlex.quote(spec.platform_archive_url)
+    platform_basename_q = shlex.quote(spec.platform_archive_basename)
+    npm_cache_dir_q = shlex.quote(spec.npm_cache_dir)
+    npm_registry_q = shlex.quote(spec.npm_registry)
+    registry_spec = shlex.quote(
+        f"{spec.package}@{spec.version}" if spec.version else spec.package
+    )
+
+    return textwrap.dedent(
+        rf"""
+        set -euo pipefail
+        export PATH="$HOME/.local/bin:$PATH"
+        wheel_dir={wheel_dir_q}
+        wheel_url={wheel_url_q}
+        node_dist_url={node_dist_url_q}
+        tool_executable={executable_q}
+        tool_tgz={archive_path_q}
+        tool_tgz_url={archive_url_q}
+        tool_tgz_basename={archive_basename_q}
+        platform_tgz={platform_path_q}
+        platform_tgz_url={platform_url_q}
+        platform_tgz_basename={platform_basename_q}
+        npm_cache_dir={npm_cache_dir_q}
+        npm_registry={npm_registry_q}
+        download_file() {{
+          url="$1"
+          dest="$2"
+          if command -v curl >/dev/null 2>&1; then
+            curl -fsSL "$url" -o "$dest"
+          elif command -v wget >/dev/null 2>&1; then
+            wget -qO "$dest" "$url"
+          elif command -v python3 >/dev/null 2>&1; then
+            python3 - "$url" "$dest" <<'PY'
+        import sys, urllib.request
+        urllib.request.urlretrieve(sys.argv[1], sys.argv[2])
+        PY
+          else
+            return 1
+          fi
+        }}
+        extract_archive() {{
+          archive="$1"
+          dest="$2"
+          mkdir -p "$dest"
+          if command -v tar >/dev/null 2>&1 \
+            && tar -xf "$archive" -C "$dest"; then
+            return 0
+          fi
+          if command -v python3 >/dev/null 2>&1; then
+            if python3 - "$archive" "$dest" <<'PY'
+        import sys, tarfile
+        with tarfile.open(sys.argv[1]) as archive:
+            archive.extractall(sys.argv[2])
+        PY
+            then
+              return 0
+            fi
+          fi
+          return 1
+        }}
+        activate_node_runtime() {{
+          node_dir="$1"
+          node_bin="$(find "$node_dir" -path '*/bin/npm' -print -quit 2>/dev/null)"
+          if [ -z "$node_bin" ]; then
+            return 1
+          fi
+          node_runtime_bin="$(dirname "$node_bin")"
+          mkdir -p "$HOME/.local/bin"
+          ln -sf "$node_runtime_bin/node" "$HOME/.local/bin/node" 2>/dev/null || true
+          ln -sf "$node_runtime_bin/npm" "$HOME/.local/bin/npm" 2>/dev/null || true
+          ln -sf "$node_runtime_bin/npx" "$HOME/.local/bin/npx" 2>/dev/null || true
+          export PATH="$HOME/.local/bin:$node_runtime_bin:$PATH"
+        }}
+        fetch_archive() {{
+          current="$1"
+          explicit_url="$2"
+          basename="$3"
+          tmp_pattern="$4"
+          if [ -f "$current" ]; then
+            printf '%s\n' "$current"
+            return 0
+          fi
+          url="$explicit_url"
+          if [ -z "$url" ] && [ -n "$wheel_url" ] && [ -n "$basename" ]; then
+            url="${{wheel_url%/}}/$basename"
+          fi
+          if [ -z "$url" ]; then
+            printf '%s\n' "$current"
+            return 0
+          fi
+          downloaded="$(mktemp "$tmp_pattern")"
+          if download_file "$url" "$downloaded" >/dev/null 2>&1 \
+            && [ -s "$downloaded" ]; then
+            printf '%s\n' "$downloaded"
+          else
+            printf '%s\n' "$current"
+          fi
+        }}
+        tool_tgz="$(fetch_archive "$tool_tgz" "$tool_tgz_url" \
+          "$tool_tgz_basename" /tmp/tb-tool-XXXXXX.tgz)"
+        if [ -n "$platform_tgz" ] || [ -n "$platform_tgz_url" ] \
+          || [ -n "$platform_tgz_basename" ]; then
+          platform_tgz="$(fetch_archive "$platform_tgz" "$platform_tgz_url" \
+            "$platform_tgz_basename" /tmp/tb-platform-XXXXXX.tgz)"
+        fi
+        mkdir -p "$HOME/.local/bin"
+        node_tgz="$wheel_dir/node-runtime.tar.xz"
+        if ! command -v npm >/dev/null 2>&1 && [ -f "$node_tgz" ]; then
+          node_dir="$(mktemp -d /tmp/tb-node-XXXXXX)"
+          if extract_archive "$node_tgz" "$node_dir"; then
+            activate_node_runtime "$node_dir" || true
+          fi
+        fi
+        if ! command -v npm >/dev/null 2>&1 && [ -n "$node_dist_url" ]; then
+          node_dist_tgz="$(mktemp /tmp/tb-node-dist-XXXXXX.tgz)"
+          if download_file "$node_dist_url" "$node_dist_tgz" && [ -s "$node_dist_tgz" ]; then
+            node_dir="$(mktemp -d /tmp/tb-node-XXXXXX)"
+            if extract_archive "$node_dist_tgz" "$node_dir"; then
+              activate_node_runtime "$node_dir" || true
+            fi
+          fi
+        fi
+        if ! command -v npm >/dev/null 2>&1; then
+          if command -v apt-get >/dev/null 2>&1; then
+            apt-get -o Acquire::ForceIPv4=true update -qq
+            apt-get -o Acquire::ForceIPv4=true install -y -qq nodejs npm
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache nodejs npm bash curl
+          elif command -v yum >/dev/null 2>&1; then
+            yum install -y nodejs npm
+          fi
+        fi
+        npm config set prefix "$HOME/.local" >/dev/null 2>&1 || true
+        tool_check() {{
+          hash -r 2>/dev/null || true
+          for attempt in 1 2 3; do
+            if command -v "$tool_executable" >/dev/null 2>&1 \
+              && "$tool_executable" --version; then
+              return 0
+            fi
+            sleep 1
+          done
+          return 1
+        }}
+        use_platform_archive=0
+        if [ -n "$platform_tgz" ] \
+          && [ "$(uname -m 2>/dev/null)" = "x86_64" ] \
+          && command -v ldd >/dev/null 2>&1 \
+          && ldd --version 2>&1 | grep -qi 'glibc\|GNU libc' \
+          && [ -f "$platform_tgz" ]; then
+          use_platform_archive=1
+        fi
+        tool_installed=0
+        if command -v npm >/dev/null 2>&1 && [ -f "$tool_tgz" ]; then
+          if [ -d "$npm_cache_dir" ]; then
+            npm_cache_tmp="$(mktemp -d /tmp/tb-npm-cache-XXXXXX)"
+            if cp -a "$npm_cache_dir"/. "$npm_cache_tmp"/; then
+              if [ "$use_platform_archive" = 1 ]; then
+                npm install -g --offline --cache "$npm_cache_tmp" \
+                  "$tool_tgz" "$platform_tgz" && tool_check \
+                  && tool_installed=1 || true
+              else
+                npm install -g --offline --cache "$npm_cache_tmp" \
+                  "$tool_tgz" && tool_check && tool_installed=1 || true
+              fi
+            fi
+          fi
+          if [ "$tool_installed" != 1 ]; then
+            if [ "$use_platform_archive" = 1 ]; then
+              npm install -g "$tool_tgz" "$platform_tgz" && tool_check \
+                && tool_installed=1 || true
+            else
+              npm install -g "$tool_tgz" && tool_check && tool_installed=1 || true
+            fi
+          fi
+        fi
+        if [ "$tool_installed" != 1 ]; then
+          if [ -n "$npm_registry" ]; then
+            NPM_CONFIG_REGISTRY="$npm_registry" \
+              npm install -g {registry_spec}
+          else
+            npm install -g {registry_spec}
+          fi
+          tool_check
+        fi
+        """
+    ).lstrip()
+
+
+def build_python_dependencies_command(
+    modules: tuple[str, ...],
+    *,
+    wheel_dir: str,
+    wheel_url: str,
+) -> str:
+    wheel_dir_q = shlex.quote(wheel_dir)
+    wheel_url_q = shlex.quote(wheel_url)
+    modules_repr = repr(tuple(modules))
+    return textwrap.dedent(
+        rf"""
+        set -euo pipefail
+        py_bin=""
+        for candidate in /opt/python3.12-runtime/bin/python3.12 python3.12 python3; do
+          ([ -x "$candidate" ] || command -v "$candidate" >/dev/null 2>&1) \
+            || continue
+          "$candidate" - <<'PY' >/dev/null 2>&1 || continue
+        import sys
+        print(sys.version)
+        PY
+          py_bin="$candidate"
+          break
+        done
+        if [ -z "$py_bin" ]; then
+          echo '[WARN] python missing for hook dependencies' >&2
+          exit 1
+        fi
+        wheel_dir={wheel_dir_q}
+        wheel_url={wheel_url_q}
+        missing=$("$py_bin" - <<'PY'
+        import importlib.util
+        mods = {modules_repr}
+        print(' '.join(module for module in mods if importlib.util.find_spec(module) is None))
+        PY
+        )
+        if [ -z "$missing" ]; then
+          exit 0
+        fi
+        export PIP_BREAK_SYSTEM_PACKAGES=1
+        pip_opts=""
+        if [ -d "$wheel_dir" ]; then
+          pip_opts="--no-index --find-links $wheel_dir"
+        elif [ -n "$wheel_url" ]; then
+          trusted_host="$(printf %s "$wheel_url" \
+            | sed -E 's#^https?://([^/:]+).*#\\1#')"
+          pip_opts="--trusted-host $trusted_host --no-index --find-links $wheel_url"
+        fi
+        run_get_pip() {{
+          get_pip="$1"
+          "$py_bin" "$get_pip" --user $pip_opts pip setuptools wheel \
+            >/dev/null 2>&1 \
+            || "$py_bin" "$get_pip" --break-system-packages $pip_opts \
+              pip setuptools wheel >/dev/null 2>&1 \
+            || true
+        }}
+        if ! "$py_bin" -m pip --version >/dev/null 2>&1; then
+          if [ -f "$wheel_dir/get-pip.py" ]; then
+            run_get_pip "$wheel_dir/get-pip.py"
+          elif [ -n "$wheel_url" ]; then
+            tmp_get_pip="$(mktemp /tmp/get-pip-XXXXXX.py)"
+            if command -v curl >/dev/null 2>&1; then
+              curl -fsSL "${{wheel_url%/}}/get-pip.py" -o "$tmp_get_pip"
+            elif command -v wget >/dev/null 2>&1; then
+              wget -qO "$tmp_get_pip" "${{wheel_url%/}}/get-pip.py"
+            elif command -v python3 >/dev/null 2>&1; then
+              python3 - "${{wheel_url%/}}/get-pip.py" "$tmp_get_pip" \
+                <<'PY' >/dev/null 2>&1 || true
+        import sys, urllib.request
+        urllib.request.urlretrieve(sys.argv[1], sys.argv[2])
+        PY
+            fi
+            if [ -s "$tmp_get_pip" ]; then
+              run_get_pip "$tmp_get_pip"
+            fi
+            rm -f "$tmp_get_pip"
+          fi
+        fi
+        break_opt=""
+        if "$py_bin" -m pip install --help 2>/dev/null \
+          | grep -q -- '--break-system-packages'; then
+          break_opt="--break-system-packages"
+        fi
+        "$py_bin" -m pip install --retries 10 --timeout 120 \
+          $break_opt --ignore-installed $pip_opts $missing \
+          || "$py_bin" -m pip install --retries 10 --timeout 120 \
+            --ignore-installed $pip_opts $missing \
+          || "$py_bin" -m pip install --retries 10 --timeout 120 \
+            --user --ignore-installed $pip_opts $missing \
+          || "$py_bin" -m pip install --retries 10 --timeout 120 \
+            $break_opt --ignore-installed $missing \
+          || "$py_bin" -m pip install --retries 10 --timeout 120 \
+            --user --ignore-installed $missing \
+          || {{ echo '[WARN] failed to install python hook dependencies' >&2; exit 1; }}
+        """
+    ).lstrip()

--- a/Agents/utils/common/Harbor/tests/test_container_bootstrap.py
+++ b/Agents/utils/common/Harbor/tests/test_container_bootstrap.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HARBOR_RUNTIME_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HARBOR_RUNTIME_DIR))
+try:
+    import container_bootstrap
+finally:
+    sys.path.remove(str(HARBOR_RUNTIME_DIR))
+
+
+def assert_valid_bash(test: unittest.TestCase, command: str) -> None:
+    result = subprocess.run(
+        ["bash", "-n"],
+        input=command,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    test.assertEqual(result.returncode, 0, result.stderr)
+
+
+class ContainerBootstrapImportTest(unittest.TestCase):
+    def test_shared_module_is_importable_from_harbor_runtime_path(self) -> None:
+        sys.path.insert(0, str(HARBOR_RUNTIME_DIR))
+        try:
+            spec = importlib.util.find_spec("container_bootstrap")
+        finally:
+            sys.path.remove(str(HARBOR_RUNTIME_DIR))
+
+        self.assertIsNotNone(spec)
+
+    def test_shared_module_exposes_bootstrap_builders(self) -> None:
+        sys.path.insert(0, str(HARBOR_RUNTIME_DIR))
+        try:
+            import container_bootstrap
+        finally:
+            sys.path.remove(str(HARBOR_RUNTIME_DIR))
+
+        self.assertTrue(hasattr(container_bootstrap, "NpmToolSpec"))
+        self.assertTrue(hasattr(container_bootstrap, "build_python_runtime_command"))
+        self.assertTrue(hasattr(container_bootstrap, "build_npm_tool_install_command"))
+        self.assertTrue(
+            hasattr(container_bootstrap, "build_python_dependencies_command")
+        )
+
+
+class PythonRuntimeCommandTest(unittest.TestCase):
+    def test_prefers_valid_python312_cache_before_ipv4_package_fallback(self) -> None:
+        command = container_bootstrap.build_python_runtime_command(
+            "/opt/tb wheels"
+        )
+
+        self.assertIn("python3.12-runtime.tar.gz", command)
+        self.assertIn("tar -xzf", command)
+        self.assertIn("/opt/python3.12-runtime/bin/python3.12", command)
+        self.assertIn("Acquire::ForceIPv4=true", command)
+        self.assertIn("rm -f /usr/local/bin/python3 /usr/local/bin/python3.12", command)
+        self.assertLess(
+            command.index("python3.12-runtime.tar.gz"),
+            command.index("apt-get"),
+        )
+        self.assertIn("wheel_dir='/opt/tb wheels'", command)
+        assert_valid_bash(self, command)
+
+
+class NpmToolInstallCommandTest(unittest.TestCase):
+    def test_uses_shared_node_cache_offline_npm_and_ipv4_fallback(self) -> None:
+        spec = container_bootstrap.NpmToolSpec(
+            executable="claude",
+            package="@anthropic-ai/claude-code",
+            version="2.1.90",
+            archive_path="/opt/tb-opik/claude-code.tgz",
+            archive_url="https://cache.example/claude-code.tgz",
+            archive_basename="claude-code.tgz",
+            npm_cache_dir="/opt/tb-opik/python-wheels/npm-cache",
+            npm_registry="https://registry.example",
+        )
+
+        command = container_bootstrap.build_npm_tool_install_command(
+            spec,
+            wheel_dir="/opt/tb-opik/python-wheels",
+            wheel_url="https://cache.example/wheels",
+            node_dist_url="https://cache.example/node.tar.gz",
+        )
+
+        self.assertIn("download_file()", command)
+        self.assertIn("extract_archive()", command)
+        self.assertIn('if extract_archive "$node_tgz" "$node_dir"; then', command)
+        self.assertIn(
+            'if download_file "$node_dist_url" "$node_dist_tgz" '
+            '&& [ -s "$node_dist_tgz" ]; then',
+            command,
+        )
+        self.assertIn("Acquire::ForceIPv4=true", command)
+        self.assertIn('cp -a "$npm_cache_dir"/. "$npm_cache_tmp"/', command)
+        self.assertIn('npm install -g --offline --cache "$npm_cache_tmp"', command)
+        self.assertIn("@anthropic-ai/claude-code@2.1.90", command)
+        self.assertLess(
+            command.index('npm install -g "$tool_tgz"'),
+            command.index("@anthropic-ai/claude-code@2.1.90"),
+        )
+        assert_valid_bash(self, command)
+
+    def test_supports_platform_archive_for_opencode(self) -> None:
+        spec = container_bootstrap.NpmToolSpec(
+            executable="opencode",
+            package="opencode-ai",
+            version="1.2.3",
+            archive_path="/cache/opencode-ai-1.2.3.tgz",
+            archive_basename="opencode-ai-1.2.3.tgz",
+            platform_archive_path="/cache/opencode-linux-x64-1.2.3.tgz",
+            platform_archive_basename="opencode-linux-x64-1.2.3.tgz",
+            npm_cache_dir="/cache/npm-cache",
+        )
+
+        command = container_bootstrap.build_npm_tool_install_command(
+            spec,
+            wheel_dir="/cache",
+            wheel_url="",
+            node_dist_url="",
+        )
+
+        self.assertIn("use_platform_archive=0", command)
+        self.assertIn("uname -m", command)
+        self.assertIn("glibc\\|GNU libc", command)
+        self.assertIn('npm install -g "$tool_tgz" "$platform_tgz"', command)
+        assert_valid_bash(self, command)
+
+
+class PythonDependenciesCommandTest(unittest.TestCase):
+    def test_handles_pep668_get_pip_sources_and_network_retries(self) -> None:
+        command = container_bootstrap.build_python_dependencies_command(
+            ("opik", "uuid6", "socksio"),
+            wheel_dir="/opt/tb-opik/python-wheels",
+            wheel_url="https://cache.example/wheels",
+        )
+        normalized = " ".join(command.replace("\\\n", "").split())
+
+        self.assertIn("mods = ('opik', 'uuid6', 'socksio')", command)
+        self.assertIn("export PIP_BREAK_SYSTEM_PACKAGES=1", command)
+        self.assertIn("$wheel_dir/get-pip.py", command)
+        self.assertIn("command -v curl", command)
+        self.assertIn("command -v wget", command)
+        self.assertIn("urllib.request.urlretrieve", command)
+        self.assertIn("--user $pip_opts pip setuptools wheel", normalized)
+        self.assertIn(
+            "--break-system-packages $pip_opts pip setuptools wheel", normalized
+        )
+        self.assertIn("pip install --help", command)
+        self.assertIn("--retries 10 --timeout 120", command)
+        assert_valid_bash(self, command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Claude Code and OpenCode each embedded hundreds of lines of container-bootstrap shell for Python, Node, npm packages/caches, and pip hook dependencies. The copies had drifted, so fixes such as PEP 668 handling, pip retries, IPv4 apt options, and get-pip fallbacks were not applied consistently.

## 2. Summary of the change

- Add `Agents/utils/common/Harbor/container_bootstrap.py` as the shared shell-builder boundary.
- Configure the shared npm installer for Claude Code and OpenCode while keeping their existing orchestration, tracing gates, and retry policies.
- Unify cached Python 3.12, Node runtime, npm tgz/offline cache, PEP 668, pip retry, and get-pip fallback behavior.
- Add generated-shell syntax and caller regression coverage, and document the shared ownership boundary.

## 3. Other details

Verification:

- `python3 -m unittest Agents/utils/common/Harbor/tests/test_container_bootstrap.py Agents/Harbor-claude-code/tests/test_sitecustomize.py Agents/Harbor-opencode/tests/test_trace_disabled.py` (26 passed, 1 optional Harbor dependency skip)
- `uvx ruff@0.16.0 check --config .github/ruff.toml ...` on all touched Python files
- `python3 -m py_compile` on the three production modules
- `git diff --check`

The broader common-Harbor discovery suite is not a clean local gate on this macOS/Python 3.14 host because of existing environment dependencies and Linux assumptions including PyYAML, `flock`, `/proc`, and local socket access. The affected focused suites pass.

Superpowers plans/specs are intentionally excluded from this PR.