### PR TITLE
fix(ci): validate Harbor Python runtime

### DIFF
--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -47,6 +47,19 @@ jobs:
           # shellcheck source=scripts/prerequisites.sh
           source scripts/prerequisites.sh
           agent_fleet_bootstrap_setup_prerequisites
+          # Harbor's dependency-cache builder packages a Python 3.12 runtime
+          # for task containers. The generic prerequisite check only requires
+          # Python 3.9+, so check this pinned builder explicitly before Harbor
+          # opens its Zellij session.
+          required_python="${PYTHON_BIN:-python3.12}"
+          if ! command -v "$required_python" >/dev/null 2>&1; then
+            echo "::error::Harbor requires $required_python to prepare its dependency cache" >&2
+            exit 1
+          fi
+          if ! "$required_python" -c 'import sys; raise SystemExit(sys.version_info[:2] != (3, 12))'; then
+            echo "::error::Harbor dependency-cache builder requires Python 3.12, got $($required_python --version 2>&1)" >&2
+            exit 1
+          fi
 
       - name: Check host capacity
         id: capacity


### PR DESCRIPTION
## 1. Why the change?

The nightly Harbor E2E workflow reached the dependency-cache setup with only the generic Python 3.9+ prerequisite validated, then failed when Harbor required `python3.12`. This adds an early, actionable check so runner drift fails at preflight rather than after the Zellij benchmark session starts.

## 2. Summary of the change

- Validate the configured `PYTHON_BIN` (default: `python3.12`) is present after the shared prerequisite bootstrap.
- Require that interpreter to be Python 3.12, matching Harbor's dependency-cache builder.

## 3. Other details

The two bare-metal runners have been provisioned with Python 3.12 and the pinned Harbor runner environment. The rerun has advanced past the prior Python and missing-runner failures into the benchmark execution step.