### PR TITLE
fix(harbor): deliver Claude Opik hook to OpenSandbox

### DIFF
--- a/Agents/Harbor-claude-code/sitecustomize.py
+++ b/Agents/Harbor-claude-code/sitecustomize.py
@@ -159,7 +159,11 @@ def _build_hook_settings_json(hook_path: str) -> str:
     def event_command(event: str) -> str:
         command = hook_command(event)
         if event != "SessionEnd":
-            return "sh -lc " + shlex.quote(command)
+            # Do not start a login shell here. Some managed Sandbox images
+            # ship Bash-only snippets in /etc/profile.d, while /bin/sh is
+            # dash. ``sh -l`` sources those snippets and aborts the hook before
+            # Claude can make its first model call.
+            return "sh -c " + shlex.quote(command)
 
         # Claude Code often cancels SessionEnd hooks while shutting down. Persist
         # stdin first, then finalize from a detached child so completed traces do
@@ -167,11 +171,11 @@ def _build_hook_settings_json(hook_path: str) -> str:
         detached = (
             'payload="${TMPDIR:-/tmp}/cc-opik-sessionend-$(date +%s%N)-$$.json"; '
             'cat > "$payload"; '
-            "nohup sh -lc "
+            "nohup sh -c "
             + shlex.quote(hook_command("SessionEnd", ' --payload-file "$1"'))
             + ' _ "$payload" >/dev/null 2>&1 &'
         )
-        return "sh -lc " + shlex.quote(detached)
+        return "sh -c " + shlex.quote(detached)
 
     payload = {
         "alwaysThinkingEnabled": True,

--- a/Agents/Harbor-claude-code/sitecustomize.py
+++ b/Agents/Harbor-claude-code/sitecustomize.py
@@ -593,6 +593,22 @@ def _patch_claude_code_realtime_hooks() -> None:
                     "export PATH=\"$HOME/.local/bin:$PATH\"; "
                     f"{patched_command}"
                 )
+                if hook_enabled:
+                    # Harbor assigns this after constructing the agent, so it
+                    # cannot be supplied by the launcher as static --ae data.
+                    # Pass the exact trial identity to Claude so every hook
+                    # subprocess can correlate its Agent trace with the Harbor
+                    # trial trace.
+                    env = dict(env or {})
+                    agent_session_id = str(
+                        getattr(_self, "session_id", "") or ""
+                    )
+                    trial_suffix = "__agent"
+                    if agent_session_id.endswith(trial_suffix):
+                        env.setdefault(
+                            "TB_TRIAL_ID",
+                            agent_session_id[: -len(trial_suffix)],
+                        )
             if not hook_enabled:
                 return await original_exec_as_agent(
                     environment,

--- a/Agents/Harbor-claude-code/sitecustomize.py
+++ b/Agents/Harbor-claude-code/sitecustomize.py
@@ -606,7 +606,7 @@ def _patch_claude_code_realtime_hooks() -> None:
                     trial_suffix = "__agent"
                     if agent_session_id.endswith(trial_suffix):
                         env.setdefault(
-                            "TB_TRIAL_ID",
+                            "HARBOR_TRIAL_ID",
                             agent_session_id[: -len(trial_suffix)],
                         )
             if not hook_enabled:

--- a/Agents/Harbor-claude-code/tests/test_sitecustomize.py
+++ b/Agents/Harbor-claude-code/tests/test_sitecustomize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import json
 import os
 import shlex
 import subprocess
@@ -35,6 +36,20 @@ def load_module():
 
 
 class ClaudeCommandPatchTest(unittest.TestCase):
+    def test_opik_hooks_do_not_use_login_shells(self) -> None:
+        module = load_module()
+        settings = json.loads(
+            module._build_hook_settings_json(
+                "/opt/tb-opik/claude_realtime_trace.py"
+            )
+        )
+
+        for event, entries in settings["hooks"].items():
+            with self.subTest(event=event):
+                command = entries[0]["hooks"][0]["command"]
+                self.assertIn("sh -c ", command)
+                self.assertNotIn("sh -lc ", command)
+
     def test_opik_hook_requires_shared_trace_gate(self) -> None:
         module = load_module()
         endpoint = "https://opik.example.invalid/api"

--- a/Agents/Harbor-claude-code/tests/test_sitecustomize.py
+++ b/Agents/Harbor-claude-code/tests/test_sitecustomize.py
@@ -77,7 +77,7 @@ class ClaudeCommandPatchTest(unittest.TestCase):
 
         self.assertEqual(
             captured_env,
-            [{"TB_TRIAL_ID": "hello_sandbox__AbCdEfG"}],
+            [{"HARBOR_TRIAL_ID": "hello_sandbox__AbCdEfG"}],
         )
 
     def test_opik_hooks_do_not_use_login_shells(self) -> None:

--- a/Agents/Harbor-claude-code/tests/test_sitecustomize.py
+++ b/Agents/Harbor-claude-code/tests/test_sitecustomize.py
@@ -36,6 +36,50 @@ def load_module():
 
 
 class ClaudeCommandPatchTest(unittest.TestCase):
+    def test_opik_hook_receives_harbor_trial_identity(self) -> None:
+        module = load_module()
+        captured_env: list[dict[str, str] | None] = []
+
+        class FakeClaudeCode:
+            async def install(self, environment):
+                return None
+
+            async def run(self, instruction, environment, context):
+                command = (
+                    "claude --verbose --output-format=stream-json "
+                    "--permission-mode=bypassPermissions --print -- 'task'"
+                )
+                return await self.exec_as_agent(environment, command)
+
+            async def exec_as_agent(
+                self, environment, command, env=None, cwd=None, timeout_sec=None
+            ):
+                captured_env.append(env)
+                return command
+
+        claude_code = types.ModuleType("harbor.agents.installed.claude_code")
+        claude_code.ClaudeCode = FakeClaudeCode
+        fake_modules = {
+            name: types.ModuleType(name)
+            for name in ("harbor", "harbor.agents", "harbor.agents.installed")
+        }
+        fake_modules["harbor.agents.installed.claude_code"] = claude_code
+
+        with mock.patch.dict(sys.modules, fake_modules):
+            module._patch_claude_code_realtime_hooks()
+            agent = FakeClaudeCode()
+            agent._extra_env = {
+                "CC_OPIK_ENABLE_HOOK": "true",
+                "OPIK_URL": "https://opik.example.invalid/api",
+            }
+            agent.session_id = "hello_sandbox__AbCdEfG__agent"
+            asyncio.run(agent.run("task", object(), object()))
+
+        self.assertEqual(
+            captured_env,
+            [{"TB_TRIAL_ID": "hello_sandbox__AbCdEfG"}],
+        )
+
     def test_opik_hooks_do_not_use_login_shells(self) -> None:
         module = load_module()
         settings = json.loads(

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -63,6 +63,11 @@ harbor_uses_local_opensandbox_dataset() {
     && [[ -d "$DATASET_PATH" ]]
 }
 
+harbor_environment_supports_claude_hook_delivery() {
+  [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" \
+    || "$HARBOR_ENVIRONMENT_TYPE" == "opensandbox" ]]
+}
+
 write_harbor_registry_summary() {
   local exit_code="$1"
   local job_dir=""
@@ -554,10 +559,11 @@ ensure_trace_plugin_source_if_needed() {
       required=("$TRACE_PLUGIN_OPENCODE_PLUGIN_SOURCE" "$TRACE_PLUGIN_OPENCODE_HOOK_SOURCE")
     fi
   elif harbor_agent_is_claude_code && harbor_trace_to_opik_enabled &&
-    [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" ]] &&
+    harbor_environment_supports_claude_hook_delivery &&
     [[ "$HARBOR_CC_OPIK_ENABLE_HOOK" == "1" ]]; then
     # With tracing off the realtime hook is forced off at command
-    # construction. E2B cannot use the host bind-mounted hook source.
+    # construction. Docker bind-mounts the hook, while OpenSandbox
+    # materializes the same read-only mount after the Sandbox starts.
     required=("$TRACE_PLUGIN_CLAUDE_HOOK_SOURCE")
   fi
 
@@ -1191,7 +1197,7 @@ run_harbor() {
   # re-enable it.
   if harbor_agent_is_claude_code \
     && [[ "$HARBOR_CC_OPIK_ENABLE_HOOK" == "1" ]] \
-    && [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" ]] &&
+    && harbor_environment_supports_claude_hook_delivery &&
     harbor_trace_to_opik_enabled; then
     if [[ -f "$HARBOR_CC_HOOK_SOURCE" ]]; then
       hook_mount_enabled=1

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -560,13 +560,16 @@ ensure_trace_plugin_source_if_needed() {
     fi
   elif harbor_agent_is_claude_code && harbor_trace_to_opik_enabled &&
     harbor_environment_supports_claude_hook_delivery &&
-    [[ "$HARBOR_CC_OPIK_ENABLE_HOOK" == "1" ]]; then
+    [[ "$HARBOR_CC_OPIK_ENABLE_HOOK" == "1" && ! -f "$HARBOR_CC_HOOK_SOURCE" ]]; then
     # With tracing off the realtime hook is forced off at command
     # construction. Docker bind-mounts the hook, while OpenSandbox
     # materializes the same read-only mount after the Sandbox starts.
-    # Validate the exact source that run_harbor later mounts.  This may be an
-    # explicit HARBOR_CC_HOOK_SOURCE override rather than the plugin default.
-    required=("$HARBOR_CC_HOOK_SOURCE")
+    # Claude tracing is best-effort: a missing hook must not prevent the
+    # benchmark task, verifier, or cleanup from running.
+    echo "[WARN] CC hook source not found, disable realtime hook: $HARBOR_CC_HOOK_SOURCE" >&2
+    echo "[WARN] initialize the plugin submodule or set HARBOR_CC_HOOK_SOURCE to an existing file" >&2
+    HARBOR_CC_OPIK_ENABLE_HOOK=0
+    export HARBOR_CC_OPIK_ENABLE_HOOK
   fi
 
   local path
@@ -1132,10 +1135,6 @@ run_harbor() {
   # endpoint or credentials there.
   if harbor_trace_to_opik_enabled; then
     cmd+=(
-      --ae "TRACE_TO_OPIK=true"
-      --ae "TB_RUN_ID=${HARBOR_RUN_ID:-$job_name}"
-      --ae "TB_TASK_ID=$effective_harbor_task_id"
-      --ae "TB_DATASET=$(harbor_metadata_dataset_name)"
       --ae "OPIK_URL_OVERRIDE=$OPIK_URL_OVERRIDE"
       --ae "OPIK_URL=$OPIK_URL_OVERRIDE"
       --ae "OPIK_PROJECT_NAME=$OPIK_PROJECT_NAME"
@@ -1207,9 +1206,13 @@ run_harbor() {
     harbor_trace_to_opik_enabled; then
     if [[ -f "$HARBOR_CC_HOOK_SOURCE" ]]; then
       hook_mount_enabled=1
-      cmd+=( --ae "CC_OPIK_ENABLE_HOOK=true" )
+      cmd+=(
+        --ae "CC_OPIK_ENABLE_HOOK=true"
+        --ae "TRACE_TO_OPIK=true"
+      )
     else
-      echo "[WARN] CC hook source not found, disable realtime hook: $HARBOR_CC_HOOK_SOURCE"
+      echo "[WARN] CC hook source not found, disable realtime hook: $HARBOR_CC_HOOK_SOURCE" >&2
+      echo "[WARN] initialize the plugin submodule or set HARBOR_CC_HOOK_SOURCE to an existing file" >&2
       cmd+=( --ae "CC_OPIK_ENABLE_HOOK=false" )
     fi
   else

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -1132,6 +1132,7 @@ run_harbor() {
   # endpoint or credentials there.
   if harbor_trace_to_opik_enabled; then
     cmd+=(
+      --ae "TRACE_TO_OPIK=true"
       --ae "OPIK_URL_OVERRIDE=$OPIK_URL_OVERRIDE"
       --ae "OPIK_URL=$OPIK_URL_OVERRIDE"
       --ae "OPIK_PROJECT_NAME=$OPIK_PROJECT_NAME"

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -564,7 +564,9 @@ ensure_trace_plugin_source_if_needed() {
     # With tracing off the realtime hook is forced off at command
     # construction. Docker bind-mounts the hook, while OpenSandbox
     # materializes the same read-only mount after the Sandbox starts.
-    required=("$TRACE_PLUGIN_CLAUDE_HOOK_SOURCE")
+    # Validate the exact source that run_harbor later mounts.  This may be an
+    # explicit HARBOR_CC_HOOK_SOURCE override rather than the plugin default.
+    required=("$HARBOR_CC_HOOK_SOURCE")
   fi
 
   local path

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -1133,6 +1133,9 @@ run_harbor() {
   if harbor_trace_to_opik_enabled; then
     cmd+=(
       --ae "TRACE_TO_OPIK=true"
+      --ae "TB_RUN_ID=${HARBOR_RUN_ID:-$job_name}"
+      --ae "TB_TASK_ID=$effective_harbor_task_id"
+      --ae "TB_DATASET=$(harbor_metadata_dataset_name)"
       --ae "OPIK_URL_OVERRIDE=$OPIK_URL_OVERRIDE"
       --ae "OPIK_URL=$OPIK_URL_OVERRIDE"
       --ae "OPIK_PROJECT_NAME=$OPIK_PROJECT_NAME"

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -109,6 +109,7 @@ run_dry() {
     HARBOR_OPIK_PYTHON="$harbor_python" \
     HARBOR_OPENSANDBOX_BUILD_ARGS_JSON="$build_args_json" \
     PI_EXTENSION_SOURCE="$extension_source" \
+    E2B_API_KEY=fake-e2b-key \
     YICLOUD_PUBLIC_KEY=fake-public \
     YICLOUD_SECRET_KEY=fake-secret \
     YICLOUD_PROJECT_NAME=test-project \
@@ -292,12 +293,6 @@ grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=true' \
   <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
   <<< "$claude_opensandbox_traced" >/dev/null
-grep -F -- 'FAKE_HARBOR_ARG=TB_RUN_ID=' \
-  <<< "$claude_opensandbox_traced" >/dev/null
-grep -F -- 'FAKE_HARBOR_ARG=TB_TASK_ID=0' \
-  <<< "$claude_opensandbox_traced" >/dev/null
-grep -F -- 'FAKE_HARBOR_ARG=TB_DATASET=harbor' \
-  <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=OPIK_URL_OVERRIDE=http://opik.example:5173/api' \
   <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- "\"source\": \"$tmp/deps/claude_realtime_trace.py\"" \
@@ -328,9 +323,40 @@ if grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
   echo 'trace-off OpenSandbox command unexpectedly enables task tracing' >&2
   exit 1
 fi
-if grep -F -- 'FAKE_HARBOR_ARG=TB_RUN_ID=' \
-  <<< "$claude_opensandbox_traceoff" >/dev/null; then
-  echo 'trace-off OpenSandbox command unexpectedly exposes trace correlation' >&2
+
+claude_opensandbox_missing_hook="$(
+  RUN_DRY_OPIK_URL='http://opik.example:5173' \
+  RUN_DRY_CC_HOOK_SOURCE="$tmp/deps/missing-claude-hook.py" \
+    run_dry 'test-project/manual:immutable' "$tmp/does-not-exist.py" \
+      '{}' auto opensandbox 0 claude-code 0
+)"
+grep -F -- '[WARN] CC hook source not found, disable realtime hook:' \
+  <<< "$claude_opensandbox_missing_hook" >/dev/null
+grep -F -- 'set HARBOR_CC_HOOK_SOURCE to an existing file' \
+  <<< "$claude_opensandbox_missing_hook" >/dev/null
+grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=false' \
+  <<< "$claude_opensandbox_missing_hook" >/dev/null
+if grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
+  <<< "$claude_opensandbox_missing_hook" >/dev/null; then
+  echo 'missing-hook OpenSandbox command unexpectedly enables Claude hook tracing' >&2
+  exit 1
+fi
+if grep -F -- "$tmp/deps/missing-claude-hook.py" \
+  <<< "$claude_opensandbox_missing_hook" | grep -F -- '"source"' >/dev/null; then
+  echo 'missing-hook OpenSandbox command unexpectedly mounts the missing hook' >&2
+  exit 1
+fi
+
+claude_e2b_traced="$(
+  RUN_DRY_OPIK_URL='http://opik.example:5173' \
+    run_dry 'test-project/manual:immutable' "$tmp/does-not-exist.py" \
+      '{}' auto e2b 0 claude-code 0
+)"
+grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=false' \
+  <<< "$claude_e2b_traced" >/dev/null
+if grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
+  <<< "$claude_e2b_traced" >/dev/null; then
+  echo 'traced E2B command unexpectedly enables the bind-mounted Claude hook' >&2
   exit 1
 fi
 

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -292,6 +292,12 @@ grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=true' \
   <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
   <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- 'FAKE_HARBOR_ARG=TB_RUN_ID=' \
+  <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- 'FAKE_HARBOR_ARG=TB_TASK_ID=0' \
+  <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- 'FAKE_HARBOR_ARG=TB_DATASET=auto' \
+  <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=OPIK_URL_OVERRIDE=http://opik.example:5173/api' \
   <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- "\"source\": \"$tmp/deps/claude_realtime_trace.py\"" \
@@ -320,6 +326,11 @@ fi
 if grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
   <<< "$claude_opensandbox_traceoff" >/dev/null; then
   echo 'trace-off OpenSandbox command unexpectedly enables task tracing' >&2
+  exit 1
+fi
+if grep -F -- 'FAKE_HARBOR_ARG=TB_RUN_ID=' \
+  <<< "$claude_opensandbox_traceoff" >/dev/null; then
+  echo 'trace-off OpenSandbox command unexpectedly exposes trace correlation' >&2
   exit 1
 fi
 

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -296,7 +296,7 @@ grep -F -- 'FAKE_HARBOR_ARG=TB_RUN_ID=' \
   <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=TB_TASK_ID=0' \
   <<< "$claude_opensandbox_traced" >/dev/null
-grep -F -- 'FAKE_HARBOR_ARG=TB_DATASET=auto' \
+grep -F -- 'FAKE_HARBOR_ARG=TB_DATASET=harbor' \
   <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=OPIK_URL_OVERRIDE=http://opik.example:5173/api' \
   <<< "$claude_opensandbox_traced" >/dev/null

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -290,6 +290,8 @@ claude_opensandbox_traced="$(
 )"
 grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=true' \
   <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
+  <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=OPIK_URL_OVERRIDE=http://opik.example:5173/api' \
   <<< "$claude_opensandbox_traced" >/dev/null
 grep -F -- "\"source\": \"$tmp/deps/claude_realtime_trace.py\"" \
@@ -313,6 +315,11 @@ fi
 if grep -F -- 'FAKE_HARBOR_ARG=OPIK_URL_OVERRIDE=' \
   <<< "$claude_opensandbox_traceoff" >/dev/null; then
   echo 'trace-off OpenSandbox command unexpectedly exposes the Opik endpoint' >&2
+  exit 1
+fi
+if grep -F -- 'FAKE_HARBOR_ARG=TRACE_TO_OPIK=true' \
+  <<< "$claude_opensandbox_traceoff" >/dev/null; then
+  echo 'trace-off OpenSandbox command unexpectedly enables task tracing' >&2
   exit 1
 fi
 

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -31,6 +31,16 @@ cat >"$tmp/bin/fake-harbor" <<'SH'
 printf 'FAKE_HARBOR_ARG=%s\n' "$@"
 SH
 chmod +x "$tmp/bin/fake-harbor"
+cat >"$tmp/bin/curl" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [[ "$arg" == '%{http_code}' ]]; then
+    printf '200'
+  fi
+done
+exit 0
+SH
+chmod +x "$tmp/bin/curl"
 printf '[environment]\nbuild_timeout_sec = 60\n' > "$tmp/dataset/0/task.toml"
 printf 'FROM ubuntu:24.04\n' > "$tmp/dataset/0/environment/Dockerfile"
 printf '[environment]\nbuild_timeout_sec = 60\n' > "$tmp/dataset/1/task.toml"
@@ -276,7 +286,7 @@ grep -F -- 'FAKE_HARBOR_ARG=HARBOR_VERIFIER_UV_BIN_DIR=/opt/tb-uv-backup/bin' \
 claude_opensandbox_traced="$(
   RUN_DRY_OPIK_URL='http://opik.example:5173' \
     run_dry 'test-project/manual:immutable' "$tmp/does-not-exist.py" \
-      '{}' auto opensandbox 0 claude-code 1
+      '{}' auto opensandbox 0 claude-code 0
 )"
 grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=true' \
   <<< "$claude_opensandbox_traced" >/dev/null
@@ -291,11 +301,11 @@ grep -F -- '"read_only": true' <<< "$claude_opensandbox_traced" >/dev/null
 claude_opensandbox_traceoff="$(
   RUN_DRY_CC_OPIK_ENABLE_HOOK=1 \
     run_dry 'test-project/manual:immutable' "$tmp/does-not-exist.py" \
-      '{}' auto opensandbox 0 claude-code 1
+      '{}' auto opensandbox 0 claude-code 0
 )"
 grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=false' \
   <<< "$claude_opensandbox_traceoff" >/dev/null
-if grep -F -- "$tmp/deps/claude_realtime_trace.py" \
+if grep -F -- "\"source\": \"$tmp/deps/claude_realtime_trace.py\"" \
   <<< "$claude_opensandbox_traceoff" >/dev/null; then
   echo 'trace-off OpenSandbox command unexpectedly mounts the Claude hook' >&2
   exit 1

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -37,6 +37,7 @@ printf '[environment]\nbuild_timeout_sec = 60\n' > "$tmp/dataset/1/task.toml"
 printf 'FROM alpine:3.20\n' > "$tmp/dataset/1/environment/Dockerfile"
 printf 'fake package\n' > "$tmp/deps/claude.tgz"
 printf 'fake wheel\n' > "$tmp/deps/wheels/dependency.whl"
+printf '# fake Claude Opik hook\n' > "$tmp/deps/claude_realtime_trace.py"
 
 run_dry() {
   local image_ref="$1"
@@ -79,6 +80,9 @@ run_dry() {
     API_KEY=fake-api-key \
     BASE_URL=https://model.example \
     MODEL=test-model \
+    OPIK_URL="${RUN_DRY_OPIK_URL:-}" \
+    HARBOR_CC_OPIK_ENABLE_HOOK="${RUN_DRY_CC_OPIK_ENABLE_HOOK:-}" \
+    HARBOR_CC_HOOK_SOURCE="${RUN_DRY_CC_HOOK_SOURCE:-$tmp/deps/claude_realtime_trace.py}" \
     HARBOR_ANTHROPIC_AUTH_TOKEN=fake-api-key \
     HARBOR_LLM_KWARGS='{"temperature":1.0}' \
     HARBOR_CC_CLAUDE_TGZ_SOURCE="$tmp/deps/claude.tgz" \
@@ -268,6 +272,39 @@ grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_CLAUDE_TGZ_PATH=' \
   <<< "$claude_opensandbox" >/dev/null
 grep -F -- 'FAKE_HARBOR_ARG=HARBOR_VERIFIER_UV_BIN_DIR=/opt/tb-uv-backup/bin' \
   <<< "$claude_opensandbox" >/dev/null
+
+claude_opensandbox_traced="$(
+  RUN_DRY_OPIK_URL='http://opik.example:5173' \
+    run_dry 'test-project/manual:immutable' "$tmp/does-not-exist.py" \
+      '{}' auto opensandbox 0 claude-code 1
+)"
+grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=true' \
+  <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- 'FAKE_HARBOR_ARG=OPIK_URL_OVERRIDE=http://opik.example:5173/api' \
+  <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- "\"source\": \"$tmp/deps/claude_realtime_trace.py\"" \
+  <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- '"target": "/opt/tb-opik/claude_realtime_trace.py"' \
+  <<< "$claude_opensandbox_traced" >/dev/null
+grep -F -- '"read_only": true' <<< "$claude_opensandbox_traced" >/dev/null
+
+claude_opensandbox_traceoff="$(
+  RUN_DRY_CC_OPIK_ENABLE_HOOK=1 \
+    run_dry 'test-project/manual:immutable' "$tmp/does-not-exist.py" \
+      '{}' auto opensandbox 0 claude-code 1
+)"
+grep -F -- 'FAKE_HARBOR_ARG=CC_OPIK_ENABLE_HOOK=false' \
+  <<< "$claude_opensandbox_traceoff" >/dev/null
+if grep -F -- "$tmp/deps/claude_realtime_trace.py" \
+  <<< "$claude_opensandbox_traceoff" >/dev/null; then
+  echo 'trace-off OpenSandbox command unexpectedly mounts the Claude hook' >&2
+  exit 1
+fi
+if grep -F -- 'FAKE_HARBOR_ARG=OPIK_URL_OVERRIDE=' \
+  <<< "$claude_opensandbox_traceoff" >/dev/null; then
+  echo 'trace-off OpenSandbox command unexpectedly exposes the Opik endpoint' >&2
+  exit 1
+fi
 
 opencode_opensandbox="$(run_dry \
   'test-project/manual:immutable' "$tmp/does-not-exist.py" '{}' auto \


### PR DESCRIPTION
Fixes #152

Summary:
- enable Claude Code realtime Opik hook delivery for OpenSandbox as well as Docker
- validate the exact configured hook source before a traced run
- preserve trace-off isolation and leave E2B/QZ behavior unchanged
- cover read-only hook materialization, Opik URL normalization, and trace-off behavior

Verified on z-cpu Linux:
- OpenSandbox Harbor shell regression: passed
- Claude sitecustomize tests: 11 passed
- YiCloud OpenSandbox adapter tests: 61 passed
- Harbor package-environment test: 1 passed
- git diff --check: passed

The fresh-Sandbox health reachability update is recorded in sii-system/tasks#168. A real one-task AgentFleet inference plus Frontgate/Agent/Harbor trace readback is still pending because YiCloud HMAC credentials are not available in the current noninteractive z-cpu environment. No production Frontgate or Opik service was changed.