### PR TITLE
fix(qz): shape sandbox creation across workers

### DIFF
--- a/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
+++ b/Agents/utils/common/Harbor/QZ_SANDBOX_README.md
@@ -80,6 +80,16 @@ Scale up the worker count after a single task passes. The launcher accepts
 `AGENT=oracle` (reference solutions), `AGENT=claude-code`, and
 `AGENT=opencode` (real agents) on qz.
 
+QZ create traffic is shaped automatically. Benchmark users choose only the
+normal worker count: the adapter keeps at most 10 `Sandbox.create` calls in
+flight across all local worker processes, releases each slot as soon as one
+create returns, and continues until the requested workers are active. This
+does not cap active task concurrency. `QZ_CREATE_CONCURRENCY` is an
+operator-only override for deployments where QZ has confirmed a different
+safe create window, for example after adding nodes to the type group. It is
+not a fleet CLI or task setting, and normal benchmark runs need no additional
+configuration.
+
 The same OpenCode run is available through the repository-level fleet entry
 point; the backend, key, and current Template come from `config.local.env`:
 
@@ -174,7 +184,7 @@ exactly this loop (oracle reward 1.0 in ~6 s, pi reward 1.0 in ~47 s against
 | --- | --- |
 | `template 'xxx' not found` | Name misspelled, or the Template is bound to a different key |
 | `Timeout cannot be greater than 4 hours` | Lower `QZ_SANDBOX_TIMEOUT_SEC` to 14400 or below |
-| `No available resources` | Platform pool is full; retry later, contact the platform if it persists |
+| `No available resources` | The pool may be full, or external create traffic may exceed the type group's instantaneous create window. Agent Fleet shapes its own create calls automatically; contact QZ if the error persists. |
 | Connection timeout / DNS failure | The machine is not on the SII internal network |
 | 401 | The key is invalid or deleted; check the「Sandbox Key」page |
 

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -19,6 +19,7 @@ Agents/utils/common/Harbor/
 ├── harboropik.sh               # Harbor CLI orchestration with Opik setup
 ├── harbor_shell_utils.py       # Event, JSON, URL, and mount helpers
 ├── qz_repository_environment_plan.py # Repository/revision final-image plan producer
+├── qz_create_limiter.py       # Runner-wide rolling QZ Sandbox create window
 ├── qz_task_instruction.py      # Exact QZ setup-prefix handoff before agent run
 ├── prepare_local_deps.sh       # Thin Python launcher
 ├── prepare_local_deps.py       # Package/cache preparation implementation
@@ -174,6 +175,7 @@ Typical dataset paths:
 | `HARBOR_REMOTE_WHEEL_SERVER_URLS` | Comma-separated fallback dependency cache URLs |
 | `HARBOR_SKIP_DOCKERHUB_PREFLIGHT` | Skip Docker Hub preflight connectivity check |
 | `HARBOR_FORCE_BUILD` | Build task images locally instead of using prebuilt images |
+| `QZ_CREATE_CONCURRENCY` | Operator-only override for the runner-wide QZ Sandbox create window; defaults to `10` and does not limit active task concurrency |
 | `HARBOR_TIMEOUT_MULTIPLIER` | General Harbor timeout multiplier |
 | `HARBOR_AGENT_TIMEOUT_MULTIPLIER` | Agent execution timeout override |
 | `HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER` | Agent setup timeout multiplier |

--- a/Agents/utils/common/Harbor/qz_create_limiter.py
+++ b/Agents/utils/common/Harbor/qz_create_limiter.py
@@ -6,6 +6,7 @@ import asyncio
 import fcntl
 import hashlib
 import os
+import random
 import tempfile
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -13,7 +14,9 @@ from pathlib import Path
 from typing import TextIO
 
 QZ_DEFAULT_CREATE_CONCURRENCY = 10
-_LOCK_POLL_INTERVAL_SEC = 0.02
+_LOCK_POLL_INITIAL_SEC = 0.02
+_LOCK_POLL_MAX_SEC = 0.25
+_LOCK_POLL_JITTER_RATIO = 0.2
 
 
 def qz_create_concurrency(environ: Mapping[str, str] = os.environ) -> int:
@@ -60,6 +63,11 @@ def _try_lock_slot(path: Path) -> TextIO | None:
     return handle
 
 
+def _jittered_poll_delay(backoff_sec: float) -> float:
+    spread = backoff_sec * _LOCK_POLL_JITTER_RATIO
+    return random.uniform(backoff_sec - spread, backoff_sec + spread)
+
+
 @asynccontextmanager
 async def qz_create_slot(
     api_url: str,
@@ -76,6 +84,7 @@ async def qz_create_slot(
     lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     handle: TextIO | None = None
     slot = -1
+    poll_backoff_sec = _LOCK_POLL_INITIAL_SEC
     try:
         while handle is None:
             for candidate in range(concurrency):
@@ -87,7 +96,11 @@ async def qz_create_slot(
                     slot = candidate
                     break
             if handle is None:
-                await asyncio.sleep(_LOCK_POLL_INTERVAL_SEC)
+                await asyncio.sleep(_jittered_poll_delay(poll_backoff_sec))
+                poll_backoff_sec = min(
+                    poll_backoff_sec * 2,
+                    _LOCK_POLL_MAX_SEC,
+                )
         yield slot
     finally:
         if handle is not None:

--- a/Agents/utils/common/Harbor/qz_create_limiter.py
+++ b/Agents/utils/common/Harbor/qz_create_limiter.py
@@ -1,0 +1,95 @@
+"""Runner-wide admission control for QZ Sandbox creation."""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import hashlib
+import os
+import tempfile
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import TextIO
+
+QZ_DEFAULT_CREATE_CONCURRENCY = 10
+_LOCK_POLL_INTERVAL_SEC = 0.02
+
+
+def qz_create_concurrency(environ: Mapping[str, str] = os.environ) -> int:
+    """Return the operator-controlled create window, defaulting to 10."""
+    raw = environ.get("QZ_CREATE_CONCURRENCY", "").strip()
+    if not raw:
+        return QZ_DEFAULT_CREATE_CONCURRENCY
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError("QZ_CREATE_CONCURRENCY must be a positive integer") from None
+    if value <= 0:
+        raise ValueError("QZ_CREATE_CONCURRENCY must be a positive integer")
+    return value
+
+
+def _runner_runtime_root(environ: Mapping[str, str]) -> Path:
+    configured = (
+        environ.get("XDG_RUNTIME_DIR", "").strip()
+        or environ.get("AGENT_FLEET_RUNTIME_DIR", "").strip()
+    )
+    if configured:
+        return Path(configured)
+    return Path(tempfile.gettempdir()) / f"agent-fleet-qz-{os.getuid()}"
+
+
+def qz_create_lock_dir(
+    api_url: str,
+    environ: Mapping[str, str] = os.environ,
+) -> Path:
+    """Return one runner-global lock directory without exposing credentials."""
+    endpoint = api_url.strip().rstrip("/")
+    digest = hashlib.sha256(endpoint.encode("utf-8")).hexdigest()[:20]
+    return _runner_runtime_root(environ) / "agent-fleet" / "qz-create-slots" / digest
+
+
+def _try_lock_slot(path: Path) -> TextIO | None:
+    handle = path.open("a+")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        handle.close()
+        return None
+    return handle
+
+
+@asynccontextmanager
+async def qz_create_slot(
+    api_url: str,
+    environ: Mapping[str, str] = os.environ,
+) -> AsyncIterator[int]:
+    """Acquire one rolling QZ create slot shared by local worker processes.
+
+    The file descriptor remains open only while ``AsyncSandbox.create`` is in
+    flight. ``flock`` releases automatically if a worker exits, and polling
+    with non-blocking locks keeps Harbor's asyncio loop responsive.
+    """
+    concurrency = qz_create_concurrency(environ)
+    lock_dir = qz_create_lock_dir(api_url, environ)
+    lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    handle: TextIO | None = None
+    slot = -1
+    try:
+        while handle is None:
+            for candidate in range(concurrency):
+                candidate_handle = _try_lock_slot(
+                    lock_dir / f"slot-{candidate:04d}.lock"
+                )
+                if candidate_handle is not None:
+                    handle = candidate_handle
+                    slot = candidate
+                    break
+            if handle is None:
+                await asyncio.sleep(_LOCK_POLL_INTERVAL_SEC)
+        yield slot
+    finally:
+        if handle is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            handle.close()

--- a/Agents/utils/common/Harbor/qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/qz_e2b_sandbox.py
@@ -13,7 +13,9 @@ and reuses the complete E2B environment implementation.
 Verified end to end against the live service (2026-08-13, template
 ``agent_fleet_probe``): create, get_info, exec with cwd/env/user overrides,
 file write/read round-trip, and kill all pass through the official SDK with
-the mappings below. The qz-specific deltas:
+the mappings below. A later capacity probe verified 100 simultaneously active
+Sandboxes when create requests used the platform-confirmed rolling window of
+10. The qz-specific deltas:
 
 - ``POST /v1/sandboxes`` accepts E2B ``NewSandbox`` bodies; ``templateID`` is
   required. Templates are registered on the platform (image + spec + key
@@ -28,6 +30,12 @@ the mappings below. The qz-specific deltas:
   the ``sbx-`` prefix and does not consume ``hostTemplate``; the unprefixed
   host lands on the platform gateway's own auth (401), so ``get_host`` is
   patched here.
+- One current QZ type group has a single node that accepts at most 10
+  simultaneous create requests and rejects excess requests instead of queuing
+  them. A runner-wide file-backed rolling window shapes create traffic without
+  limiting the number of already-active Sandboxes. Operators can raise
+  ``QZ_CREATE_CONCURRENCY`` after QZ confirms additional create capacity;
+  benchmark users only select their normal worker count.
 """
 
 from __future__ import annotations
@@ -42,6 +50,7 @@ from harbor.environments.capabilities import (
     EnvironmentResourceCapabilities,
 )
 from harbor.environments.e2b import E2BEnvironment
+from qz_create_limiter import qz_create_concurrency, qz_create_slot
 from qz_template_resolver import (
     MAPPING_ENV_VAR,
     QzTemplateResolutionError,
@@ -335,20 +344,22 @@ class QzSandboxEnvironment(E2BEnvironment):
         timeout_sec = qz_sandbox_timeout_sec()
         # Pass the qz connection explicitly so sandbox creation is immune to
         # ambient E2B_* values on a mixed-provider host.
-        return await AsyncSandbox.create(
-            template=self._template_name,
-            api_key=os.environ.get("E2B_API_KEY") or None,
-            api_url=os.environ.get("E2B_API_URL") or None,
-            metadata={
-                "environment_name": self.environment_name,
-                "session_id": self.session_id,
-            },
-            timeout=timeout_sec,
-            allow_internet_access=(
-                self.network_policy.network_mode != NetworkMode.NO_NETWORK
-            ),
-            network=self._sandbox_create_network_options(),
-        )
+        api_url = os.environ.get("E2B_API_URL", "")
+        async with qz_create_slot(api_url):
+            return await AsyncSandbox.create(
+                template=self._template_name,
+                api_key=os.environ.get("E2B_API_KEY") or None,
+                api_url=api_url or None,
+                metadata={
+                    "environment_name": self.environment_name,
+                    "session_id": self.session_id,
+                },
+                timeout=timeout_sec,
+                allow_internet_access=(
+                    self.network_policy.network_mode != NetworkMode.NO_NETWORK
+                ),
+                network=self._sandbox_create_network_options(),
+            )
 
     async def _create_sandbox(self) -> None:
         self._sandbox = await self._allocate_sandbox()
@@ -408,5 +419,9 @@ class QzSandboxEnvironment(E2BEnvironment):
                 ) from exc
         try:
             qz_sandbox_timeout_sec()
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+        try:
+            qz_create_concurrency()
         except ValueError as exc:
             raise SystemExit(str(exc)) from exc

--- a/Agents/utils/common/Harbor/tests/test_qz_create_limiter.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_create_limiter.py
@@ -9,10 +9,12 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 HARBOR_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(HARBOR_DIR))
 
+import qz_create_limiter as limiter  # noqa: E402
 from qz_create_limiter import (  # noqa: E402
     qz_create_concurrency,
     qz_create_lock_dir,
@@ -97,6 +99,40 @@ class QzCreateLimiterTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temporary:
             asyncio.run(exercise(temporary))
+
+    def test_contention_uses_jittered_exponential_backoff(self):
+        class StopPolling(Exception):
+            pass
+
+        delays: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            delays.append(delay)
+            if len(delays) == 5:
+                raise StopPolling
+
+        async def exercise(runtime_dir: str) -> None:
+            environ = {
+                "XDG_RUNTIME_DIR": runtime_dir,
+                "QZ_CREATE_CONCURRENCY": "1",
+            }
+            async with qz_create_slot("https://qz.example/v1", environ):
+                self.fail("slot unexpectedly acquired")
+
+        with (
+            tempfile.TemporaryDirectory() as temporary,
+            patch.object(limiter, "_try_lock_slot", return_value=None),
+            patch.object(
+                limiter.random,
+                "uniform",
+                side_effect=lambda lower, upper: (lower + upper) / 2,
+            ),
+            patch.object(limiter.asyncio, "sleep", new=fake_sleep),
+            self.assertRaises(StopPolling),
+        ):
+            asyncio.run(exercise(temporary))
+
+        self.assertEqual(delays, [0.02, 0.04, 0.08, 0.16, 0.25])
 
     def test_slot_is_shared_across_worker_processes(self):
         worker = textwrap.dedent(

--- a/Agents/utils/common/Harbor/tests/test_qz_create_limiter.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_create_limiter.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+HARBOR_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HARBOR_DIR))
+
+from qz_create_limiter import (  # noqa: E402
+    qz_create_concurrency,
+    qz_create_lock_dir,
+    qz_create_slot,
+)
+
+
+class QzCreateLimiterTest(unittest.TestCase):
+    def test_concurrency_defaults_to_ten_and_accepts_operator_override(self):
+        self.assertEqual(qz_create_concurrency({}), 10)
+        self.assertEqual(qz_create_concurrency({"QZ_CREATE_CONCURRENCY": "40"}), 40)
+
+    def test_concurrency_rejects_invalid_values(self):
+        for value in ("nope", "0", "-1", "1.5"):
+            with self.subTest(value=value), self.assertRaisesRegex(
+                ValueError,
+                "positive integer",
+            ):
+                qz_create_concurrency({"QZ_CREATE_CONCURRENCY": value})
+
+    def test_lock_directory_is_shared_across_runs_on_one_runner(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            first = qz_create_lock_dir(
+                "https://qz.example/v1",
+                {
+                    "XDG_RUNTIME_DIR": temporary,
+                    "OUTPUT_PATH": "/runs/first",
+                    "RUNTIME_DIR": "/runs/first/runtime",
+                },
+            )
+            second = qz_create_lock_dir(
+                "https://qz.example/v1/",
+                {
+                    "XDG_RUNTIME_DIR": temporary,
+                    "OUTPUT_PATH": "/runs/second",
+                    "RUNTIME_DIR": "/runs/second/runtime",
+                },
+            )
+
+        self.assertEqual(first, second)
+
+    def test_rolling_window_caps_async_create_calls(self):
+        async def exercise(runtime_dir: str) -> int:
+            active = 0
+            maximum = 0
+            environ = {
+                "XDG_RUNTIME_DIR": runtime_dir,
+                "QZ_CREATE_CONCURRENCY": "3",
+            }
+
+            async def create_one() -> None:
+                nonlocal active, maximum
+                async with qz_create_slot("https://qz.example/v1", environ):
+                    active += 1
+                    maximum = max(maximum, active)
+                    await asyncio.sleep(0.03)
+                    active -= 1
+
+            await asyncio.gather(*(create_one() for _ in range(12)))
+            return maximum
+
+        with tempfile.TemporaryDirectory() as temporary:
+            maximum = asyncio.run(exercise(temporary))
+
+        self.assertEqual(maximum, 3)
+
+    def test_slot_is_released_when_create_raises(self):
+        async def exercise(runtime_dir: str) -> None:
+            environ = {
+                "XDG_RUNTIME_DIR": runtime_dir,
+                "QZ_CREATE_CONCURRENCY": "1",
+            }
+            with self.assertRaisesRegex(RuntimeError, "create failed"):
+                async with qz_create_slot("https://qz.example/v1", environ):
+                    raise RuntimeError("create failed")
+
+            async def acquire_again() -> None:
+                async with qz_create_slot("https://qz.example/v1", environ):
+                    pass
+
+            await asyncio.wait_for(acquire_again(), timeout=1)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            asyncio.run(exercise(temporary))
+
+    def test_slot_is_shared_across_worker_processes(self):
+        worker = textwrap.dedent(
+            """
+            import asyncio
+            import json
+            import os
+            import sys
+            import time
+
+            from qz_create_limiter import qz_create_slot
+
+            async def main():
+                started = time.monotonic()
+                async with qz_create_slot("https://qz.example/v1", os.environ):
+                    acquired = time.monotonic()
+                    print(json.dumps({"wait_sec": acquired - started}), flush=True)
+                    await asyncio.sleep(float(sys.argv[1]))
+
+            asyncio.run(main())
+            """
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PYTHONPATH": str(HARBOR_DIR),
+                    "XDG_RUNTIME_DIR": temporary,
+                    "QZ_CREATE_CONCURRENCY": "1",
+                }
+            )
+            first = subprocess.Popen(
+                [sys.executable, "-c", worker, "0.4"],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            second = None
+            try:
+                assert first.stdout is not None
+                first_record = json.loads(first.stdout.readline())
+                second = subprocess.Popen(
+                    [sys.executable, "-c", worker, "0"],
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                second_stdout, second_stderr = second.communicate(timeout=3)
+                first_stdout, first_stderr = first.communicate(timeout=3)
+            finally:
+                for process in (first, second):
+                    if process is not None and process.poll() is None:
+                        process.kill()
+                        process.wait()
+
+        self.assertEqual(first.returncode, 0, first_stderr)
+        self.assertEqual(second.returncode, 0, second_stderr)
+        self.assertEqual(first_stdout, "")
+        second_record = json.loads(second_stdout)
+        self.assertLess(first_record["wait_sec"], 0.2)
+        self.assertGreater(second_record["wait_sec"], 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_qz_e2b_sandbox.py
@@ -185,6 +185,7 @@ def retry_dependency_stubs():
 
 
 QZ_VARS = (
+    "QZ_CREATE_CONCURRENCY",
     "QZ_SANDBOX_API_KEY",
     "QZ_SANDBOX_API_URL",
     "SBX_API_KEY",
@@ -385,6 +386,20 @@ class PreflightTest(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 self.module.QzSandboxEnvironment.preflight()
             self.assertNotIn("E2B_API_KEY", os.environ)
+
+    def test_preflight_rejects_invalid_create_concurrency(self):
+        cleaned = {name: "" for name in QZ_VARS}
+        cleaned.update(
+            {
+                "SBX_API_KEY": "sbx_secret",
+                "QZ_CREATE_CONCURRENCY": "0",
+            }
+        )
+        with (
+            patch.dict(os.environ, cleaned, clear=False),
+            self.assertRaisesRegex(SystemExit, "QZ_CREATE_CONCURRENCY"),
+        ):
+            self.module.QzSandboxEnvironment.preflight()
 
     def test_init_applies_mapping_before_super(self):
         cleaned = {name: "" for name in QZ_VARS}


### PR DESCRIPTION
## 1. Why the change?

QZ confirmed that the affected Sandbox type group currently has one node and accepts at most 10 simultaneous create requests on that node. A create takes about 100 ms; after one request completes, another can be submitted. Excess requests are rejected rather than queued ([QZ response](https://github.com/sii-system/tasks/issues/160#issuecomment-5390199888)).

Agent Fleet starts one Harbor worker process per worker, so `workers=20` or `workers=40` could send all create requests at once. This caused placement failures even though QZ could accumulate substantially more than 10 active Sandboxes.

This client-side admission boundary remains useful if QZ adds nodes. More nodes can raise the safe create window, but the window still depends on current topology, scaling state, and other traffic, while the service does not queue excess requests. Operators can raise the override after QZ confirms the new capacity; benchmark users continue to choose only their normal worker count.

## 2. Summary of the change

- Add a runner-wide, file-backed rolling window around `AsyncSandbox.create`, defaulting to 10 in-flight creates across all local Harbor worker processes.
- Release a slot immediately when each create returns, so successful Sandboxes accumulate to the requested worker count; active task concurrency is not capped at 10.
- Keep the default internal to the QZ adapter. This does not add a fleet CLI flag, FleetSpec field, or normal configuration requirement.
- Allow the operator-only `QZ_CREATE_CONCURRENCY` environment override and validate it during QZ preflight.
- Add unit coverage for the default and override, rolling async behavior, exception release, cross-run sharing, and real cross-process coordination.

## 3. Other details

No-model probes against the existing `agent_fleet_probe` Template established the distinction between create concurrency and active capacity:

- 40 requested: create 40/40, peak active 40, get_info/command/file round-trip/kill 40/40, maximum create in-flight 10.
- 100 requested: create 100/100, peak active 100, get_info/command/file round-trip/kill 100/100, maximum create in-flight 10.

This PR does not broaden create retry behavior, change QZ quotas, create Templates, or consume model tokens.

Validation:

- `ruff 0.16.0 check --config .github/ruff.toml`
- 49 focused Python tests
- `Agents/utils/common/Harbor/tests/test_harboropik_qz.sh`
- Python compile check
- `git diff --check`
