### PR TITLE
Add DeepSearchQA benchmark support

### DIFF
--- a/Agents/AGENTS.md
+++ b/Agents/AGENTS.md
@@ -26,7 +26,7 @@ Main `env.sh` parameters:
 
 ```bash
 AGENT="claude-code"        # claude-code, opencode, or pi
-DATASET_NAME="seta"        # seta, smith, terminalbench21, or sweverify
+DATASET_NAME="seta"        # deepsearchqa, seta, smith, terminalbench21, or sweverify
 DATASET_PATH="/workspace/seta-env/Harbor-Dataset"
 TOTAL_WORKERS="80"         # zellij worker panes
 HARBOR_N_CONCURRENT="80"       # Harbor concurrency, normally = TOTAL_WORKERS
@@ -40,6 +40,7 @@ restarting.
 
 | Dataset | `DATASET_NAME` | Typical `DATASET_PATH` | Workers |
 | --- | --- | --- | --- |
+| DeepSearchQA | `deepsearchqa` | Harbor registry | runner concurrency |
 | SETA | `seta` | `/workspace/seta-env/Harbor-Dataset` | 80 |
 | SWE-Smith | `smith` | `/workspace/harbor/datasets/swesmith` | 80 |
 | Terminal-Bench 2.1 | `terminalbench21` | `/workspace/terminal-bench-2-1/tasks` | 20 |
@@ -47,6 +48,8 @@ restarting.
 
 `DATASET_NAME` selects a task list under `Tasks/` (for example
 `Tasks/SETA/harbor_tasks.txt`); `TASK_SOURCE_FILE=<path>` overrides it.
+DeepSearchQA runs from Harbor Hub and requires a Gemini judge key; see
+[Tasks/DeepSearchQA/README.md](../Tasks/DeepSearchQA/README.md).
 
 ### Online Analysis (opt-in)
 

--- a/Agents/AGENTS.md
+++ b/Agents/AGENTS.md
@@ -48,7 +48,7 @@ restarting.
 
 `DATASET_NAME` selects a task list under `Tasks/` (for example
 `Tasks/SETA/harbor_tasks.txt`); `TASK_SOURCE_FILE=<path>` overrides it.
-DeepSearchQA runs from Harbor Hub and requires a Gemini judge key; see
+DeepSearchQA runs from Harbor Hub and requires an OpenAI-compatible judge endpoint; see
 [Tasks/DeepSearchQA/README.md](../Tasks/DeepSearchQA/README.md).
 
 ### Online Analysis (opt-in)

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -146,7 +146,9 @@ Typical dataset paths:
 | `MODEL` | Model name passed to Harbor |
 | `BASE_URL` | Model gateway base URL |
 | `API_KEY` | Model gateway API key |
-| `GEMINI_API_KEY` or `GOOGLE_API_KEY` | DeepSearchQA verifier credential; required for live DeepSearchQA runs |
+| `JUDGE_BASE_URL` | OpenAI-compatible judge URL for DeepSearchQA; `/v1` and `/v1/chat/completions` forms are accepted |
+| `JUDGE_API_KEY` | DeepSearchQA judge credential; passed only to the verifier |
+| `JUDGE_MODEL` | Model name used by the DeepSearchQA judge |
 | `HARBOR_TEMPERATURE` | OpenCode sampling temperature for fixed benchmark runs; unset by default |
 | `HARBOR_TOP_P` | OpenCode nucleus-sampling value for fixed benchmark runs; unset by default |
 | `HARBOR_MAX_TOKENS` | Maximum output tokens for OpenCode, Claude Code, or Pi fixed benchmark runs; defaults to existing agent limits when unset |

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -113,8 +113,9 @@ continue to use the shell entry points documented in the README files.
 
 ## Task Resolution
 
-`DATASET_NAME` selects a built-in local dataset alias:
+`DATASET_NAME` selects a built-in dataset alias:
 
+- `deepsearchqa`: Harbor registry dataset `kgmon/deepsearchqa`
 - `seta`: `Tasks/SETA/harbor_tasks.txt`
 - `sweverify`: `Tasks/SWE-verify/harbor_tasks.txt`
 - `smith`: `Tasks/SWE-smith/harbor_tasks.txt`
@@ -130,6 +131,7 @@ Typical dataset paths:
 
 | Dataset | `DATASET_NAME` | `DATASET_PATH` | Metric | Suggested workers |
 | --- | --- | --- | --- | --- |
+| DeepSearchQA | `deepsearchqa` | unset | reward (F1) | runner concurrency |
 | SETA | `seta` | `/workspace/seta-env/Harbor-Dataset` | success rate | `80` |
 | SWE-Smith | `smith` | `/workspace/harbor/datasets/swesmith` | reward | `80` |
 | Terminal-Bench 2.1 | `terminalbench21` | `/workspace/terminal-bench-2-1/tasks` | success rate | `20` |
@@ -144,6 +146,7 @@ Typical dataset paths:
 | `MODEL` | Model name passed to Harbor |
 | `BASE_URL` | Model gateway base URL |
 | `API_KEY` | Model gateway API key |
+| `GEMINI_API_KEY` or `GOOGLE_API_KEY` | DeepSearchQA verifier credential; required for live DeepSearchQA runs |
 | `HARBOR_TEMPERATURE` | OpenCode sampling temperature for fixed benchmark runs; unset by default |
 | `HARBOR_TOP_P` | OpenCode nucleus-sampling value for fixed benchmark runs; unset by default |
 | `HARBOR_MAX_TOKENS` | Maximum output tokens for OpenCode, Claude Code, or Pi fixed benchmark runs; defaults to existing agent limits when unset |

--- a/Agents/utils/common/Harbor/deepsearchqa_verifier.py
+++ b/Agents/utils/common/Harbor/deepsearchqa_verifier.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from harbor.verifier.verifier import Verifier
 
-
 _JUDGE_ENV_NAMES = ("JUDGE_BASE_URL", "JUDGE_API_KEY", "JUDGE_MODEL")
 _OVERLAY_DIR = Path(__file__).with_name("deepsearchqa_verifier_files")
 

--- a/Agents/utils/common/Harbor/deepsearchqa_verifier.py
+++ b/Agents/utils/common/Harbor/deepsearchqa_verifier.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from harbor.verifier.verifier import Verifier
+
+
+_JUDGE_ENV_NAMES = ("JUDGE_BASE_URL", "JUDGE_API_KEY", "JUDGE_MODEL")
+_OVERLAY_DIR = Path(__file__).with_name("deepsearchqa_verifier_files")
+
+
+class DeepSearchQAVerifier(Verifier):
+    def __init__(
+        self,
+        *args: Any,
+        verifier_env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        judge_env = {name: os.environ.get(name, "") for name in _JUDGE_ENV_NAMES}
+        super().__init__(
+            *args,
+            verifier_env={**(verifier_env or {}), **judge_env},
+            **kwargs,
+        )
+
+    def _resolve_tests(self) -> tuple[list[Path], Path, Path]:
+        source_dirs, _, _ = super()._resolve_tests()
+        test_path = _OVERLAY_DIR / "test.sh"
+        return [*source_dirs, _OVERLAY_DIR], _OVERLAY_DIR, test_path

--- a/Agents/utils/common/Harbor/deepsearchqa_verifier_files/openai_judge.py
+++ b/Agents/utils/common/Harbor/deepsearchqa_verifier_files/openai_judge.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Replace DeepSearchQA's judge call with an OpenAI-compatible endpoint."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from urllib import error, request
+
+
+def judge_endpoint(base_url: str) -> str:
+    endpoint = base_url.rstrip("/")
+    if endpoint.endswith("/chat/completions"):
+        return endpoint
+    if endpoint.endswith("/v1"):
+        return f"{endpoint}/chat/completions"
+    return f"{endpoint}/v1/chat/completions"
+
+
+def _required_judge_setting(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Set {name} for the DeepSearchQA verifier.")
+    return value
+
+
+def call_judge(prompt: str) -> str:
+    base_url = _required_judge_setting("JUDGE_BASE_URL")
+    api_key = _required_judge_setting("JUDGE_API_KEY")
+    model = _required_judge_setting("JUDGE_MODEL")
+    max_retries = int(os.environ.get("DEEPSEARCHQA_GRADER_MAX_RETRIES", "5"))
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+    ).encode()
+    judge_request = request.Request(
+        judge_endpoint(base_url),
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    response_body: bytes | None = None
+    last_error: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            with request.urlopen(judge_request, timeout=120) as response:
+                response_body = response.read()
+            break
+        except (error.URLError, TimeoutError) as exc:
+            last_error = exc
+            if attempt == max_retries - 1:
+                break
+            time.sleep(1 + (2 ** (attempt + random.random())))
+
+    if response_body is None:
+        raise RuntimeError(
+            f"Judge request failed after {max_retries} attempts: {last_error}"
+        )
+
+    try:
+        parsed = json.loads(response_body)
+        content = parsed["choices"][0]["message"]["content"]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+        raise RuntimeError("Judge returned a malformed chat completion.") from exc
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("Judge returned a malformed chat completion.")
+    return content
+
+
+def main() -> None:
+    import verifier as official_verifier
+
+    official_verifier.call_gemini = call_judge
+    official_verifier.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/Agents/utils/common/Harbor/deepsearchqa_verifier_files/openai_judge.py
+++ b/Agents/utils/common/Harbor/deepsearchqa_verifier_files/openai_judge.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Replace DeepSearchQA's judge call with an OpenAI-compatible endpoint."""
 
 from __future__ import annotations

--- a/Agents/utils/common/Harbor/deepsearchqa_verifier_files/test.sh
+++ b/Agents/utils/common/Harbor/deepsearchqa_verifier_files/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+python /tests/openai_judge.py /tests/metadata.json /workspace/answer.txt

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -42,9 +42,10 @@ PI_PROVIDER="${PI_PROVIDER:-}"
 
 HARBOR_ROOT="${HARBOR_ROOT:-/workspace/harbor}"
 # Dataset selection:
-#   DATASET_NAME: auto, seta, smith, terminalbench21, sweverify,
+#   DATASET_NAME: auto, deepsearchqa, seta, smith, terminalbench21, sweverify,
 #     or a Harbor registry dataset id such as owner/name or owner/name@version.
-#     seta, terminalbench21, and sweverify are registry aliases. smith is local.
+#     deepsearchqa, seta, terminalbench21, and sweverify are registry aliases.
+#     smith is local.
 #     For a local/offline checkout, use auto so the dataset is inferred from
 #     DATASET_PATH.
 #   DATASET_PATH examples:
@@ -57,6 +58,7 @@ DATASET_NAME="${DATASET_NAME:-auto}"
 DATASET_PATH="${DATASET_PATH:-/workspace/seta-env/Harbor-Dataset}"
 METRIC_MODE="${METRIC_MODE:-auto}"
 HARBOR_TERMINALBENCH21_REGISTRY_ID="terminal-bench/terminal-bench-2-1"
+HARBOR_DEEPSEARCHQA_REGISTRY_ID="kgmon/deepsearchqa"
 
 # Host-direct runs must not assume that the caller can write to /workspace.
 # The checkout-local runs directory is ignored by git, mounted at the same path
@@ -259,7 +261,14 @@ HARBOR_RETRY_EXCLUDE_EXCEPTIONS="${HARBOR_RETRY_EXCLUDE_EXCEPTIONS-RewardFileNot
 HARBOR_AK_MAX_TURNS="${HARBOR_AK_MAX_TURNS:-}"
 HARBOR_AK_COLLECT_ROLLOUT_DETAILS="${HARBOR_AK_COLLECT_ROLLOUT_DETAILS:-}"
 HARBOR_AK_ENABLE_SUMMARIZE="${HARBOR_AK_ENABLE_SUMMARIZE:-}"
-HARBOR_DISALLOWED_TOOLS="${HARBOR_DISALLOWED_TOOLS:-WebSearch WebFetch RemoteTrigger AskUserQuestion}"
+_HARBOR_DEFAULT_DISALLOWED_TOOLS="WebSearch WebFetch RemoteTrigger AskUserQuestion"
+case "$DATASET_NAME" in
+  deepsearchqa|kgmon/deepsearchqa|kgmon/deepsearchqa@*)
+    _HARBOR_DEFAULT_DISALLOWED_TOOLS="RemoteTrigger AskUserQuestion"
+    ;;
+esac
+HARBOR_DISALLOWED_TOOLS="${HARBOR_DISALLOWED_TOOLS-$_HARBOR_DEFAULT_DISALLOWED_TOOLS}"
+unset _HARBOR_DEFAULT_DISALLOWED_TOOLS
 HARBOR_APPEND_SYSTEM_PROMPT="${HARBOR_APPEND_SYSTEM_PROMPT:-Use English only for all reasoning, messages, filenames, and tool arguments. Use ASCII characters only unless reading existing non-ASCII file contents is strictly necessary.}"
 HARBOR_API_BASE="${HARBOR_API_BASE:-${HARBOR_ANTHROPIC_BASE_URL%/}/v1/chat/completions}"
 ROLLOUT="${ROLLOUT:-0}"
@@ -1065,6 +1074,7 @@ harbor_metric_mode() {
 
 harbor_registry_dataset_name() {
   case "$DATASET_NAME" in
+    deepsearchqa) printf '%s\n' "$HARBOR_DEEPSEARCHQA_REGISTRY_ID"; return 0 ;;
     seta) printf 'seta-env\n'; return 0 ;;
     terminalbench21) printf '%s\n' "$HARBOR_TERMINALBENCH21_REGISTRY_ID"; return 0 ;;
     sweverify) printf 'swebench-verified\n'; return 0 ;;
@@ -1086,6 +1096,20 @@ harbor_metadata_dataset_name() {
 
 harbor_uses_registry_dataset() {
   harbor_registry_dataset_name >/dev/null
+}
+
+harbor_validate_dataset_runtime_requirements() {
+  local registry_dataset
+  registry_dataset="$(harbor_registry_dataset_name 2>/dev/null || true)"
+  case "$registry_dataset" in
+    "$HARBOR_DEEPSEARCHQA_REGISTRY_ID"|"$HARBOR_DEEPSEARCHQA_REGISTRY_ID"@*)
+      if [[ -z "${GEMINI_API_KEY:-}" && -z "${GOOGLE_API_KEY:-}" ]]; then
+        echo "[ERROR] DeepSearchQA requires GEMINI_API_KEY or GOOGLE_API_KEY for its verifier." >&2
+        echo "[ERROR] Store the key in config.local.env or export it for this run." >&2
+        return 1
+      fi
+      ;;
+  esac
 }
 
 harbor_registry_task_name() {

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -99,6 +99,9 @@ HARBOR_MONITOR_CONFIGURED_TIMEOUT="${HARBOR_MONITOR_CONFIGURED_TIMEOUT:-}"
 
 API_KEY="${API_KEY:-xxx}"
 BASE_URL="${BASE_URL:-}"
+JUDGE_BASE_URL="${JUDGE_BASE_URL:-}"
+JUDGE_API_KEY="${JUDGE_API_KEY:-}"
+JUDGE_MODEL="${JUDGE_MODEL:-}"
 # Normalize to a versionless API root: callers may supply a value already ending
 # in /v1, but the endpoints below append /v1 (or /v1/chat/completions), so strip
 # one trailing /v1 to avoid doubling it.
@@ -263,11 +266,14 @@ HARBOR_AK_COLLECT_ROLLOUT_DETAILS="${HARBOR_AK_COLLECT_ROLLOUT_DETAILS:-}"
 HARBOR_AK_ENABLE_SUMMARIZE="${HARBOR_AK_ENABLE_SUMMARIZE:-}"
 _HARBOR_DEFAULT_DISALLOWED_TOOLS="WebSearch WebFetch RemoteTrigger AskUserQuestion"
 case "$DATASET_NAME" in
-  deepsearchqa|kgmon/deepsearchqa|kgmon/deepsearchqa@*)
+  deepsearchqa|deepsearchqa@*|kgmon/deepsearchqa|kgmon/deepsearchqa@*)
     _HARBOR_DEFAULT_DISALLOWED_TOOLS="RemoteTrigger AskUserQuestion"
+    HARBOR_DISALLOWED_TOOLS="${HARBOR_DISALLOWED_TOOLS-$_HARBOR_DEFAULT_DISALLOWED_TOOLS}"
+    ;;
+  *)
+    HARBOR_DISALLOWED_TOOLS="${HARBOR_DISALLOWED_TOOLS:-$_HARBOR_DEFAULT_DISALLOWED_TOOLS}"
     ;;
 esac
-HARBOR_DISALLOWED_TOOLS="${HARBOR_DISALLOWED_TOOLS-$_HARBOR_DEFAULT_DISALLOWED_TOOLS}"
 unset _HARBOR_DEFAULT_DISALLOWED_TOOLS
 HARBOR_APPEND_SYSTEM_PROMPT="${HARBOR_APPEND_SYSTEM_PROMPT:-Use English only for all reasoning, messages, filenames, and tool arguments. Use ASCII characters only unless reading existing non-ASCII file contents is strictly necessary.}"
 HARBOR_API_BASE="${HARBOR_API_BASE:-${HARBOR_ANTHROPIC_BASE_URL%/}/v1/chat/completions}"
@@ -657,6 +663,7 @@ HARBOR_OPENSANDBOX_IMAGE_MANAGER="${HARBOR_OPENSANDBOX_IMAGE_MANAGER:-$SCRIPT_DI
 
 export SCRIPT_DIR REPO_ROOT AGENTS_DIR TASKS_DIR HARBOR_CLAUDE_CODE_DIR HARBOR_OPENCODE_DIR HARBOR_PI_DIR WORKSPACE_DIR RUN_ID TOTAL_WORKERS N_ATTEMPTS MODEL AGENT MAX_RETRIES
 export HARBOR_ROOT DATASET_PATH DATASET_NAME METRIC_MODE OUTPUT_ROOT OUTPUT_PATH TASK_SOURCE_FILE TASK_FILE FLEET_TASKS QUEUE_DIR RUNTIME_DIR LAYOUT_FILE JOBS_ROOT
+export JUDGE_BASE_URL JUDGE_API_KEY JUDGE_MODEL
 export HARBOR_ONLINE_ANALYSIS HARBOR_ONLINE_ANALYSIS_POLL_INTERVAL HARBOR_ONLINE_ANALYSIS_DIR HARBOR_ONLINE_ANALYSIS_PID_FILE HARBOR_ONLINE_ANALYSIS_LOG_FILE HARBOR_EARLY_STOP HARBOR_ZELLIJ_CLOSE_ON_COMPLETE HARBOR_ZELLIJ_KEEP_ON_FAILURE
 export HARBOR_MONITOR_ENABLED HARBOR_MONITOR_DIR HARBOR_MONITOR_PID_FILE HARBOR_MONITOR_LOG_FILE HARBOR_BENCHMARK_PID_FILE HARBOR_BENCHMARK_EXIT_FILE HARBOR_JOB_DIR_FILE HARBOR_MONITOR_RESTART_CMD HARBOR_MONITOR_STOP_CMD HARBOR_MONITOR_INTERVAL HARBOR_MONITOR_STARTUP_GRACE HARBOR_MONITOR_STALL_SECONDS HARBOR_MONITOR_MAX_RETRIES HARBOR_MONITOR_CONFIGURED_TIMEOUT
 export API_KEY BASE_URL HARBOR_ANALYZER_API_KEY HARBOR_ANALYZER_BASE_URL HARBOR_ANALYZER_MODEL HARBOR_ANALYZER_PI_PROVIDER HARBOR_ANALYZER_NO_PROXY HARBOR_ANALYZER_ENABLED HARBOR_ANALYZER_MODE HARBOR_ANALYZER_OUTPUT_DIR HARBOR_ANALYZER_PID_FILE HARBOR_ANALYZER_SUPERVISOR_PID_FILE HARBOR_ANALYZER_SUPERVISOR_ID_FILE HARBOR_ANALYZER_LOG_FILE HARBOR_ANALYZER_POLL_INTERVAL HARBOR_ANALYZER_TIMEOUT HARBOR_ANALYZER_MAX_CONCURRENCY HARBOR_FIXER_API_KEY HARBOR_FIXER_BASE_URL HARBOR_FIXER_MODEL HARBOR_FIXER_PI_BIN HARBOR_FIXER_PI_PROVIDER HARBOR_FIXER_NO_PROXY HARBOR_FIXER_AGENT_TIMEOUT HARBOR_FIXER_EXECUTION_TIMEOUT HARBOR_FIXER_SUMMARY_LIMIT HARBOR_FIXER_MAX_CONCURRENCY HARBOR_FIXER_MAX_TASK_SUMMARY_CHARS HARBOR_FIXER_MAX_TASK_SUMMARIES_CHARS OPIK_URL OPIK_URL_OVERRIDE OPIK_BASE OPIK_PROJECT_NAME OPIK_API_KEY OPIK_WORKSPACE CC_OPIK_DEBUG
@@ -1074,7 +1081,10 @@ harbor_metric_mode() {
 
 harbor_registry_dataset_name() {
   case "$DATASET_NAME" in
-    deepsearchqa) printf '%s\n' "$HARBOR_DEEPSEARCHQA_REGISTRY_ID"; return 0 ;;
+    deepsearchqa|deepsearchqa@*)
+      printf '%s%s\n' "$HARBOR_DEEPSEARCHQA_REGISTRY_ID" "${DATASET_NAME#deepsearchqa}"
+      return 0
+      ;;
     seta) printf 'seta-env\n'; return 0 ;;
     terminalbench21) printf '%s\n' "$HARBOR_TERMINALBENCH21_REGISTRY_ID"; return 0 ;;
     sweverify) printf 'swebench-verified\n'; return 0 ;;
@@ -1098,18 +1108,24 @@ harbor_uses_registry_dataset() {
   harbor_registry_dataset_name >/dev/null
 }
 
-harbor_validate_dataset_runtime_requirements() {
+harbor_uses_deepsearchqa_dataset() {
   local registry_dataset
   registry_dataset="$(harbor_registry_dataset_name 2>/dev/null || true)"
-  case "$registry_dataset" in
-    "$HARBOR_DEEPSEARCHQA_REGISTRY_ID"|"$HARBOR_DEEPSEARCHQA_REGISTRY_ID"@*)
-      if [[ -z "${GEMINI_API_KEY:-}" && -z "${GOOGLE_API_KEY:-}" ]]; then
-        echo "[ERROR] DeepSearchQA requires GEMINI_API_KEY or GOOGLE_API_KEY for its verifier." >&2
-        echo "[ERROR] Store the key in config.local.env or export it for this run." >&2
-        return 1
-      fi
-      ;;
-  esac
+  [[ "$registry_dataset" == "$HARBOR_DEEPSEARCHQA_REGISTRY_ID" \
+    || "$registry_dataset" == "$HARBOR_DEEPSEARCHQA_REGISTRY_ID"@* ]]
+}
+
+harbor_validate_dataset_runtime_requirements() {
+  harbor_uses_deepsearchqa_dataset || return 0
+  local name value
+  for name in JUDGE_BASE_URL JUDGE_API_KEY JUDGE_MODEL; do
+    value="${!name:-}"
+    if [[ -z "${value//[[:space:]]/}" ]]; then
+      printf '[ERROR] DeepSearchQA requires %s for its verifier.\n' "$name" >&2
+      echo "[ERROR] Store it in config.local.env or export it for this run." >&2
+      return 1
+    fi
+  done
 }
 
 harbor_registry_task_name() {

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -885,6 +885,9 @@ run_oracle_task() {
   else
     cmd+=( --path "$DATASET_PATH" )
   fi
+  if harbor_uses_deepsearchqa_dataset; then
+    cmd+=( --verifier "deepsearchqa_verifier:DeepSearchQAVerifier" )
+  fi
   append_environment_backend_args
   if [[ "$HARBOR_ENVIRONMENT_TYPE" != "e2b" && "$HARBOR_ENVIRONMENT_TYPE" != "qz" ]] \
     && verifier_uv_bin_ready; then
@@ -1148,6 +1151,9 @@ run_harbor() {
     cmd+=( --dataset "$(harbor_registry_dataset_name)" )
   else
     cmd+=( --path "$DATASET_PATH" )
+  fi
+  if harbor_uses_deepsearchqa_dataset; then
+    cmd+=( --verifier "deepsearchqa_verifier:DeepSearchQAVerifier" )
   fi
   prepare_opensandbox_image_ref "$out_dir/opensandbox-bundle.json" || return 1
   append_environment_backend_args
@@ -1508,6 +1514,9 @@ run_opencode_task() {
       cmd+=( --dataset "$(harbor_registry_dataset_name)" )
     else
       cmd+=( --path "$DATASET_PATH" )
+    fi
+    if harbor_uses_deepsearchqa_dataset; then
+      cmd+=( --verifier "deepsearchqa_verifier:DeepSearchQAVerifier" )
     fi
     prepare_opensandbox_image_ref "$out_dir/opensandbox-bundle.json" || return 1
     append_environment_backend_args

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -1622,6 +1622,9 @@ main() {
   harbor_validate_generation_controls
   validate_environment_backend
   configure_trace_disabled_runtime
+  if [[ "$HARBOR_DRY_RUN" != "1" ]]; then
+    harbor_validate_dataset_runtime_requirements
+  fi
   harbor_init_run_dirs
   if ! harbor_agent_is_oracle && harbor_trace_to_opik_enabled; then
     normalize_opik_url_override

--- a/Agents/utils/common/Harbor/scripts/write_harbor_registry_summary.py
+++ b/Agents/utils/common/Harbor/scripts/write_harbor_registry_summary.py
@@ -32,11 +32,17 @@ def reward_rollup(stats: dict) -> tuple[str, dict[str, int]]:
         metrics = evaluation.get("metrics")
         if isinstance(metrics, list):
             for metric in metrics:
-                mean = metric.get("mean") if isinstance(metric, dict) else None
-                if isinstance(mean, (int, float)) and not isinstance(mean, bool):
-                    weighted_total += float(mean) * weight
-                    weighted_trials += weight
-                    break
+                if not isinstance(metric, dict):
+                    continue
+                for metric_name in ("reward", "mean"):
+                    value = metric.get(metric_name)
+                    if isinstance(value, (int, float)) and not isinstance(value, bool):
+                        weighted_total += float(value) * weight
+                        weighted_trials += weight
+                        break
+                else:
+                    continue
+                break
 
         reward_stats = evaluation.get("reward_stats")
         rewards = reward_stats.get("reward") if isinstance(reward_stats, dict) else None

--- a/Agents/utils/common/Harbor/tests/test_deepsearchqa_judge.py
+++ b/Agents/utils/common/Harbor/tests/test_deepsearchqa_judge.py
@@ -1,0 +1,182 @@
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+
+VERIFIER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "deepsearchqa_verifier_files"
+    / "openai_judge.py"
+)
+SPEC = importlib.util.spec_from_file_location("deepsearchqa_judge", VERIFIER_PATH)
+assert SPEC and SPEC.loader
+VERIFIER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = VERIFIER
+SPEC.loader.exec_module(VERIFIER)
+
+
+def load_verifier_adapter() -> ModuleType:
+    class FakeVerifier:
+        def __init__(
+            self,
+            *_args: object,
+            verifier_env: dict[str, str] | None = None,
+            **_kwargs: object,
+        ) -> None:
+            self.verifier_env = verifier_env
+
+        def _resolve_tests(self) -> tuple[list[Path], Path, Path]:
+            official = Path("/official/tests")
+            return [official], official, official / "test.sh"
+
+    harbor = ModuleType("harbor")
+    harbor_verifier = ModuleType("harbor.verifier")
+    harbor_verifier_module = ModuleType("harbor.verifier.verifier")
+    harbor_verifier_module.Verifier = FakeVerifier
+    adapter_path = Path(__file__).resolve().parents[1] / "deepsearchqa_verifier.py"
+    adapter_spec = importlib.util.spec_from_file_location(
+        "deepsearchqa_verifier_adapter_test",
+        adapter_path,
+    )
+    assert adapter_spec and adapter_spec.loader
+    adapter = importlib.util.module_from_spec(adapter_spec)
+    with patch.dict(
+        sys.modules,
+        {
+            "harbor": harbor,
+            "harbor.verifier": harbor_verifier,
+            "harbor.verifier.verifier": harbor_verifier_module,
+        },
+    ):
+        adapter_spec.loader.exec_module(adapter)
+    return adapter
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode()
+
+
+class DeepSearchQAJudgeTest(unittest.TestCase):
+    def test_adapter_injects_judge_env_and_overlays_official_tests(self) -> None:
+        adapter = load_verifier_adapter()
+        with patch.dict(
+            "os.environ",
+            {
+                "JUDGE_BASE_URL": "https://judge.example/v1",
+                "JUDGE_API_KEY": "secret",
+                "JUDGE_MODEL": "judge-model",
+            },
+            clear=True,
+        ):
+            verifier = adapter.DeepSearchQAVerifier(
+                verifier_env={"EXISTING": "value"}
+            )
+
+        self.assertEqual(
+            verifier.verifier_env,
+            {
+                "EXISTING": "value",
+                "JUDGE_BASE_URL": "https://judge.example/v1",
+                "JUDGE_API_KEY": "secret",
+                "JUDGE_MODEL": "judge-model",
+            },
+        )
+        source_dirs, tests_dir, test_path = verifier._resolve_tests()
+        self.assertEqual(source_dirs[0], Path("/official/tests"))
+        self.assertEqual(source_dirs[-1], tests_dir)
+        self.assertEqual(tests_dir.name, "deepsearchqa_verifier_files")
+        self.assertEqual(test_path, tests_dir / "test.sh")
+
+    def test_wrapper_replaces_only_the_official_judge_call(self) -> None:
+        official_verifier = ModuleType("verifier")
+        invoked: list[object] = []
+        official_verifier.call_gemini = object()
+
+        def official_main() -> None:
+            invoked.append(official_verifier.call_gemini)
+
+        official_verifier.main = official_main
+        with patch.dict(sys.modules, {"verifier": official_verifier}):
+            VERIFIER.main()
+
+        self.assertEqual(invoked, [VERIFIER.call_judge])
+
+    def test_normalizes_openai_compatible_endpoint(self) -> None:
+        cases = {
+            "https://judge.example": "https://judge.example/v1/chat/completions",
+            "https://judge.example/v1": "https://judge.example/v1/chat/completions",
+            "https://judge.example/v1/chat/completions": (
+                "https://judge.example/v1/chat/completions"
+            ),
+        }
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(VERIFIER.judge_endpoint(value), expected)
+
+    def test_calls_openai_chat_completions_contract(self) -> None:
+        response = FakeResponse(
+            {"choices": [{"message": {"content": '{"Answer Correctness": {}}'}}]}
+        )
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "JUDGE_BASE_URL": "https://judge.example/v1/chat/completions",
+                    "JUDGE_API_KEY": "secret",
+                    "JUDGE_MODEL": "judge-model",
+                },
+                clear=True,
+            ),
+            patch.object(VERIFIER.request, "urlopen", return_value=response) as urlopen,
+        ):
+            result = VERIFIER.call_judge("rate this")
+
+        self.assertEqual(result, '{"Answer Correctness": {}}')
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "https://judge.example/v1/chat/completions")
+        self.assertEqual(request.get_header("Authorization"), "Bearer secret")
+        payload = json.loads(request.data)
+        self.assertEqual(payload["model"], "judge-model")
+        self.assertEqual(
+            payload["messages"], [{"role": "user", "content": "rate this"}]
+        )
+
+    def test_requires_all_judge_settings(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "JUDGE_BASE_URL"):
+                VERIFIER.call_judge("rate this")
+
+    def test_rejects_malformed_chat_completion(self) -> None:
+        response = FakeResponse({"choices": []})
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "JUDGE_BASE_URL": "https://judge.example/v1",
+                    "JUDGE_API_KEY": "secret",
+                    "JUDGE_MODEL": "judge-model",
+                },
+                clear=True,
+            ),
+            patch.object(VERIFIER.request, "urlopen", return_value=response),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "malformed"):
+                VERIFIER.call_judge("rate this")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_deepsearchqa_judge.py
+++ b/Agents/utils/common/Harbor/tests/test_deepsearchqa_judge.py
@@ -4,8 +4,8 @@ import sys
 import unittest
 from pathlib import Path
 from types import ModuleType
+from typing import Self
 from unittest.mock import patch
-
 
 VERIFIER_PATH = (
     Path(__file__).resolve().parents[1]
@@ -60,7 +60,7 @@ class FakeResponse:
     def __init__(self, payload: dict[str, object]) -> None:
         self.payload = payload
 
-    def __enter__(self) -> "FakeResponse":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *_args: object) -> None:
@@ -156,9 +156,11 @@ class DeepSearchQAJudgeTest(unittest.TestCase):
         )
 
     def test_requires_all_judge_settings(self) -> None:
-        with patch.dict("os.environ", {}, clear=True):
-            with self.assertRaisesRegex(RuntimeError, "JUDGE_BASE_URL"):
-                VERIFIER.call_judge("rate this")
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            self.assertRaisesRegex(RuntimeError, "JUDGE_BASE_URL"),
+        ):
+            VERIFIER.call_judge("rate this")
 
     def test_rejects_malformed_chat_completion(self) -> None:
         response = FakeResponse({"choices": []})
@@ -173,9 +175,9 @@ class DeepSearchQAJudgeTest(unittest.TestCase):
                 clear=True,
             ),
             patch.object(VERIFIER.request, "urlopen", return_value=response),
+            self.assertRaisesRegex(RuntimeError, "malformed"),
         ):
-            with self.assertRaisesRegex(RuntimeError, "malformed"):
-                VERIFIER.call_judge("rate this")
+            VERIFIER.call_judge("rate this")
 
 
 if __name__ == "__main__":

--- a/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
@@ -281,6 +281,7 @@ run_harboropik() {
   local min_test="${9:-0}"
   local runs="${10:-1}"
   local n_concurrent="${11:-1}"
+  local gemini_api_key="${12:-}"
   local opik_base="http://opik.example"
   local opik_url_override="http://opik.example/api"
   local hook_flag="1"
@@ -330,6 +331,7 @@ run_harboropik() {
     OPIK_API_KEY="fake-opik-key" \
     BASE_URL="http://llm.example" \
     API_KEY="fake-llm-key" \
+    GEMINI_API_KEY="$gemini_api_key" \
     MODEL="fake-model" \
     MIN_TEST="$min_test" \
     MIN_TEST_INCLUDE_TASK="fix-git" \
@@ -400,6 +402,7 @@ main() {
   local seta_capture sweverify_capture registry_capture traceoff_capture traceoff_oc_capture
   local opencode_registry_capture opencode_local_capture
   local min_test_capture
+  local deepsearchqa_capture
   tmp="$(mktemp -d)"
   TEST_TMP_DIR="$tmp"
   trap 'rm -rf "$TEST_TMP_DIR"' EXIT
@@ -433,6 +436,16 @@ main() {
   assert_file_content "${registry_capture}.pid-identity" "valid"
   assert_registry_summary "$tmp/claude-registry/run/summary.txt"
   assert_registry_summary_requires_result "$tmp/registry-missing-result"
+
+  deepsearchqa_capture="$tmp/deepsearchqa.args"
+  run_harboropik \
+    "claude-code" "$capture_bin" "$deepsearchqa_capture" "$tmp/deepsearchqa" \
+    "deepsearchqa" "" "true" "1" "0" "1" "1" "fake-judge-key"
+  assert_arg_pair "$deepsearchqa_capture" "--dataset" "kgmon/deepsearchqa"
+  assert_arg_pair \
+    "$deepsearchqa_capture" \
+    "--ak" \
+    "disallowed_tools=RemoteTrigger AskUserQuestion"
 
   opencode_capture="$tmp/opencode-default.args"
   run_harboropik \

--- a/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_extra_compose.sh
@@ -281,7 +281,9 @@ run_harboropik() {
   local min_test="${9:-0}"
   local runs="${10:-1}"
   local n_concurrent="${11:-1}"
-  local gemini_api_key="${12:-}"
+  local judge_base_url="${12:-}"
+  local judge_api_key="${13:-}"
+  local judge_model="${14:-}"
   local opik_base="http://opik.example"
   local opik_url_override="http://opik.example/api"
   local hook_flag="1"
@@ -331,7 +333,9 @@ run_harboropik() {
     OPIK_API_KEY="fake-opik-key" \
     BASE_URL="http://llm.example" \
     API_KEY="fake-llm-key" \
-    GEMINI_API_KEY="$gemini_api_key" \
+    JUDGE_BASE_URL="$judge_base_url" \
+    JUDGE_API_KEY="$judge_api_key" \
+    JUDGE_MODEL="$judge_model" \
     MODEL="fake-model" \
     MIN_TEST="$min_test" \
     MIN_TEST_INCLUDE_TASK="fix-git" \
@@ -402,7 +406,7 @@ main() {
   local seta_capture sweverify_capture registry_capture traceoff_capture traceoff_oc_capture
   local opencode_registry_capture opencode_local_capture
   local min_test_capture
-  local deepsearchqa_capture
+  local deepsearchqa_capture deepsearchqa_opencode_capture deepsearchqa_oracle_capture
   tmp="$(mktemp -d)"
   TEST_TMP_DIR="$tmp"
   trap 'rm -rf "$TEST_TMP_DIR"' EXIT
@@ -440,12 +444,40 @@ main() {
   deepsearchqa_capture="$tmp/deepsearchqa.args"
   run_harboropik \
     "claude-code" "$capture_bin" "$deepsearchqa_capture" "$tmp/deepsearchqa" \
-    "deepsearchqa" "" "true" "1" "0" "1" "1" "fake-judge-key"
+    "deepsearchqa" "" "true" "1" "0" "1" "1" \
+    "https://judge.example/v1/chat/completions" "fake-judge-key" "judge-model"
   assert_arg_pair "$deepsearchqa_capture" "--dataset" "kgmon/deepsearchqa"
+  assert_arg_pair \
+    "$deepsearchqa_capture" \
+    "--verifier" \
+    "deepsearchqa_verifier:DeepSearchQAVerifier"
+  assert_arg_absent "$deepsearchqa_capture" "fake-judge-key"
   assert_arg_pair \
     "$deepsearchqa_capture" \
     "--ak" \
     "disallowed_tools=RemoteTrigger AskUserQuestion"
+
+  deepsearchqa_opencode_capture="$tmp/deepsearchqa-opencode.args"
+  run_harboropik \
+    "opencode" "$capture_bin" "$deepsearchqa_opencode_capture" \
+    "$tmp/deepsearchqa-opencode" "deepsearchqa" "" "true" "1" "0" "1" "1" \
+    "https://judge.example/v1/chat/completions" "fake-judge-key" "judge-model"
+  assert_arg_pair \
+    "$deepsearchqa_opencode_capture" \
+    "--verifier" \
+    "deepsearchqa_verifier:DeepSearchQAVerifier"
+  assert_arg_absent "$deepsearchqa_opencode_capture" "fake-judge-key"
+
+  deepsearchqa_oracle_capture="$tmp/deepsearchqa-oracle.args"
+  run_harboropik \
+    "oracle" "$capture_bin" "$deepsearchqa_oracle_capture" \
+    "$tmp/deepsearchqa-oracle" "deepsearchqa" "" "true" "1" "0" "1" "1" \
+    "https://judge.example/v1/chat/completions" "fake-judge-key" "judge-model"
+  assert_arg_pair \
+    "$deepsearchqa_oracle_capture" \
+    "--verifier" \
+    "deepsearchqa_verifier:DeepSearchQAVerifier"
+  assert_arg_absent "$deepsearchqa_oracle_capture" "fake-judge-key"
 
   opencode_capture="$tmp/opencode-default.args"
   run_harboropik \

--- a/Agents/utils/common/Harbor/tests/test_registry_summary.py
+++ b/Agents/utils/common/Harbor/tests/test_registry_summary.py
@@ -1,0 +1,52 @@
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from write_harbor_registry_summary import reward_rollup  # noqa: E402
+
+
+class RegistrySummaryTest(unittest.TestCase):
+    def test_rolls_up_named_reward_from_multi_key_metrics(self) -> None:
+        stats = {
+            "evals": {
+                "deepsearchqa": {
+                    "n_trials": 2,
+                    "metrics": [
+                        {
+                            "f1_score": 0.75,
+                            "fully_correct": 0.5,
+                            "reward": 0.75,
+                        }
+                    ],
+                    "reward_stats": {"reward": {"0.5": ["a"], "1.0": ["b"]}},
+                }
+            }
+        }
+
+        mean_reward, reward_counts = reward_rollup(stats)
+
+        self.assertEqual(mean_reward, "0.75")
+        self.assertEqual(reward_counts, {"0.5": 1, "1.0": 1})
+
+    def test_keeps_legacy_mean_metric_support(self) -> None:
+        stats = {
+            "evals": {
+                "legacy": {
+                    "n_trials": 1,
+                    "metrics": [{"mean": 0.5}],
+                    "reward_stats": {"reward": {"0.5": ["a"]}},
+                }
+            }
+        }
+
+        mean_reward, reward_counts = reward_rollup(stats)
+
+        self.assertEqual(mean_reward, "0.5")
+        self.assertEqual(reward_counts, {"0.5": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_task_selection.py
+++ b/Agents/utils/common/Harbor/tests/test_task_selection.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 HARBOR_DIR = Path(__file__).resolve().parents[1]
 ENV_SH = HARBOR_DIR / "env.sh"
+HARBOROPIK_SH = HARBOR_DIR / "harboropik.sh"
 START_SH = HARBOR_DIR / "start.sh"
 PREPARE_LOCAL = 'mkdir -p "$QUEUE_DIR" "$RUNTIME_DIR"; harbor_prepare_task_file'
 
@@ -20,6 +21,9 @@ class HarborTaskSelectionTest(unittest.TestCase):
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.pop("RESET_RUN", None)
+        env.pop("GEMINI_API_KEY", None)
+        env.pop("GOOGLE_API_KEY", None)
+        env.pop("HARBOR_DISALLOWED_TOOLS", None)
         env.update(overrides)
         return subprocess.run(
             ["bash", "-c", f'. "$1"; {command}', "bash", str(ENV_SH)],
@@ -104,6 +108,107 @@ class HarborTaskSelectionTest(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_deepsearchqa_alias_enables_native_web_tools(self) -> None:
+        for dataset_name in (
+            "deepsearchqa",
+            "kgmon/deepsearchqa",
+            "kgmon/deepsearchqa@latest",
+        ):
+            with self.subTest(dataset_name=dataset_name):
+                result = self.run_env(
+                    'printf "dataset=%s\\ntools=%s\\n" '
+                    '"$(harbor_registry_dataset_name)" "$HARBOR_DISALLOWED_TOOLS"',
+                    DATASET_NAME=dataset_name,
+                    OPIK_URL="",
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                expected_dataset = (
+                    "kgmon/deepsearchqa"
+                    if dataset_name == "deepsearchqa"
+                    else dataset_name
+                )
+                self.assertIn(f"dataset={expected_dataset}", result.stdout)
+                self.assertIn("tools=RemoteTrigger AskUserQuestion", result.stdout)
+
+    def test_deepsearchqa_preserves_explicit_disallowed_tools(self) -> None:
+        for explicit_value in ("WebSearch Bash", ""):
+            with self.subTest(explicit_value=explicit_value):
+                result = self.run_env(
+                    'printf "[%s]\\n" "$HARBOR_DISALLOWED_TOOLS"',
+                    DATASET_NAME="deepsearchqa",
+                    HARBOR_DISALLOWED_TOOLS=explicit_value,
+                    OPIK_URL="",
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), f"[{explicit_value}]")
+
+    def test_deepsearchqa_requires_a_judge_key(self) -> None:
+        result = self.run_env(
+            "harbor_validate_dataset_runtime_requirements",
+            DATASET_NAME="deepsearchqa",
+            GEMINI_API_KEY="",
+            GOOGLE_API_KEY="",
+            OPIK_URL="",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("GEMINI_API_KEY or GOOGLE_API_KEY", result.stderr)
+        self.assertIn("config.local.env", result.stderr)
+
+    def test_deepsearchqa_accepts_either_judge_key(self) -> None:
+        for key_name in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
+            with self.subTest(key_name=key_name):
+                result = self.run_env(
+                    "harbor_validate_dataset_runtime_requirements",
+                    DATASET_NAME="deepsearchqa",
+                    OPIK_URL="",
+                    **{key_name: "test-key"},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_deepsearchqa_live_runner_fails_before_creating_run_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "run"
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DATASET_NAME": "deepsearchqa",
+                    "GEMINI_API_KEY": "",
+                    "GOOGLE_API_KEY": "",
+                    "HARBOR_DRY_RUN": "0",
+                    "HARBOR_QUEUE_WORKER": "1",
+                    "OPIK_URL": "",
+                    "OUTPUT_PATH": str(output),
+                    "QUEUE_DIR": str(output / "queue"),
+                    "RUNTIME_DIR": str(output / "runtime"),
+                    "JOBS_ROOT": str(output / "jobs"),
+                }
+            )
+
+            result = subprocess.run(
+                ["bash", str(HARBOROPIK_SH)],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("GEMINI_API_KEY or GOOGLE_API_KEY", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_other_registry_datasets_do_not_require_a_judge_key(self) -> None:
+        result = self.run_env(
+            "harbor_validate_dataset_runtime_requirements",
+            DATASET_NAME="owner/dataset",
+            OPIK_URL="",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_local_selection_filters_and_guards_run_reuse(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/Agents/utils/common/Harbor/tests/test_task_selection.py
+++ b/Agents/utils/common/Harbor/tests/test_task_selection.py
@@ -21,8 +21,9 @@ class HarborTaskSelectionTest(unittest.TestCase):
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.pop("RESET_RUN", None)
-        env.pop("GEMINI_API_KEY", None)
-        env.pop("GOOGLE_API_KEY", None)
+        env.pop("JUDGE_BASE_URL", None)
+        env.pop("JUDGE_API_KEY", None)
+        env.pop("JUDGE_MODEL", None)
         env.pop("HARBOR_DISALLOWED_TOOLS", None)
         env.update(overrides)
         return subprocess.run(
@@ -112,6 +113,7 @@ class HarborTaskSelectionTest(unittest.TestCase):
     def test_deepsearchqa_alias_enables_native_web_tools(self) -> None:
         for dataset_name in (
             "deepsearchqa",
+            "deepsearchqa@latest",
             "kgmon/deepsearchqa",
             "kgmon/deepsearchqa@latest",
         ):
@@ -125,8 +127,8 @@ class HarborTaskSelectionTest(unittest.TestCase):
 
                 self.assertEqual(result.returncode, 0, result.stderr)
                 expected_dataset = (
-                    "kgmon/deepsearchqa"
-                    if dataset_name == "deepsearchqa"
+                    dataset_name.replace("deepsearchqa", "kgmon/deepsearchqa", 1)
+                    if dataset_name.startswith("deepsearchqa")
                     else dataset_name
                 )
                 self.assertIn(f"dataset={expected_dataset}", result.stdout)
@@ -145,30 +147,56 @@ class HarborTaskSelectionTest(unittest.TestCase):
                 self.assertEqual(result.returncode, 0, result.stderr)
                 self.assertEqual(result.stdout.strip(), f"[{explicit_value}]")
 
-    def test_deepsearchqa_requires_a_judge_key(self) -> None:
+    def test_empty_disallowed_tools_keeps_safe_default_for_other_datasets(self) -> None:
         result = self.run_env(
-            "harbor_validate_dataset_runtime_requirements",
-            DATASET_NAME="deepsearchqa",
-            GEMINI_API_KEY="",
-            GOOGLE_API_KEY="",
+            'printf "[%s]\\n" "$HARBOR_DISALLOWED_TOOLS"',
+            DATASET_NAME="terminalbench21",
+            HARBOR_DISALLOWED_TOOLS="",
             OPIK_URL="",
         )
 
-        self.assertEqual(result.returncode, 1)
-        self.assertIn("GEMINI_API_KEY or GOOGLE_API_KEY", result.stderr)
-        self.assertIn("config.local.env", result.stderr)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.strip(),
+            "[WebSearch WebFetch RemoteTrigger AskUserQuestion]",
+        )
 
-    def test_deepsearchqa_accepts_either_judge_key(self) -> None:
-        for key_name in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
-            with self.subTest(key_name=key_name):
-                result = self.run_env(
-                    "harbor_validate_dataset_runtime_requirements",
-                    DATASET_NAME="deepsearchqa",
-                    OPIK_URL="",
-                    **{key_name: "test-key"},
-                )
+    def test_deepsearchqa_requires_every_judge_setting(self) -> None:
+        valid_settings = {
+            "JUDGE_BASE_URL": "https://judge.example/v1/chat/completions",
+            "JUDGE_API_KEY": "test-key",
+            "JUDGE_MODEL": "test-model",
+        }
+        for missing_name in valid_settings:
+            for invalid_value in ("", " \t "):
+                with self.subTest(
+                    missing_name=missing_name,
+                    invalid_value=invalid_value,
+                ):
+                    settings = valid_settings.copy()
+                    settings[missing_name] = invalid_value
+                    result = self.run_env(
+                        "harbor_validate_dataset_runtime_requirements",
+                        DATASET_NAME="deepsearchqa",
+                        OPIK_URL="",
+                        **settings,
+                    )
 
-                self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn(missing_name, result.stderr)
+                    self.assertIn("config.local.env", result.stderr)
+
+    def test_deepsearchqa_accepts_complete_judge_settings(self) -> None:
+        result = self.run_env(
+            "harbor_validate_dataset_runtime_requirements",
+            DATASET_NAME="deepsearchqa",
+            JUDGE_BASE_URL="https://judge.example/v1/chat/completions",
+            JUDGE_API_KEY="test-key",
+            JUDGE_MODEL="test-model",
+            OPIK_URL="",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_deepsearchqa_live_runner_fails_before_creating_run_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -177,8 +205,9 @@ class HarborTaskSelectionTest(unittest.TestCase):
             env.update(
                 {
                     "DATASET_NAME": "deepsearchqa",
-                    "GEMINI_API_KEY": "",
-                    "GOOGLE_API_KEY": "",
+                    "JUDGE_BASE_URL": "",
+                    "JUDGE_API_KEY": "",
+                    "JUDGE_MODEL": "",
                     "HARBOR_DRY_RUN": "0",
                     "HARBOR_QUEUE_WORKER": "1",
                     "OPIK_URL": "",
@@ -198,7 +227,7 @@ class HarborTaskSelectionTest(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 1)
-            self.assertIn("GEMINI_API_KEY or GOOGLE_API_KEY", result.stderr)
+            self.assertIn("JUDGE_BASE_URL", result.stderr)
             self.assertFalse(output.exists())
 
     def test_other_registry_datasets_do_not_require_a_judge_key(self) -> None:

--- a/Tasks/AGENTS.md
+++ b/Tasks/AGENTS.md
@@ -11,6 +11,7 @@ and ClawBio run against an OpenClaw fleet from `Agents/Openclaw/` (see
 | Path | Role |
 | --- | --- |
 | `SETA/`, `SWE-smith/`, `SWE-verify/`, `Terminal-bench-2/` | Harbor task lists |
+| `DeepSearchQA/` | DeepSearchQA Harbor Hub entrypoint and verifier setup |
 | `Pinchbench/` | PinchBench runner for the OpenClaw fleet |
 | `clawBio/` | ClawBio bioinformatics benchmark for the OpenClaw fleet |
 
@@ -28,6 +29,10 @@ The `seta`, `sweverify`, and `terminalbench21` aliases resolve to Harbor
 registry datasets by default and skip these local files. `TASK_SOURCE_FILE=<path>`
 overrides the built-in selection for local runs. Task lists are owned here —
 don't duplicate them under `Agents/`.
+
+`deepsearchqa` is also a registry alias, resolving to `kgmon/deepsearchqa`.
+It has no local task list; see [DeepSearchQA/README.md](DeepSearchQA/README.md)
+for its web-tool and verifier-key requirements.
 
 ## PinchBench (`Pinchbench/`)
 

--- a/Tasks/AGENTS.md
+++ b/Tasks/AGENTS.md
@@ -32,7 +32,7 @@ don't duplicate them under `Agents/`.
 
 `deepsearchqa` is also a registry alias, resolving to `kgmon/deepsearchqa`.
 It has no local task list; see [DeepSearchQA/README.md](DeepSearchQA/README.md)
-for its web-tool and verifier-key requirements.
+for its web-tool and judge-endpoint requirements.
 
 ## PinchBench (`Pinchbench/`)
 

--- a/Tasks/DeepSearchQA/README.md
+++ b/Tasks/DeepSearchQA/README.md
@@ -1,0 +1,37 @@
+# DeepSearchQA
+
+Agent Fleet runs the published [Harbor Hub dataset](https://hub.harborframework.com/datasets/kgmon/deepsearchqa) without vendoring its 900 tasks. `DATASET_NAME=deepsearchqa` resolves to `kgmon/deepsearchqa`; a versioned registry ID such as `kgmon/deepsearchqa@<version>` also works directly.
+
+DeepSearchQA tasks require internet access. For Claude Code runs, the alias leaves `WebSearch` and `WebFetch` available while continuing to disable interactive and remote-trigger tools. An explicit `HARBOR_DISALLOWED_TOOLS` value always takes precedence.
+
+## Verifier credential
+
+The dataset verifier uses Gemini 2.5 Flash by default. Put one judge credential in the git-ignored `config.local.env`:
+
+```bash
+GEMINI_API_KEY=replace-with-your-key
+# Alternatively: GOOGLE_API_KEY=replace-with-your-key
+```
+
+The key is consumed by the verifier contract, not passed to the evaluated agent. Live runs fail before setup if neither variable is available. To use a different judge, set `DEEPSEARCHQA_GRADER_MODEL`; results from a different judge may not be directly comparable with the published benchmark.
+
+## Run
+
+Start with one task because both web research and judge calls can incur cost:
+
+```bash
+DATASET_NAME=deepsearchqa \
+HARBOR_LIMIT=1 \
+HARBOR_N_CONCURRENT=1 \
+bash Agents/utils/common/Harbor/start.sh --detach
+```
+
+For a full run, remove `HARBOR_LIMIT` and set the desired concurrency:
+
+```bash
+DATASET_NAME=deepsearchqa \
+HARBOR_N_CONCURRENT=10 \
+bash Agents/utils/common/Harbor/start.sh --detach
+```
+
+The native registry summary reports `mean_reward` from DeepSearchQA's primary `reward` metric and preserves the complete Harbor statistics in `OUTPUT_PATH/summary.txt`.

--- a/Tasks/DeepSearchQA/README.md
+++ b/Tasks/DeepSearchQA/README.md
@@ -1,19 +1,20 @@
 # DeepSearchQA
 
-Agent Fleet runs the published [Harbor Hub dataset](https://hub.harborframework.com/datasets/kgmon/deepsearchqa) without vendoring its 900 tasks. `DATASET_NAME=deepsearchqa` resolves to `kgmon/deepsearchqa`; a versioned registry ID such as `kgmon/deepsearchqa@<version>` also works directly.
+Agent Fleet runs the published [Harbor Hub dataset](https://hub.harborframework.com/datasets/kgmon/deepsearchqa) without vendoring its 900 tasks. `DATASET_NAME=deepsearchqa` resolves to `kgmon/deepsearchqa`; versioned forms such as `deepsearchqa@<version>` and `kgmon/deepsearchqa@<version>` also work.
 
 DeepSearchQA tasks require internet access. For Claude Code runs, the alias leaves `WebSearch` and `WebFetch` available while continuing to disable interactive and remote-trigger tools. An explicit `HARBOR_DISALLOWED_TOOLS` value always takes precedence.
 
-## Verifier credential
+## Judge endpoint
 
-The dataset verifier uses Gemini 2.5 Flash by default. Put one judge credential in the git-ignored `config.local.env`:
+Agent Fleet replaces the package's Gemini verifier at runtime with an OpenAI-compatible chat-completions verifier. Configure the existing judge endpoint values in the git-ignored `config.local.env`:
 
 ```bash
-GEMINI_API_KEY=replace-with-your-key
-# Alternatively: GOOGLE_API_KEY=replace-with-your-key
+JUDGE_BASE_URL=https://judge.example/v1/chat/completions
+JUDGE_API_KEY=replace-with-your-key
+JUDGE_MODEL=your-judge-model
 ```
 
-The key is consumed by the verifier contract, not passed to the evaluated agent. Live runs fail before setup if neither variable is available. To use a different judge, set `DEEPSEARCHQA_GRADER_MODEL`; results from a different judge may not be directly comparable with the published benchmark.
+These values are consumed only by the verifier and are not passed to the evaluated agent. Live runs fail before setup if any value is missing. Scores from a judge other than the package's original Gemini judge may not be directly comparable with the published benchmark.
 
 ## Run
 

--- a/Tasks/README.md
+++ b/Tasks/README.md
@@ -4,6 +4,7 @@ Benchmarks, task lists, and automated task workflows.
 
 | Path | Role |
 | --- | --- |
+| [`DeepSearchQA/`](./DeepSearchQA/) | DeepSearchQA Harbor Hub entrypoint and verifier setup. |
 | [`Pinchbench/`](./Pinchbench/) | PinchBench benchmark task runner for OpenClaw. |
 | [`clawBio/`](./clawBio/) | ClawBio benchmark task runner for OpenClaw. |
 | [`SWE-rebench-v2/`](./SWE-rebench-v2/) | SWE-rebench-v2 Harbor Hub entrypoint. |


### PR DESCRIPTION
## 1. Why the change?

Agent Fleet already accepts arbitrary Harbor registry IDs, but DeepSearchQA was not runnable with benchmark-appropriate defaults: the Claude Code runner disabled its native web tools, the published package's verifier required Gemini credentials, there was no early judge-endpoint validation, and the registry summary could not extract the primary reward from DeepSearchQA's multi-key metrics.

Source dataset: https://hub.harborframework.com/datasets/kgmon/deepsearchqa

## 2. Summary of the change

- Add `deepsearchqa` as an alias for `kgmon/deepsearchqa`, including bare and canonical versioned forms.
- Keep `WebSearch` and `WebFetch` available for DeepSearchQA Claude Code runs while preserving explicit `HARBOR_DISALLOWED_TOOLS` overrides; other datasets retain the existing safe default for empty values.
- Overlay only the published verifier's judge-call boundary with an OpenAI-compatible `/v1/chat/completions` adapter, preserving the official task metadata, grading prompt, and score calculation.
- Use the existing `JUDGE_BASE_URL`, `JUDGE_API_KEY`, and `JUDGE_MODEL` settings. They are injected only into the verifier environment and the API key is absent from Harbor command arguments and evaluated-agent variables.
- Fail live runs before creating run state when any judge setting is empty or whitespace-only; dry runs remain credential-free.
- Read `reward` from Harbor's multi-key aggregate metrics while retaining legacy `mean` support.
- Add focused unit/integration coverage and operator documentation for smoke runs, full runs, cost, and cross-judge comparability.

## 3. Other details

- The 900 published tasks remain in Harbor Hub and are not vendored into this repository.
- The adapter is applied consistently to Claude Code, OpenCode, Pi/shared Harbor, and Oracle command paths.
- Verified locally:
  - 15 focused Python tests
  - Python compile checks and Bash syntax checks for changed paths
  - Harbor v0.18 custom-verifier import and verifier-only environment injection
  - official downloaded DeepSearchQA verifier executed with the OpenAI-compatible judge overlay and a mocked chat-completions response
  - DeepSearchQA Harbor dry-run command assembly with the custom verifier selected and no judge key in arguments
  - clean staged diff and two independent review passes with no remaining Critical or Important findings
- Not run locally:
  - paid live web/judge E2E because no judge endpoint credentials are configured on this host
  - the full Linux-only Harbor shell integration suite because Docker is not running and the macOS host lacks its `flock`, `/proc`, and Linux-binary assumptions
