### PR TITLE
fix(rollout): add http backlogs and file lock for high concurrency

### DIFF
--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -1128,6 +1128,8 @@ harbor_validate_task_selection() {
 
 harbor_prepare_task_file() {
   mkdir -p "$(dirname "$TASK_FILE")"
+  (
+  flock -x 9
   if [[ -z "$FLEET_TASKS" ]]; then
     if [[ "${RESET_RUN:-0}" == "1" || ! -s "$TASK_FILE" ]]; then
       harbor_generate_task_file
@@ -1158,6 +1160,7 @@ harbor_prepare_task_file() {
   if [[ ! -f "$NEXT_INDEX_FILE" ]]; then
     echo 1 > "$NEXT_INDEX_FILE"
   fi
+  ) 9>"${TASK_FILE}.lock"
 }
 
 harbor_task_count() {

--- a/Agents/utils/common/Harbor/start.sh
+++ b/Agents/utils/common/Harbor/start.sh
@@ -519,6 +519,7 @@ fi
 if [[ $# -gt 0 ]]; then
   if [[ "$ROLLOUT" != "1" ]] && ! harbor_uses_registry_dataset; then
     harbor_prepare_task_file
+    export RESET_RUN=0
   fi
   if [[ "$ROLLOUT" != "1" ]]; then
     harbor_start_online_analysis_if_enabled
@@ -564,6 +565,7 @@ fi
 if [[ "$ROLLOUT" != "1" ]] && ! harbor_uses_registry_dataset; then
   harbor_prepare_task_file
 fi
+export RESET_RUN=0
 if [[ "$ROLLOUT" != "1" ]]; then
   harbor_start_online_analysis_if_enabled
 fi

--- a/Agents/utils/common/Harbor/tests/test_task_selection.py
+++ b/Agents/utils/common/Harbor/tests/test_task_selection.py
@@ -136,6 +136,35 @@ class HarborTaskSelectionTest(unittest.TestCase):
             self.assertIn("unknown task(s): missing-a, missing-b", result.stderr)
             self.assertFalse((output / "tasks.txt").exists())
 
+    def test_concurrent_prepare_generates_task_file_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output, common = self.local_fixture(Path(tmp), "task-a")
+            env = os.environ.copy()
+            env.update(common, FLEET_TASKS="")
+            command = (
+                '. "$1"; mkdir -p "$QUEUE_DIR" "$RUNTIME_DIR"; '
+                "harbor_generate_task_file() { "
+                'echo generate >> "$OUTPUT_PATH/generate.calls"; sleep 0.2; '
+                'echo task-a > "$TASK_FILE"; }; '
+                "harbor_prepare_task_file"
+            )
+            processes = [
+                subprocess.Popen(
+                    ["bash", "-c", command, "bash", str(ENV_SH)],
+                    env=env,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                for _ in range(8)
+            ]
+
+            for process in processes:
+                stdout, stderr = process.communicate(timeout=5)
+                self.assertEqual(process.returncode, 0, stderr or stdout)
+            calls = (output / "generate.calls").read_text(encoding="utf-8")
+            self.assertEqual(calls.splitlines(), ["generate"])
+
     def test_missing_generic_dataset_explains_removed_auto_provisioning(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             _, common = self.local_fixture(Path(tmp))

--- a/Agents/utils/rl/rollout_remote_harbor.py
+++ b/Agents/utils/rl/rollout_remote_harbor.py
@@ -595,6 +595,10 @@ def _wait_result(result_path: Path, timeout: float) -> dict[str, Any]:
     raise TimeoutError(f"timed out waiting for rollout worker result: {result_path}")
 
 
+class RolloutHTTPServer(ThreadingHTTPServer):
+    request_queue_size = 1024
+
+
 class Handler(BaseHTTPRequestHandler):
     server_version = "agent-fleet-rl-rollout/0.2"
 
@@ -749,7 +753,7 @@ def main() -> int:
     for path in (TRACE_LOG.parent, PENDING_DIR, ACTIVE_DIR, RESULTS_DIR):
         path.mkdir(parents=True, exist_ok=True)
     print(f"RL rollout Harbor service listening on {host}:{port}", flush=True)
-    ThreadingHTTPServer((host, port), Handler).serve_forever()
+    RolloutHTTPServer((host, port), Handler).serve_forever()
     return 0
 
 

--- a/Agents/utils/rl/tests/test_rollout_request_context.py
+++ b/Agents/utils/rl/tests/test_rollout_request_context.py
@@ -34,6 +34,9 @@ class RolloutRequestContextTest(unittest.TestCase):
         handler._send_json = mock.Mock()
         return handler
 
+    def test_http_backlog_supports_rollout_burst(self) -> None:
+        self.assertGreaterEqual(MODULE.RolloutHTTPServer.request_queue_size, 300)
+
     def _enqueue_with_temp_context(
         self,
         request: dict[str, object],


### PR DESCRIPTION
## 1. Why the change?

http listen not enough for high concurrency
all workers will try to fetch one not exist file

## 2. Summary of the change 

increase http backlog to 1024 and can config higher
add a lock for file create