### PR TITLE
feat(opensandbox): cache prebuild uploads locally

### DIFF
--- a/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
+++ b/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
@@ -108,10 +108,29 @@ digest ref = <registry>/<project>/<task>@sha256:<artifact-digest>
 
 The `input_hash` is a full SHA-256 calculated before build and the Registry
 `artifact_digest` is collected by an independent `skopeo inspect` after copy.
-The cache authority is the target task repository, not a local record. Each
-Compose service has an independent service tag and artifact resolution. The
-manager does not implement Registry Project management, raw blob
-upload, an old-Registry fallback, or a cross-repository layer index.
+Normal on-demand preparation keeps the target task repository as cache
+authority. Dataset prebuild additionally enables a persistent local
+uploaded-Bundle index under
+`<HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT>/uploaded-bundles/`. Entries are scoped by
+Registry host, Project, benchmark, platform, and normalized task repository.
+They are written only after every service has resolved successfully through the
+Registry path.
+
+On a later prebuild, the default local-cache path parses the current Bundle and
+compares its definition identity and every service's full static environment
+hash before reusing the recorded immutable digest refs. This avoids Registry
+login and manifest inspection. With
+`HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION=1`, a structurally valid
+entry matching the same target and task identity is trusted before task parsing
+or content hashing. That mode deliberately does not prove that the dataset is
+unchanged or that Registry retention has preserved the artifacts. Disable the
+local path with `HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE=0`, remove
+the relevant local entry, or use the manager's `--force` option when Registry
+revalidation/rebuild is required.
+
+Each Compose service has an independent service tag and artifact resolution.
+The manager does not implement Registry Project management, raw blob upload,
+an old-Registry fallback, or a cross-repository layer index.
 
 The current context hash is conservative: generated cache files are ignored,
 but `.dockerignore` is not yet evaluated. This can cause an unnecessary rebuild
@@ -235,4 +254,5 @@ cleanup.
 - Configured domestic Docker and APT mirrors are preferred. Proxy build args
   are forwarded only when explicitly enabled.
 - `--force` bypasses the target-tag cache lookup; it does not change the
-  deterministic tag or the image content identity.
+  deterministic tag or the image content identity. It also bypasses the local
+  uploaded-Bundle index.

--- a/Agents/utils/common/Harbor/OPENSANDBOX_README.md
+++ b/Agents/utils/common/Harbor/OPENSANDBOX_README.md
@@ -150,6 +150,27 @@ bash Agents/utils/common/Harbor/prebuild_opensandbox_dataset.sh \
   /absolute/path/to/Harbor-Dataset seta
 ```
 
+Every successful Registry resolution also updates a target-scoped local
+uploaded-Bundle index under `HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT`. On restart,
+prebuild recomputes each task's static environment hash and, when it still
+matches the local record, skips Registry login and manifest inspection. For a
+stable dataset, hashing can also be skipped:
+
+```bash
+HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION=1 \
+bash Agents/utils/common/Harbor/prebuild_opensandbox_dataset.sh \
+  /absolute/path/to/Harbor-Dataset seta
+```
+
+Fast resume trusts that the recorded Registry artifacts still exist and that
+the task content has not changed. Leave the option at its default `0` to retain
+local hash validation. Set
+`HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE=0` to bypass the local
+index entirely and restore per-task Registry lookup. Fast resume also defers
+configured package-source health probes, so a batch made entirely of local
+hits performs no per-task network request. If a real miss later fails while
+building, the existing health check and trusted-source fallback still run.
+
 Prebuild performs a bounded BuildKit cache prune before starting and every 30
 minutes while it runs. Defaults are `max-used-space=500GB`,
 `min-free-space=300GB`, and `reserved-space=100GB`; all four values are
@@ -160,8 +181,10 @@ BuildKit cache and does not delete images, containers, volumes, or artifacts
 already published to the OCI Registry.
 
 Already published content-addressed images are reused in the task-specific
-repository. Unsupported environment definitions are listed as skipped in the
-prebuild report; unsupported runtime capabilities fail before creation.
+repository, and every current run still gets its per-task Bundle Manifest even
+on a local cache hit. Unsupported environment definitions are listed as
+skipped in the prebuild report; unsupported runtime capabilities fail before
+creation.
 
 ## Troubleshooting
 

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -180,6 +180,8 @@ Typical dataset paths:
 | `HARBOR_OPENSANDBOX_IMAGE_REF` | Legacy explicit single-image override; it must be fully qualified under `YICLOUD_HARBOR_HOST` |
 | `HARBOR_OPENSANDBOX_BUNDLE_MANIFEST` | Optional versioned service Bundle Manifest; every service image must be fully qualified under `YICLOUD_HARBOR_HOST` |
 | `HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT` | H-local Registry records, image locks, build logs, and immutable Bundle cache root |
+| `HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE` | Dataset prebuild local uploaded-Bundle index switch; defaults to `1` and avoids Registry lookup after a content-hash match |
+| `HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION` | Trust a matching target/task entry in the local uploaded-Bundle index without parsing or hashing task content; defaults to `0` |
 | `YICLOUD_HARBOR_HOST` | Required Harbor registry host used for publication and every OpenSandbox image pull; set the real value in `config.local.env` or the environment |
 | `YICLOUD_HARBOR_PROJECT` | Externally provisioned Harbor Project for the selected benchmark; task repositories are derived per task |
 | `YICLOUD_HARBOR_TLS_VERIFY` | Whether `skopeo` verifies the configured Harbor TLS certificate; current internal ingress requires `0` |

--- a/Agents/utils/common/Harbor/opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/opensandbox_image_manager.py
@@ -42,6 +42,8 @@ Each benchmark is a Registry Project and each task has its own repository.
 Deterministic service tags are cache lookup keys; Registry manifest digests are
 the immutable runtime addresses.
 Single-Dockerfile tasks are represented as one implicit ``main`` service.
+Dataset prebuild may additionally trust a persistent local uploaded-Bundle
+index, with an explicit option to skip the otherwise-default content-hash check.
 """
 
 from __future__ import annotations
@@ -141,6 +143,7 @@ OPENSANDBOX_ADAPTER_METADATA: dict[str, dict[str, dict[str, dict[str, object]]]]
     }
 }
 LEGACY_DOCKERFILE_KEEPALIVE = ["sh", "-c", "while :; do sleep 60; done"]
+LOCAL_UPLOAD_INDEX_VERSION = 1
 
 
 def log(message: str) -> None:
@@ -1362,6 +1365,132 @@ def _read_record(path: Path) -> dict[str, object]:
     return loaded if isinstance(loaded, dict) else {}
 
 
+def local_upload_manifest_path(
+    cache_root: Path,
+    target: RegistryTarget,
+    *,
+    benchmark: str,
+    platform: str,
+) -> Path:
+    """Return the persistent, target-scoped uploaded-Bundle index entry."""
+    scope = json.dumps(
+        {
+            "benchmark": benchmark,
+            "platform": platform,
+            "project": target.project,
+            "registry": target.registry,
+            "version": LOCAL_UPLOAD_INDEX_VERSION,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    scope_key = hashlib.sha256(scope).hexdigest()[:20]
+    return (
+        cache_root
+        / "uploaded-bundles"
+        / scope_key
+        / f"{target.task_repository}.json"
+    )
+
+
+def _cached_bundle_matches_target(
+    manifest: dict[str, object],
+    *,
+    target: RegistryTarget,
+    benchmark: str,
+    task_identity: str,
+    platform: str,
+) -> bool:
+    registry = manifest.get("registry")
+    benchmark_record = manifest.get("benchmark")
+    services = manifest.get("services")
+    main = manifest.get("main")
+    if (
+        manifest.get("schema_version") != BUNDLE_SCHEMA_VERSION
+        or manifest.get("bundle_format") != BUNDLE_FORMAT_VERSION
+        or manifest.get("task_identity") != task_identity
+        or not isinstance(registry, dict)
+        or registry.get("host") != target.registry
+        or registry.get("project") != target.project
+        or registry.get("task_repository") != target.task_repository
+        or registry.get("repository") != target.repository
+        or not isinstance(benchmark_record, dict)
+        or benchmark_record.get("name") != benchmark
+        or not isinstance(services, dict)
+        or not services
+        or not isinstance(main, str)
+        or main not in services
+    ):
+        return False
+
+    for service_record in services.values():
+        if not isinstance(service_record, dict):
+            return False
+        image = service_record.get("image")
+        if not isinstance(image, dict) or image.get("platform") != platform:
+            return False
+        artifact_digest = image.get("artifact_digest")
+        input_hash = image.get("input_hash")
+        if (
+            not isinstance(artifact_digest, str)
+            or not re.fullmatch(r"sha256:[0-9a-f]{64}", artifact_digest)
+            or image.get("digest_ref") != target.digest_ref(artifact_digest)
+            or not isinstance(input_hash, str)
+            or not re.fullmatch(r"sha256:[0-9a-f]{64}", input_hash)
+        ):
+            return False
+    return True
+
+
+def _cached_bundle_matches_content(
+    manifest: dict[str, object], bundle: BundleSpec
+) -> bool:
+    if manifest.get("definition_identity") != f"sha256:{bundle.definition_identity}":
+        return False
+    services = manifest.get("services")
+    if not isinstance(services, dict) or set(services) != set(bundle.services):
+        return False
+    for name, service in bundle.services.items():
+        service_record = services.get(name)
+        if not isinstance(service_record, dict):
+            return False
+        image = service_record.get("image")
+        if not isinstance(image, dict):
+            return False
+        docker_image = service.source_image if service.build is None else None
+        expected_hash = "sha256:" + image_identity(
+            bundle.environment_dir, docker_image=docker_image
+        )
+        if image.get("input_hash") != expected_hash:
+            return False
+    return True
+
+
+def _prepared_from_cached_bundle(
+    manifest: dict[str, object],
+    *,
+    cached_path: Path,
+    configured_output: Path | None,
+) -> PreparedBundle:
+    manifest_path = cached_path
+    if configured_output is not None:
+        manifest_path = Path(configured_output).expanduser().resolve()
+        atomic_write_json(manifest_path, manifest)
+    services = manifest.get("services")
+    main = manifest.get("main")
+    if not isinstance(services, dict) or not isinstance(main, str):
+        raise TypeError(f"invalid local uploaded-Bundle entry: {cached_path}")
+    main_record = services.get(main)
+    image = main_record.get("image") if isinstance(main_record, dict) else None
+    if not isinstance(image, dict):
+        raise TypeError(f"invalid local uploaded-Bundle main service: {cached_path}")
+    return PreparedBundle(
+        main_image_ref=str(image["digest_ref"]),
+        manifest=manifest,
+        manifest_path=manifest_path,
+    )
+
+
 def _service_image_inputs(
     service: ServiceSpec,
     *,
@@ -1712,7 +1841,61 @@ def prepare_bundle(args: argparse.Namespace) -> PreparedBundle:
         )
     args.registry = validate_registry_host(args.registry)
     task_dir = resolve_task_dir(args.task_dir, args.dataset_root, args.include)
+    cache_root = args.cache_root.resolve()
+    benchmark = args.benchmark_name or args.project
+    target = RegistryTarget(
+        registry=args.registry,
+        project=args.project,
+        task_repository=args.task_repository or normalize_task_repository(task_dir.name),
+    )
+    reuse_local_upload = bool(getattr(args, "reuse_local_upload_cache", False))
+    skip_hash_verification = bool(getattr(args, "skip_hash_verification", False))
+    upload_manifest_path = local_upload_manifest_path(
+        cache_root,
+        target,
+        benchmark=benchmark,
+        platform=args.platform,
+    )
+    cached_manifest = (
+        _read_record(upload_manifest_path)
+        if reuse_local_upload and not args.force and not args.dry_run
+        else {}
+    )
+    cached_target_matches = bool(cached_manifest) and _cached_bundle_matches_target(
+        cached_manifest,
+        target=target,
+        benchmark=benchmark,
+        task_identity=task_dir.name,
+        platform=args.platform,
+    )
+    configured_output = getattr(args, "bundle_manifest_output", None)
+    if cached_target_matches and skip_hash_verification:
+        log(
+            "local uploaded-Bundle cache hit "
+            f"task={task_dir.name} verification=skipped: {upload_manifest_path}"
+        )
+        return _prepared_from_cached_bundle(
+            cached_manifest,
+            cached_path=upload_manifest_path,
+            configured_output=configured_output,
+        )
+
     bundle = resolve_bundle_spec(task_dir)
+    if cached_target_matches and _cached_bundle_matches_content(cached_manifest, bundle):
+        log(
+            "local uploaded-Bundle cache hit "
+            f"task={task_dir.name} verification=content-hash: {upload_manifest_path}"
+        )
+        return _prepared_from_cached_bundle(
+            cached_manifest,
+            cached_path=upload_manifest_path,
+            configured_output=configured_output,
+        )
+    if cached_manifest and reuse_local_upload and not args.force and not args.dry_run:
+        log(
+            "local uploaded-Bundle cache miss "
+            f"task={task_dir.name}; falling back to Registry resolution"
+        )
     build_network = getattr(args, "build_network", "default")
     args.apt_mirror = validate_apt_mirror(
         getattr(args, "apt_mirror", DEFAULT_APT_MIRROR),
@@ -1723,12 +1906,6 @@ def prepare_bundle(args: argparse.Namespace) -> PreparedBundle:
         args, build_network
     )
     explicit_build_args = parse_build_args(args.build_args_json)
-    cache_root = args.cache_root.resolve()
-    target = RegistryTarget(
-        registry=args.registry,
-        project=args.project,
-        task_repository=args.task_repository or normalize_task_repository(bundle.task_identity),
-    )
     publisher: SkopeoPublisher | None = None
     registry: RegistryClient | None = None
     proxy_args: dict[str, str] = {}
@@ -1771,7 +1948,7 @@ def prepare_bundle(args: argparse.Namespace) -> PreparedBundle:
             bundle.services[name],
             artifacts[name],
             bundle.environment_dir,
-            benchmark=args.benchmark_name or args.project,
+            benchmark=benchmark,
             task_identity=bundle.task_identity,
             definition_kind=bundle.definition_kind,
         )
@@ -1781,7 +1958,7 @@ def prepare_bundle(args: argparse.Namespace) -> PreparedBundle:
     manifest: dict[str, object] = {
         "schema_version": BUNDLE_SCHEMA_VERSION,
         "bundle_format": BUNDLE_FORMAT_VERSION,
-        "benchmark": {"name": args.benchmark_name or args.project},
+        "benchmark": {"name": benchmark},
         "task_identity": bundle.task_identity,
         "registry": {
             "host": target.registry,
@@ -1798,7 +1975,8 @@ def prepare_bundle(args: argparse.Namespace) -> PreparedBundle:
         "requirements": bundle.requirements,
     }
 
-    configured_output = getattr(args, "bundle_manifest_output", None)
+    if reuse_local_upload and not args.dry_run:
+        atomic_write_json(upload_manifest_path, manifest)
     manifest_path: Path | None = None
     if configured_output is not None:
         manifest_path = Path(configured_output).expanduser().resolve()
@@ -1989,6 +2167,24 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--force", action="store_true")
     parser.add_argument(
+        "--reuse-local-upload-cache",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "reuse a target-scoped local record after verifying the current task "
+            "content hash, avoiding a Registry cache lookup"
+        ),
+    )
+    parser.add_argument(
+        "--skip-hash-verification",
+        action="store_true",
+        default=False,
+        help=(
+            "trust a matching local uploaded-Bundle record without hashing task "
+            "content; requires --reuse-local-upload-cache"
+        ),
+    )
+    parser.add_argument(
         "--no-cache",
         action="store_true",
         help="disable BuildKit layer cache for this build without changing image identity",
@@ -2029,6 +2225,10 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         parser.error("--project must be a single Registry Project name")
     if args.task_repository and "/" in args.task_repository:
         parser.error("--task-repository must be a single repository name")
+    if args.skip_hash_verification and not args.reuse_local_upload_cache:
+        parser.error(
+            "--skip-hash-verification requires --reuse-local-upload-cache"
+        )
     return args
 
 

--- a/Agents/utils/common/Harbor/prebuild_opensandbox_dataset.sh
+++ b/Agents/utils/common/Harbor/prebuild_opensandbox_dataset.sh
@@ -54,6 +54,8 @@ HARBOR_OPENSANDBOX_BUILD_NETWORK="${HARBOR_OPENSANDBOX_BUILD_NETWORK:-host}"
 HARBOR_OPENSANDBOX_BUILD_PROXY_URL="${HARBOR_OPENSANDBOX_BUILD_PROXY_URL:-}"
 HARBOR_OPENSANDBOX_PREBUILD_CONCURRENCY="${HARBOR_OPENSANDBOX_PREBUILD_CONCURRENCY:-1}"
 HARBOR_OPENSANDBOX_DRY_RUN="${HARBOR_OPENSANDBOX_DRY_RUN:-0}"
+HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE="${HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE:-1}"
+HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION="${HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION:-0}"
 HARBOR_OPENSANDBOX_PREBUILD_ROOT="${HARBOR_OPENSANDBOX_PREBUILD_ROOT:-/data/harbor-runs/opensandbox-prebuild}"
 HARBOR_OPENSANDBOX_PREBUILD_GC_INTERVAL_SEC="${HARBOR_OPENSANDBOX_PREBUILD_GC_INTERVAL_SEC:-1800}"
 HARBOR_OPENSANDBOX_PREBUILD_GC_MAX_USED_SPACE="${HARBOR_OPENSANDBOX_PREBUILD_GC_MAX_USED_SPACE:-500GB}"
@@ -164,6 +166,19 @@ case "${HARBOR_OPENSANDBOX_DRY_RUN}" in
   0|1) ;;
   *) print_error "[ERROR] HARBOR_OPENSANDBOX_DRY_RUN must be 0 or 1"; exit 1 ;;
 esac
+case "${HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE}" in
+  0|1) ;;
+  *) print_error "[ERROR] HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE must be 0 or 1"; exit 1 ;;
+esac
+case "${HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION}" in
+  0|1) ;;
+  *) print_error "[ERROR] HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION must be 0 or 1"; exit 1 ;;
+esac
+if [[ "${HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION}" == 1 \
+  && "${HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE}" != 1 ]]; then
+  print_error "[ERROR] HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION=1 requires HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE=1"
+  exit 1
+fi
 case "${HARBOR_OPENSANDBOX_APT_MIRROR_PROBE_TIMEOUT_SEC}" in
   ''|*[!0-9]*|0)
     print_error "[ERROR] HARBOR_OPENSANDBOX_APT_MIRROR_PROBE_TIMEOUT_SEC must be a positive integer"
@@ -222,7 +237,12 @@ select_domestic_apt_mirror() {
   return 1
 }
 
-if ! package_sources_healthy; then
+# Fast resume returns from the image manager before package-source validation.
+# Defer health traffic in that mode so a fully local batch performs no network
+# request merely to discover its cache hits. A real cache miss still probes and
+# switches sources through the existing failed-build fallback below.
+if [[ "${HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION}" != 1 ]] \
+  && ! package_sources_healthy; then
   print_warning \
     "[WARN] configured package sources are unavailable; using trusted domestic defaults"
   if ! HARBOR_OPENSANDBOX_APT_MIRROR="$(select_domestic_apt_mirror)"; then
@@ -345,6 +365,17 @@ printf '[prebuild] benchmark=%s supported=%s skipped=%s concurrency=%s dry_run=%
   "${HARBOR_OPENSANDBOX_PREBUILD_CONCURRENCY}" "${HARBOR_OPENSANDBOX_DRY_RUN}"
 printf '[prebuild] registry=%s project=%s (task repositories are derived per task)\n' \
   "${YICLOUD_HARBOR_HOST}" "${YICLOUD_HARBOR_PROJECT}"
+local_upload_hash_verification=disabled
+if [[ "${HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE}" == 1 ]]; then
+  local_upload_hash_verification=enabled
+  if [[ "${HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION}" == 1 ]]; then
+    local_upload_hash_verification=skipped
+  fi
+fi
+printf '[prebuild] local_upload_cache=%s hash_verification=%s cache_root=%s\n' \
+  "$([[ "${HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE}" == 1 ]] && printf enabled || printf disabled)" \
+  "${local_upload_hash_verification}" \
+  "${HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT}"
 printf '[prebuild] package_sources=%s apt_mirror=%s fallback_apt_mirrors=%s\n' \
   "$([[ -n "${HARBOR_OPENSANDBOX_PACKAGE_SOURCE_HEALTH_URL}" ]] && printf configured || printf domestic-defaults)" \
   "${HARBOR_OPENSANDBOX_APT_MIRROR}" \
@@ -379,6 +410,8 @@ export HARBOR_OPENSANDBOX_BUILD_USE_PROXY
 export HARBOR_OPENSANDBOX_BUILD_NETWORK
 export HARBOR_OPENSANDBOX_BUILD_PROXY_URL
 export HARBOR_OPENSANDBOX_DRY_RUN
+export HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE
+export HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION
 export HARBOR_OPENSANDBOX_IMAGE_MANAGER
 export HARBOR_OPENSANDBOX_MANAGER_PYTHON
 export run_dir
@@ -447,10 +480,13 @@ xargs -0 -r -P "${HARBOR_OPENSANDBOX_PREBUILD_CONCURRENCY}" -n 1 \
       )
       [[ "${YICLOUD_HARBOR_TLS_VERIFY}" == 1 ]] && command+=(--registry-tls-verify)
       [[ "${HARBOR_OPENSANDBOX_BUILD_USE_PROXY}" == 1 ]] && command+=(--use-proxy)
+      [[ "${HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE}" == 1 ]] && command+=(--reuse-local-upload-cache)
+      [[ "${HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION}" == 1 ]] && command+=(--skip-hash-verification)
       [[ "${HARBOR_OPENSANDBOX_DRY_RUN}" == 1 ]] && command+=(--dry-run)
     }
     active_apt_mirror="${HARBOR_OPENSANDBOX_APT_MIRROR}"
-    if ! package_sources_healthy; then
+    if [[ "${HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION}" != 1 ]] \
+      && ! package_sources_healthy; then
       if ! active_apt_mirror="$(select_domestic_apt_mirror)"; then
         printf "[prebuild][failed] task=%s configured package sources are unavailable and no trusted domestic APT fallback is reachable\n" \
           "${task_name}" >&2

--- a/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
@@ -79,6 +79,18 @@ class OpenSandboxImageManagerTest(unittest.TestCase):
         self.assertEqual(args.build_timeout_sec, 7200.0)
         self.assertTrue(args.retry_no_cache_on_apt_404)
 
+    def test_skip_hash_verification_requires_local_upload_cache(self) -> None:
+        with patch("sys.stderr", new=io.StringIO()), self.assertRaises(SystemExit):
+            parse_args(
+                [
+                    "--task-dir",
+                    "/tmp/example-task",
+                    "--project",
+                    "test-project",
+                    "--skip-hash-verification",
+                ]
+            )
+
     def test_cli_enables_host_proxy_by_default(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             args = parse_args(
@@ -701,6 +713,119 @@ networks:
             image_ref,
             r"^harbor\.example\.internal/test-project/0@sha256:[0-9a-f]{64}$",
         )
+
+    def test_local_uploaded_bundle_avoids_registry_and_can_skip_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            task = self.make_task(root, "0")
+            cache_root = root / "cache"
+
+            def make_args(output: Path, *, skip_hash: bool = False) -> Namespace:
+                argv = [
+                    "--task-dir",
+                    str(task),
+                    "--registry",
+                    "harbor.example.internal",
+                    "--project",
+                    "test-project",
+                    "--benchmark-name",
+                    "seta",
+                    "--cache-root",
+                    str(cache_root),
+                    "--bundle-manifest-output",
+                    str(output),
+                    "--reuse-local-upload-cache",
+                    "--no-use-proxy",
+                ]
+                if skip_hash:
+                    argv.append("--skip-hash-verification")
+                with patch.dict(os.environ, {}, clear=True):
+                    return parse_args(argv)
+
+            publisher = Mock()
+            publisher.inspect_config.return_value = {
+                "entrypoint": None,
+                "cmd": None,
+                "working_dir": None,
+                "exposed_ports": [],
+                "healthcheck": None,
+            }
+            registry = Mock()
+            registry.manifest.return_value = {
+                "artifact_digest": "sha256:" + "a" * 64,
+                "media_type": DOCKER_MANIFEST,
+            }
+            first_output = root / "first.json"
+            with (
+                patch(
+                    "opensandbox_image_manager.registry_credentials",
+                    return_value=("user", "password"),
+                ),
+                patch(
+                    "opensandbox_image_manager.SkopeoPublisher",
+                    return_value=publisher,
+                ),
+                patch(
+                    "opensandbox_image_manager.RegistryClient",
+                    return_value=registry,
+                ),
+            ):
+                first = prepare_bundle(make_args(first_output))
+
+            self.assertTrue(first_output.is_file())
+            self.assertEqual(registry.manifest.call_count, 1)
+            uploaded = list((cache_root / "uploaded-bundles").glob("*/*.json"))
+            self.assertEqual(len(uploaded), 1)
+
+            verified_output = root / "verified.json"
+            with (
+                patch(
+                    "opensandbox_image_manager.registry_credentials",
+                    side_effect=AssertionError("Registry access is not expected"),
+                ),
+                patch(
+                    "opensandbox_image_manager.environment_content_hash",
+                    wraps=environment_content_hash,
+                ) as content_hash,
+            ):
+                verified = prepare_bundle(make_args(verified_output))
+
+            self.assertGreater(content_hash.call_count, 0)
+            self.assertEqual(verified.main_image_ref, first.main_image_ref)
+            self.assertEqual(
+                json.loads(verified_output.read_text(encoding="utf-8")),
+                first.manifest,
+            )
+
+            (task / "environment" / "Dockerfile").write_text(
+                "FROM ubuntu:24.04\nRUN echo changed\n", encoding="utf-8"
+            )
+            with (
+                patch(
+                    "opensandbox_image_manager.registry_credentials",
+                    side_effect=AssertionError("stale cache reached Registry fallback"),
+                ),
+                self.assertRaisesRegex(AssertionError, "Registry fallback"),
+            ):
+                prepare_bundle(make_args(root / "stale.json"))
+
+            skipped_output = root / "skipped.json"
+            with (
+                patch(
+                    "opensandbox_image_manager.resolve_bundle_spec",
+                    side_effect=AssertionError("task content must not be resolved"),
+                ),
+                patch(
+                    "opensandbox_image_manager.registry_credentials",
+                    side_effect=AssertionError("Registry access is not expected"),
+                ),
+            ):
+                skipped = prepare_bundle(
+                    make_args(skipped_output, skip_hash=True)
+                )
+
+            self.assertEqual(skipped.main_image_ref, first.main_image_ref)
+            self.assertTrue(skipped_output.is_file())
 
     def test_registry_target_keeps_project_and_task_repository_separate(self) -> None:
         target = RegistryTarget("registry.example", "seta", "973")

--- a/config.env
+++ b/config.env
@@ -186,6 +186,15 @@ YICLOUD_SANDBOX_FAST_UPLOAD_ORIGIN=https://sandbox.yicloud.com.cn
 # Optional explicit BuildKit proxy.  It takes precedence over HTTP(S)_PROXY;
 # use a host-local endpoint only when that local proxy is intended.
 # HARBOR_OPENSANDBOX_BUILD_PROXY_URL=http://127.0.0.1:7890
+# Dataset prebuild records each successfully resolved Registry Bundle under the
+# local image cache. On later runs it verifies the current task hash against
+# that record and skips the Registry request when they match. Set to 0 to
+# restore Registry-authoritative cache lookup for every task.
+# HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE=1
+# Optional fast-resume mode: trust a target-scoped local uploaded-Bundle record
+# by task identity without parsing or hashing the dataset. Use only when the
+# dataset and Registry retention are known to be stable.
+# HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION=0
 # OpenSandbox dataset prebuild always prunes unused BuildKit cache once before
 # a non-dry-run batch and periodically while active. Set the interval to 0 to
 # disable only periodic GC. These options do not delete images, containers,


### PR DESCRIPTION
## 1. Why the change?

Large datasets may contain tens of thousands of tasks. When prebuild is restarted, even if only one task is missing, every task must recalculate its hash and perform a Registry request to discover the cache hit.

This makes resuming prebuild unnecessarily slow.

## 2. Summary of the change

- Cache successfully uploaded Bundle records locally.
- Reuse matching local records without querying the Registry.
- Add an optional fast-resume mode that skips task hash verification and trusts the local uploaded-task record.
- Fall back to the existing Registry lookup and build flow when no local record exists.
- Avoid unnecessary package-source health requests for local hits in fast-resume mode.

## 3. Other details

Hash verification remains enabled by default. Fast-resume mode is intended for stable datasets where task content rarely changes and Registry artifacts are retained.