### PR TITLE
Fix Harbor E2E output path

### DIFF
--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -75,7 +75,13 @@ class E2eValidationWorkflowTest(unittest.TestCase):
 
     def test_pins_the_output_path_for_producer_and_consumers(self):
         # A runner-level OUTPUT_ROOT/OUTPUT_PATH would otherwise win via
-        # config_loader.sh and Harbor would write outside runs/$RUN_ID.
+        # config_loader.sh. The path must also stay stable when start.sh changes
+        # into the Harbor script directory before launching Zellij.
+        self.assertIn(
+            "printf 'output_path=%s/runs/%s\\n' \"$GITHUB_WORKSPACE\" \"$RUN_ID\"",
+            self.workflow,
+        )
+        self.assertNotIn("printf 'output_path=runs/%s\\n'", self.workflow)
         self.assertIn(
             "OUTPUT_PATH: ${{ steps.params.outputs.output_path }}",
             self.workflow,

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -98,7 +98,7 @@ jobs:
             printf 'tasks=%s\n' "$tasks"
             printf 'agent=%s\n' "$agent"
             printf 'run_id=%s\n' "$RUN_ID"
-            printf 'output_path=runs/%s\n' "$RUN_ID"
+            printf 'output_path=%s/runs/%s\n' "$GITHUB_WORKSPACE" "$RUN_ID"
           } >> "$GITHUB_OUTPUT"
 
           # The expected trial count guards against task selection silently not


### PR DESCRIPTION
## 1. Why the change?

The Harbor E2E workflow passed a relative `runs/<run-id>` output path into the benchmark. `start.sh` changes into the Harbor script directory before launching the Zellij registry pane, so the child could write its runtime files under a different directory than the health gate and artifact uploader inspect. The scheduled run then reported a missing `summary.txt` with zero trials even though the launcher had started.

Failure evidence: https://github.com/sii-system/agent-fleet/actions/runs/32766699286

## 2. Summary of the change

- Resolve the E2E output path from `GITHUB_WORKSPACE` before passing it to Harbor.
- Add a workflow regression assertion that rejects the relative output path.

## 3. Other details

Verification:

- `python3 -m unittest discover -s .github/scripts/tests` (267 tests)
- `uvx ruff@0.16.0 check --config .github/ruff.toml .github/scripts/tests/test_e2e_validation_workflow.py`
- `git diff --check upstream/main...HEAD`

A self-hosted canary rerun is still needed after merge to validate the real Harbor runtime path.
