### PR TITLE
fix(harbor): publish registry preparation failures

### DIFF
--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -332,8 +332,11 @@ wraps `harboropik.sh`, which writes the same summary path from Harbor's job
 result. The wrapper exits automatically only when Harbor returns zero and an
 aggregate result was found. It keeps failed or incomplete runs open for
 diagnosis, while foreground `start.sh` prints the final summary and returns
-the recorded Harbor status after Zellij exits. The wrapper also keeps a
-successful final pane open when the completion switch is `0`.
+the recorded Harbor status after Zellij exits. Runtime-preparation failures
+are also recorded in `HARBOR_BENCHMARK_EXIT_FILE` before the diagnostic pane
+is held open, so keeping the pane does not hide terminal state from external
+controllers. The wrapper also keeps a successful final pane open when the
+completion switch is `0`.
 
 RL rollout flow:
 

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -335,7 +335,9 @@ diagnosis, while foreground `start.sh` prints the final summary and returns
 the recorded Harbor status after Zellij exits. Runtime-preparation failures
 are also recorded in `HARBOR_BENCHMARK_EXIT_FILE` before the diagnostic pane
 is held open, so keeping the pane does not hide terminal state from external
-controllers. The wrapper also keeps a successful final pane open when the
+controllers. If the marker itself cannot be published, the wrapper reports
+the write failure and preserves the existing summary and failure-pane
+diagnostics. The wrapper also keeps a successful final pane open when the
 completion switch is `0`.
 
 RL rollout flow:

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -337,8 +337,11 @@ are also recorded in `HARBOR_BENCHMARK_EXIT_FILE` before the diagnostic pane
 is held open, so keeping the pane does not hide terminal state from external
 controllers. If the marker itself cannot be published, the wrapper reports
 the write failure and preserves the existing summary and failure-pane
-diagnostics. The wrapper also keeps a successful final pane open when the
-completion switch is `0`.
+diagnostics. If Harbor itself completed successfully, a marker-publication
+failure becomes a nonzero wrapper exit but skips the permanent failure-pane
+hold, so a successful run cannot hang solely because its marker is unwritable.
+The wrapper also keeps a successful final pane open when the completion switch
+is `0`.
 
 RL rollout flow:
 

--- a/Agents/utils/common/Harbor/run_harbor_registry.sh
+++ b/Agents/utils/common/Harbor/run_harbor_registry.sh
@@ -26,13 +26,45 @@ show_registry_summary() {
   fi
 }
 
+record_registry_exit() {
+  local status="$1"
+  local exit_dir exit_tmp
+
+  exit_dir="$(dirname "$HARBOR_BENCHMARK_EXIT_FILE")"
+  exit_tmp="${HARBOR_BENCHMARK_EXIT_FILE}.tmp.${BASHPID:-$$}"
+  if ! mkdir -p "$exit_dir"; then
+    echo "failed to create Harbor completion directory: $exit_dir" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$status" > "$exit_tmp"; then
+    echo "failed to write Harbor completion status: $exit_tmp" >&2
+    return 1
+  fi
+  if ! mv -f -- "$exit_tmp" "$HARBOR_BENCHMARK_EXIT_FILE"; then
+    rm -f -- "$exit_tmp" || true
+    echo "failed to publish Harbor completion status: $HARBOR_BENCHMARK_EXIT_FILE" >&2
+    return 1
+  fi
+  return 0
+}
+
 # A zero process status is complete only when the summary writer found the
 # aggregate Harbor result. Keep incomplete and failed panes available so the
 # error that preceded the summary cannot disappear behind "Bye from Zellij!".
 if [[ "$status" -eq 0 ]] &&
    ! grep -qx 'status:      complete' "$OUTPUT_PATH/summary.txt" 2>/dev/null; then
   status=1
-  printf '%s\n' "$status" > "$HARBOR_BENCHMARK_EXIT_FILE"
+fi
+
+# harboropik.sh records its own exit after it starts, but registry runtime
+# preparation happens before that script and can fail without triggering its
+# EXIT trap. Publish the wrapper's normalized terminal status before any pane
+# is held open so foreground and detached controllers always see completion.
+if ! record_registry_exit "$status"; then
+  if [[ "$status" -eq 0 ]]; then
+    status=1
+  fi
+  exit "$status"
 fi
 
 if [[ "$status" -ne 0 ]]; then

--- a/Agents/utils/common/Harbor/run_harbor_registry.sh
+++ b/Agents/utils/common/Harbor/run_harbor_registry.sh
@@ -37,7 +37,13 @@ record_registry_exit() {
     return 1
   fi
   if ! printf '%s\n' "$status" > "$exit_tmp"; then
+    rm -f -- "$exit_tmp" || true
     echo "failed to write Harbor completion status: $exit_tmp" >&2
+    return 1
+  fi
+  if [[ -d "$HARBOR_BENCHMARK_EXIT_FILE" ]]; then
+    rm -f -- "$exit_tmp" || true
+    echo "Harbor completion target is a directory: $HARBOR_BENCHMARK_EXIT_FILE" >&2
     return 1
   fi
   if ! mv -f -- "$exit_tmp" "$HARBOR_BENCHMARK_EXIT_FILE"; then

--- a/Agents/utils/common/Harbor/run_harbor_registry.sh
+++ b/Agents/utils/common/Harbor/run_harbor_registry.sh
@@ -66,22 +66,29 @@ fi
 # preparation happens before that script and can fail without triggering its
 # EXIT trap. Publish the wrapper's normalized terminal status before any pane
 # is held open so foreground and detached controllers always see completion.
+skip_failure_pane_hold=0
 if ! record_registry_exit "$status"; then
   echo "[WARN] Harbor completion status could not be published; continuing failure diagnostics" >&2
   if [[ "$status" -eq 0 ]]; then
     status=1
+    skip_failure_pane_hold=1
   fi
 fi
 
 if [[ "$status" -ne 0 ]]; then
   show_registry_summary
   if [[ "${HARBOR_ZELLIJ_KEEP_ON_FAILURE:-1}" == "1" ]]; then
-    echo
-    echo "Harbor failed; keeping this pane open for diagnostics."
-    echo "Press Ctrl-q to leave Zellij after reviewing the error above."
-    while true; do
-      sleep 3600
-    done
+    if [[ "$skip_failure_pane_hold" == "1" ]]; then
+      echo
+      echo "Harbor completed, but its completion status could not be published; not keeping this pane open."
+    else
+      echo
+      echo "Harbor failed; keeping this pane open for diagnostics."
+      echo "Press Ctrl-q to leave Zellij after reviewing the error above."
+      while true; do
+        sleep 3600
+      done
+    fi
   fi
   exit "$status"
 fi

--- a/Agents/utils/common/Harbor/run_harbor_registry.sh
+++ b/Agents/utils/common/Harbor/run_harbor_registry.sh
@@ -61,10 +61,10 @@ fi
 # EXIT trap. Publish the wrapper's normalized terminal status before any pane
 # is held open so foreground and detached controllers always see completion.
 if ! record_registry_exit "$status"; then
+  echo "[WARN] Harbor completion status could not be published; continuing failure diagnostics" >&2
   if [[ "$status" -eq 0 ]]; then
     status=1
   fi
-  exit "$status"
 fi
 
 if [[ "$status" -ne 0 ]]; then

--- a/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
+++ b/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
@@ -110,6 +110,29 @@ SH
   [[ "$(cat "$output/harbor-benchmark.exit")" == "1" ]]
   stop_wrapper
 
+  local invalid_exit_parent="$output/not-a-directory"
+  : > "$invalid_exit_parent"
+  : > "$log"
+  FAKE_PREP_STATUS=9 HARBOR_ZELLIJ_KEEP_ON_FAILURE=1 \
+    HARBOR_BENCHMARK_EXIT_FILE="$invalid_exit_parent/harbor-benchmark.exit" \
+    OUTPUT_PATH="$output" bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 &
+  WRAPPER_PID="$!"
+  wait_for_wrapper_message "$log" 'Harbor failed; keeping this pane open'
+  grep -q 'failed to create Harbor completion directory' "$log"
+  grep -q 'continuing failure diagnostics' "$log"
+  grep -q 'summary unavailable' "$log"
+  kill -0 "$WRAPPER_PID"
+  stop_wrapper
+
+  status=0
+  : > "$log"
+  FAKE_HARBOR_STATUS=0 HARBOR_ZELLIJ_KEEP_ON_FAILURE=0 \
+    HARBOR_BENCHMARK_EXIT_FILE="$invalid_exit_parent/harbor-benchmark.exit" \
+    OUTPUT_PATH="$output" bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 || status="$?"
+  [[ "$status" -eq 1 ]]
+  grep -q '^registry summary$' "$log"
+  grep -q 'continuing failure diagnostics' "$log"
+
   FAKE_HARBOR_STATUS=7 HARBOR_ZELLIJ_KEEP_ON_FAILURE=1 OUTPUT_PATH="$output" \
     bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 &
   WRAPPER_PID="$!"

--- a/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
+++ b/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
@@ -150,16 +150,36 @@ SH
   [[ -z "$(find "$output" -maxdepth 1 -name 'harbor-benchmark.exit.tmp.*' -print -quit)" ]]
 
   local exit_target_dir="$output/exit-target-directory"
+  local wrapper_status_file="$output/wrapper.status"
   mkdir -p "$exit_target_dir"
-  status=0
   : > "$log"
-  FAKE_HARBOR_STATUS=0 HARBOR_ZELLIJ_KEEP_ON_FAILURE=0 \
-    HARBOR_BENCHMARK_EXIT_FILE="$exit_target_dir" \
-    OUTPUT_PATH="$output" bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 || status="$?"
-  [[ "$status" -eq 1 ]]
+  rm -f "$wrapper_status_file"
+  (
+    local wrapper_status=0
+    FAKE_HARBOR_STATUS=0 HARBOR_ZELLIJ_KEEP_ON_FAILURE=1 \
+      HARBOR_BENCHMARK_EXIT_FILE="$exit_target_dir" \
+      OUTPUT_PATH="$output" bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 \
+      || wrapper_status="$?"
+    echo "$wrapper_status" > "$wrapper_status_file"
+  ) &
+  WRAPPER_PID="$!"
+  local deadline=$((SECONDS + 10))
+  until [[ -s "$wrapper_status_file" ]]; do
+    if [[ "$SECONDS" -ge "$deadline" ]]; then
+      cat "$log" >&2
+      echo "successful Harbor run hung after marker publication failed" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+  wait "$WRAPPER_PID"
+  WRAPPER_PID=""
+  [[ "$(cat "$wrapper_status_file")" == "1" ]]
   grep -q 'Harbor completion target is a directory' "$log"
   grep -q 'continuing failure diagnostics' "$log"
   grep -q '^registry summary$' "$log"
+  grep -q 'not keeping this pane open' "$log"
+  ! grep -q 'Harbor failed; keeping this pane open' "$log"
   [[ -z "$(find "$exit_target_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]]
 
   FAKE_HARBOR_STATUS=7 HARBOR_ZELLIJ_KEEP_ON_FAILURE=1 OUTPUT_PATH="$output" \

--- a/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
+++ b/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
@@ -91,19 +91,40 @@ exit "$status"
 SH
   chmod +x "$wrapper_dir/harboropik.sh" "$wrapper_dir/run_harbor_registry.sh"
 
+  local status=0
+  mkdir -p "$output"
+  rm -f "$output/harbor-benchmark.exit" "$output/summary.txt"
+  FAKE_PREP_STATUS=9 HARBOR_ZELLIJ_KEEP_ON_FAILURE=0 OUTPUT_PATH="$output" \
+    bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 || status="$?"
+  [[ "$status" -eq 1 ]]
+  [[ "$(cat "$output/harbor-benchmark.exit")" == "1" ]]
+  grep -q 'failed to prepare registry agent runtime' "$log"
+  grep -q 'summary unavailable' "$log"
+
+  : > "$log"
+  rm -f "$output/harbor-benchmark.exit" "$output/summary.txt"
+  FAKE_PREP_STATUS=9 HARBOR_ZELLIJ_KEEP_ON_FAILURE=1 OUTPUT_PATH="$output" \
+    bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 &
+  WRAPPER_PID="$!"
+  wait_for_wrapper_message "$log" 'Harbor failed; keeping this pane open'
+  [[ "$(cat "$output/harbor-benchmark.exit")" == "1" ]]
+  stop_wrapper
+
   FAKE_HARBOR_STATUS=7 HARBOR_ZELLIJ_KEEP_ON_FAILURE=1 OUTPUT_PATH="$output" \
     bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 &
   WRAPPER_PID="$!"
   wait_for_wrapper_message "$log" 'Harbor failed; keeping this pane open'
   grep -q '^registry summary$' "$log"
   grep -q 'Press Ctrl-q' "$log"
+  [[ "$(cat "$output/harbor-benchmark.exit")" == "7" ]]
   stop_wrapper
 
-  local status=0
+  status=0
   : > "$log"
   FAKE_HARBOR_STATUS=7 HARBOR_ZELLIJ_KEEP_ON_FAILURE=0 OUTPUT_PATH="$output" \
     bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 || status="$?"
   [[ "$status" -eq 7 ]]
+  [[ "$(cat "$output/harbor-benchmark.exit")" == "7" ]]
   grep -q '^registry summary$' "$log"
   ! grep -q 'keeping this pane open' "$log"
 
@@ -111,6 +132,7 @@ SH
   FAKE_HARBOR_STATUS=0 OUTPUT_PATH="$output" \
     bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 || status="$?"
   [[ "$status" -eq 0 ]]
+  [[ "$(cat "$output/harbor-benchmark.exit")" == "0" ]]
 
   : > "$log"
   FAKE_HARBOR_STATUS=0 HARBOR_ZELLIJ_CLOSE_ON_COMPLETE=0 OUTPUT_PATH="$output" \

--- a/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
+++ b/Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh
@@ -77,6 +77,12 @@ HARBOR_BENCHMARK_EXIT_FILE="${HARBOR_BENCHMARK_EXIT_FILE:-$OUTPUT_PATH/harbor-be
 harbor_prepare_agent_runtime() {
   return "${FAKE_PREP_STATUS:-0}"
 }
+printf() {
+  if [[ "${FAKE_MARKER_PRINTF_FAILURE:-0}" == "1" ]]; then
+    return 1
+  fi
+  builtin printf "$@"
+}
 export OUTPUT_PATH HARBOR_ZELLIJ_CLOSE_ON_COMPLETE HARBOR_ZELLIJ_KEEP_ON_FAILURE
 export HARBOR_BENCHMARK_EXIT_FILE
 SH
@@ -132,6 +138,29 @@ SH
   [[ "$status" -eq 1 ]]
   grep -q '^registry summary$' "$log"
   grep -q 'continuing failure diagnostics' "$log"
+
+  status=0
+  : > "$log"
+  rm -f "$output/harbor-benchmark.exit" "$output/summary.txt"
+  FAKE_PREP_STATUS=9 FAKE_MARKER_PRINTF_FAILURE=1 HARBOR_ZELLIJ_KEEP_ON_FAILURE=0 \
+    OUTPUT_PATH="$output" bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 || status="$?"
+  [[ "$status" -eq 1 ]]
+  grep -q 'failed to write Harbor completion status' "$log"
+  grep -q 'continuing failure diagnostics' "$log"
+  [[ -z "$(find "$output" -maxdepth 1 -name 'harbor-benchmark.exit.tmp.*' -print -quit)" ]]
+
+  local exit_target_dir="$output/exit-target-directory"
+  mkdir -p "$exit_target_dir"
+  status=0
+  : > "$log"
+  FAKE_HARBOR_STATUS=0 HARBOR_ZELLIJ_KEEP_ON_FAILURE=0 \
+    HARBOR_BENCHMARK_EXIT_FILE="$exit_target_dir" \
+    OUTPUT_PATH="$output" bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 || status="$?"
+  [[ "$status" -eq 1 ]]
+  grep -q 'Harbor completion target is a directory' "$log"
+  grep -q 'continuing failure diagnostics' "$log"
+  grep -q '^registry summary$' "$log"
+  [[ -z "$(find "$exit_target_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]]
 
   FAKE_HARBOR_STATUS=7 HARBOR_ZELLIJ_KEEP_ON_FAILURE=1 OUTPUT_PATH="$output" \
     bash "$wrapper_dir/run_harbor_registry.sh" >"$log" 2>&1 &


### PR DESCRIPTION
## 1. Why the change?

Native registry runs prepare the agent runtime in `run_harbor_registry.sh` before invoking `harboropik.sh`. When that preparation fails, `harboropik.sh` never starts, so its EXIT trap cannot write `HARBOR_BENCHMARK_EXIT_FILE`.

The run is already terminal, but foreground and detached controllers cannot observe the completion contract. With `HARBOR_ZELLIJ_KEEP_ON_FAILURE=1`, the diagnostic pane remains open and the missing marker can make an outer controller wait indefinitely.

This was reproduced during the YiCloud OpenSandbox E2E work tracked in `sii-system/tasks#168`.

## 2. Summary of the change

- Publish the registry wrapper's normalized exit status for every terminal path, including runtime-preparation failures.
- Write the marker through a temporary file and atomic rename before entering either success or failure pane-retention loops.
- Preserve existing status semantics:
  - successful complete summary: `0`;
  - Harbor failure: the Harbor exit status;
  - zero process exit with an incomplete summary: `1`.
- Extend the registry wrapper regression test for preparation failures with failure-pane retention both disabled and enabled.
- Document that keeping the diagnostic pane open does not hide terminal state from external controllers.

## 3. Other details

Validation:

- `bash Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh`
- `bash Agents/utils/common/Harbor/tests/test_start_user_feedback.sh`
- `bash -n Agents/utils/common/Harbor/run_harbor_registry.sh Agents/utils/common/Harbor/tests/test_gen_zellij_layouts.sh`
- `git diff --check`
- z-cpu Linux smoke covering:
  - preparation failure with pane close: `exit=1`, marker `1`;
  - preparation failure with pane retained: marker `1` is visible while the pane remains alive;
  - complete run: `exit=0`, marker `0`;
  - incomplete summary: `exit=1`, marker `1`.

The smoke uses no YiCloud credentials and creates no Sandbox because the affected failure occurs before `CreateSandbox`.
