### PR TITLE
feat(opensandbox): support portable verifier runtime bundles

### DIFF
--- a/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
+++ b/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
@@ -101,10 +101,16 @@ OCI Registry addressing is explicit:
 
 ```text
 Project = benchmark
-Repository = normalized task identity
+Repository = task identity (verbatim)
 tag = <service>-<short-input-hash>
 digest ref = <registry>/<project>/<task>@sha256:<artifact-digest>
 ```
+
+The default repository name must exactly match the task directory name. The
+image manager validates that it is already a legal OCI repository component;
+it does not sanitize, truncate, or append a hash. Invalid task identities must
+be fixed by the dataset adapter so that Registry publication never silently
+changes task identity.
 
 The `input_hash` is a full SHA-256 calculated before build and the Registry
 `artifact_digest` is collected by an independent `skopeo inspect` after copy.
@@ -112,7 +118,7 @@ Normal on-demand preparation keeps the target task repository as cache
 authority. Dataset prebuild additionally enables a persistent local
 uploaded-Bundle index under
 `<HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT>/uploaded-bundles/`. Entries are scoped by
-Registry host, Project, benchmark, platform, and normalized task repository.
+Registry host, Project, benchmark, platform, and verbatim task repository.
 They are written only after every service has resolved successfully through the
 Registry path.
 

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -22,6 +22,9 @@ Agents/utils/common/Harbor/
 ├── qz_task_instruction.py      # Exact QZ setup-prefix handoff before agent run
 ├── prepare_local_deps.sh       # Thin Python launcher
 ├── prepare_local_deps.py       # Package/cache preparation implementation
+├── python_runtime.py           # Shared portable Python runtime builder
+├── verifier_runtime/
+│   └── swe_rebench_v2_bundle_preparer.py # Dataset-specific bundle preparer
 ├── runner-requirements.txt     # Exact direct dependencies for the runner image
 ├── setup_runner_env.sh         # Explicit host setup / image validation
 ├── harbor_prepare_runner_cli.py # Startup validation for the configured CLI
@@ -92,6 +95,8 @@ including external commands required to complete them:
 | Shell caller | Python helper | Delegated responsibility |
 | --- | --- | --- |
 | `prepare_local_deps.sh` | `prepare_local_deps.py` | Downloads, runtime archives, npm caches, and manifest generation |
+| `prepare_local_deps.py` and `env.sh` | `python_runtime.py` | Builds and validates the reusable Python runtime primitive |
+| `env.sh` | `verifier_runtime/swe_rebench_v2_bundle_preparer.py` | Composes and validates the SWE-rebench-V2 verifier bundle |
 | `harboropik.sh` and model-fusion wrappers | `harbor_shell_utils.py` | Structured events, JSON normalization, URL parsing, and read-only mount JSON |
 | `monitor_harbor.sh` | `harbor_monitor_utils.py` | Reward, success, exception, and environment statistics |
 | `Agents/utils/rl/run_rl_rollout_server.sh`, `run_rl_rollout_worker.sh`, `monitor_rl_rollout.sh` | `Agents/utils/rl/rollout_worker_utils.py` | Request headers/JSON, LLM kwargs, result assembly, and monitor rendering |
@@ -179,6 +184,7 @@ Typical dataset paths:
 | `HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER` | Agent setup timeout multiplier |
 | `HARBOR_OPENSANDBOX_IMAGE_REF` | Legacy explicit single-image override; it must be fully qualified under `YICLOUD_HARBOR_HOST` |
 | `HARBOR_OPENSANDBOX_BUNDLE_MANIFEST` | Optional versioned service Bundle Manifest; every service image must be fully qualified under `YICLOUD_HARBOR_HOST` |
+| `HARBOR_OPENSANDBOX_BENCHMARK` | Benchmark identifier recorded in generated Bundles and consumed by the thin verifier-runtime bundle selector |
 | `HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT` | H-local Registry records, image locks, build logs, and immutable Bundle cache root |
 | `HARBOR_OPENSANDBOX_PREBUILD_USE_LOCAL_UPLOAD_CACHE` | Dataset prebuild local uploaded-Bundle index switch; defaults to `1` and avoids Registry lookup after a content-hash match |
 | `HARBOR_OPENSANDBOX_PREBUILD_SKIP_HASH_VERIFICATION` | Trust a matching target/task entry in the local uploaded-Bundle index without parsing or hashing task content; defaults to `0` |
@@ -192,7 +198,7 @@ Typical dataset paths:
 | `YICLOUD_SANDBOX_STATUS_LOG_INTERVAL_SEC` | Interval for Pending/state progress diagnostics, default `30` |
 | `YICLOUD_SANDBOX_RETAIN_ON_START_FAILURE` | Debug-only switch that skips automatic deletion after environment start failure, default `0` |
 | `YICLOUD_SANDBOX_RETAIN_AFTER_TRIAL` | Debug-only switch that retains a completed trial Sandbox until platform expiry, default `0` |
-| `YICLOUD_SANDBOX_UPLOAD_BACKEND` | OpenSandbox Agent/task input transport: `http`, strict object-store `s3`, or S3-preferred `auto` with the existing HTTP fallback; default `http`, while selecting an S3 profile implies `auto` unless explicitly set to strict `s3`. In `auto`, users without write credentials can reuse anonymously readable objects and fall back to HTTP when an object is absent |
+| `YICLOUD_SANDBOX_UPLOAD_BACKEND` | OpenSandbox Agent/task input transport: `http`, strict object-store `s3`, or S3-preferred `auto` with the existing HTTP fallback; default `http`, while selecting an S3 profile implies `auto` unless explicitly set to strict `s3`. In `auto`, users without write credentials can reuse anonymously readable objects and fall back to HTTP when an object is absent; every fallback emits a warning naming the attempted backend, fallback backend, artifact kind, phase, and target. A selected verifier runtime bundle requires `s3` or `auto` |
 | `YICLOUD_SANDBOX_S3_PROFILE` | Project-local provider profile under `.s3-profiles/<name>`; selecting one implies the `auto` backend by default and atomically resolves the bucket, anonymous read origin, prefix, and optional sibling write config |
 | `YICLOUD_SANDBOX_S3_CONFIG` | Optional s3cmd write configuration path available only to the Harbor runner; it is consulted when an immutable object is absent, never sent to a Sandbox, and may be omitted by read-only users |
 | `YICLOUD_SANDBOX_S3_BUCKET` | Bucket for immutable Agent and task input objects |

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -634,6 +634,65 @@ YICLOUD_HARBOR_HOST="${YICLOUD_HARBOR_HOST:-}"
 YICLOUD_HARBOR_PROJECT="${YICLOUD_HARBOR_PROJECT:-}"
 YICLOUD_HARBOR_TLS_VERIFY="${YICLOUD_HARBOR_TLS_VERIFY:-0}"
 HARBOR_OPENSANDBOX_BENCHMARK="${HARBOR_OPENSANDBOX_BENCHMARK:-$DATASET_NAME}"
+
+# Keep benchmark-specific verifier runtime policy in this thin selector. The
+# OpenSandbox provider treats the selected archive as an opaque filesystem
+# bundle and does not know which runtimes it contains.
+select_verifier_runtime_bundle() {
+  if [[ "$HARBOR_ENVIRONMENT_TYPE" != "opensandbox" ]]; then
+    printf '%s\n' "none"
+    return 0
+  fi
+  case "$HARBOR_OPENSANDBOX_BENCHMARK" in
+    agent-fleet-swe-rebench-v2)
+      printf '%s\n' "agent-fleet-swe-rebench-v2-verifier-bundle"
+      ;;
+    *)
+      printf '%s\n' "none"
+      ;;
+  esac
+}
+
+resolve_verifier_runtime_bundle() {
+  VERIFIER_RUNTIME_BUNDLE_ID="$1"
+  VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE=""
+  VERIFIER_RUNTIME_BUNDLE_ARCHIVE_MOUNT_PATH=""
+  VERIFIER_RUNTIME_BUNDLE_ROOT=""
+  VERIFIER_RUNTIME_BUNDLE_PREPARER=""
+  case "$VERIFIER_RUNTIME_BUNDLE_ID" in
+    none)
+      ;;
+    agent-fleet-swe-rebench-v2-verifier-bundle)
+      VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE="$HARBOR_CC_PY_WHEEL_DIR_SOURCE/$VERIFIER_RUNTIME_BUNDLE_ID.tar.gz"
+      VERIFIER_RUNTIME_BUNDLE_ARCHIVE_MOUNT_PATH="$HARBOR_CC_PY_WHEEL_DIR_MOUNT_PATH/$VERIFIER_RUNTIME_BUNDLE_ID.tar.gz"
+      VERIFIER_RUNTIME_BUNDLE_ROOT="/tmp/harbor-verifier-bundles/$VERIFIER_RUNTIME_BUNDLE_ID"
+      VERIFIER_RUNTIME_BUNDLE_PREPARER="$SCRIPT_DIR/verifier_runtime/swe_rebench_v2_bundle_preparer.py"
+      ;;
+    *)
+      echo "[ERROR] unknown verifier runtime bundle: $VERIFIER_RUNTIME_BUNDLE_ID" >&2
+      return 1
+      ;;
+  esac
+}
+
+resolve_verifier_runtime_bundle "$(select_verifier_runtime_bundle)"
+
+verifier_runtime_bundle_required() {
+  [[ "$VERIFIER_RUNTIME_BUNDLE_ID" != "none" ]]
+}
+
+validate_verifier_runtime_bundle_transport() {
+  verifier_runtime_bundle_required || return 0
+  case "$YICLOUD_SANDBOX_UPLOAD_BACKEND" in
+    s3|auto)
+      ;;
+    *)
+      echo "[ERROR] verifier runtime bundle $VERIFIER_RUNTIME_BUNDLE_ID requires YICLOUD_SANDBOX_UPLOAD_BACKEND=s3 or auto" >&2
+      return 1
+      ;;
+  esac
+}
+
 HARBOR_OPENSANDBOX_DOCKER_CONFIG="${HARBOR_OPENSANDBOX_DOCKER_CONFIG:-$HOME/.docker/config.json}"
 HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT="${HARBOR_OPENSANDBOX_IMAGE_CACHE_ROOT:-/data/harbor-runs/opensandbox-images}"
 HARBOR_OPENSANDBOX_IMAGE_PLATFORM="${HARBOR_OPENSANDBOX_IMAGE_PLATFORM:-linux/amd64}"
@@ -1352,13 +1411,32 @@ harbor_npm_tarball_version_ready() {
     "$path" "$expected_version" >/dev/null 2>&1
 }
 
+harbor_verifier_bundle_archive_ready() {
+  local path="$1"
+  [[ -f "$path" && -f "$VERIFIER_RUNTIME_BUNDLE_PREPARER" ]] \
+    && python3 "$VERIFIER_RUNTIME_BUNDLE_PREPARER" \
+      check --archive "$path" >/dev/null 2>&1
+}
+
+harbor_python_runtime_archive_ready() {
+  local path="$1"
+  [[ -f "$path" ]] \
+    && python3 "$SCRIPT_DIR/python_runtime.py" \
+      --check "$path" >/dev/null 2>&1
+}
+
+verifier_runtime_bundle_ready() {
+  verifier_runtime_bundle_required \
+    && harbor_verifier_bundle_archive_ready "$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE"
+}
+
 harbor_local_cache_ready() {
   [[ -f "$LOCAL_WHEEL_DIR/manifest.txt" ]] \
     && grep -qx 'cache_schema=3' "$LOCAL_WHEEL_DIR/manifest.txt" \
     && [[ "$(find "$LOCAL_WHEEL_DIR" -maxdepth 1 -name 'opik-*.whl' -type f | wc -l | tr -d ' ')" == "1" ]] \
     && [[ -f "$LOCAL_WHEEL_DIR/get-pip.py" ]] \
     && harbor_tar_file_ready "$LOCAL_WHEEL_DIR/node-runtime.tar.xz" \
-    && harbor_gzip_file_ready "$LOCAL_WHEEL_DIR/python3.12-runtime.tar.gz" \
+    && harbor_python_runtime_archive_ready "$LOCAL_WHEEL_DIR/python3.12-runtime.tar.gz" \
     && {
       if harbor_agent_is_opencode; then
         harbor_gzip_file_ready "$LOCAL_WHEEL_DIR/${OPENCODE_TGZ_BASENAME}" \
@@ -1465,6 +1543,20 @@ harbor_apply_effective_wheel_source() {
   fi
 }
 
+harbor_prewarm_s3_upload_sources() {
+  local -a sources=("$@")
+  echo "prewarming immutable OpenSandbox S3 objects..."
+  if python3 "$SCRIPT_DIR/opensandbox_s3_upload.py" preflight \
+    && python3 "$SCRIPT_DIR/opensandbox_s3_upload.py" prewarm "${sources[@]}"; then
+    return 0
+  fi
+  if [[ "$YICLOUD_SANDBOX_UPLOAD_BACKEND" == "auto" ]]; then
+    echo '[WARN] OpenSandbox S3 attempt failed backend=auto phase=prewarm; runtime will retry S3 and warn before any HTTP fallback' >&2
+    return 0
+  fi
+  return 1
+}
+
 harbor_prewarm_s3_upload_cache() {
   if [[ "$HARBOR_ENVIRONMENT_TYPE" != "opensandbox" \
     || ( "$YICLOUD_SANDBOX_UPLOAD_BACKEND" != "s3" \
@@ -1490,20 +1582,39 @@ harbor_prewarm_s3_upload_cache() {
         && sources+=("$TRACE_PLUGIN_OPENCODE_HOOK_SOURCE")
       ;;
   esac
+  if verifier_runtime_bundle_required && verifier_runtime_bundle_ready; then
+    sources+=("$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE")
+  fi
+  harbor_prewarm_s3_upload_sources "${sources[@]}"
+}
 
-  echo "prewarming immutable OpenSandbox S3 objects..."
-  if python3 "$SCRIPT_DIR/opensandbox_s3_upload.py" preflight \
-    && python3 "$SCRIPT_DIR/opensandbox_s3_upload.py" prewarm "${sources[@]}"; then
-    return 0
+harbor_build_verifier_runtime_bundle() {
+  verifier_runtime_bundle_required || return 0
+  validate_verifier_runtime_bundle_transport || return 1
+  verifier_runtime_bundle_ready && return 0
+
+  echo "preparing verifier runtime bundle: $VERIFIER_RUNTIME_BUNDLE_ID"
+  if [[ ! -f "$VERIFIER_RUNTIME_BUNDLE_PREPARER" ]] \
+    || ! python3 "$VERIFIER_RUNTIME_BUNDLE_PREPARER" build \
+    --cache-dir "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" \
+    --output "$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE"; then
+    echo "failed to prepare verifier runtime bundle: $VERIFIER_RUNTIME_BUNDLE_ID" >&2
+    return 1
   fi
-  if [[ "$YICLOUD_SANDBOX_UPLOAD_BACKEND" == "auto" ]]; then
-    echo '[WARN] OpenSandbox S3 prewarm was unavailable; runtime will retry anonymous reads and fall back to HTTP when necessary' >&2
-    return 0
+  if ! verifier_runtime_bundle_ready; then
+    echo "prepared verifier runtime bundle is invalid: $VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE" >&2
+    return 1
   fi
-  return 1
+}
+
+harbor_prepare_verifier_runtime_bundle() {
+  harbor_build_verifier_runtime_bundle || return 1
+  verifier_runtime_bundle_required || return 0
+  harbor_prewarm_s3_upload_sources "$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE"
 }
 
 harbor_prepare_or_select_wheels() {
+  validate_verifier_runtime_bundle_transport || return 1
   mkdir -p "$RUNTIME_DIR"
   local status_file="${RUNTIME_DIR}/local-deps-prepare.status"
   rm -f "$WORKERS_READY_FILE" "$WORKERS_FAILED_FILE" "$EFFECTIVE_WHEEL_URL_FILE" "$EFFECTIVE_CLAUDE_TGZ_URL_FILE" "$HARBOR_RUNNER_PREPARE_STATUS_FILE"
@@ -1512,6 +1623,11 @@ harbor_prepare_or_select_wheels() {
 
   if harbor_local_cache_ready; then
     echo "using local wheel cache"
+    harbor_build_verifier_runtime_bundle || {
+      echo "failed" > "$status_file"
+      touch "$WORKERS_FAILED_FILE"
+      return 1
+    }
     harbor_ensure_local_wheels_server
     harbor_write_effective_wheel_source "$HARBOR_LOCAL_WHEEL_SERVER_URL"
     harbor_prewarm_s3_upload_cache || {
@@ -1551,6 +1667,11 @@ harbor_prepare_or_select_wheels() {
     prepare_pi_cache=1
   fi
   if (cd "$SCRIPT_DIR" && WHEEL_DIR="$LOCAL_WHEEL_DIR" CACHE_SCHEMA=3 CLAUDE_CODE_VERSION="$CLAUDE_CODE_VERSION" CLAUDE_CODE_TGZ_BASENAME="$CLAUDE_CODE_TGZ_BASENAME" PREPARE_OPENCODE_CACHE="$prepare_opencode_cache" OPENCODE_VERSION="$OPENCODE_VERSION" OPENCODE_TGZ_BASENAME="$OPENCODE_TGZ_BASENAME" OPENCODE_LINUX_X64_TGZ_BASENAME="$OPENCODE_LINUX_X64_TGZ_BASENAME" PREPARE_PI_CACHE="$prepare_pi_cache" PI_VERSION="$PI_VERSION" PI_TGZ_BASENAME="$PI_TGZ_BASENAME" PI_NODE_RUNTIME_BASENAME="$PI_NODE_RUNTIME_BASENAME" PI_RUNTIME_BASENAME="$PI_RUNTIME_BASENAME" ./prepare_local_deps.sh 2>&1 | tee -a "$LOCAL_DEPS_LOG_FILE"); then
+    harbor_build_verifier_runtime_bundle || {
+      echo "failed" > "$status_file"
+      touch "$WORKERS_FAILED_FILE"
+      return 1
+    }
     harbor_ensure_local_wheels_server
     harbor_write_effective_wheel_source "$HARBOR_LOCAL_WHEEL_SERVER_URL"
     harbor_prewarm_s3_upload_cache || {
@@ -1570,8 +1691,18 @@ harbor_prepare_or_select_wheels() {
 
 harbor_prepare_agent_runtime() {
   if harbor_agent_is_oracle \
-    || [[ "$ROLLOUT" == "1" && "$RL_AGENT" == "oracle" ]] \
-    || [[ "$HARBOR_ENVIRONMENT_TYPE" == "e2b" || "$HARBOR_ENVIRONMENT_TYPE" == "qz" ]]; then
+    || [[ "$ROLLOUT" == "1" && "$RL_AGENT" == "oracle" ]]; then
+    mkdir -p "$RUNTIME_DIR"
+    rm -f "$WORKERS_FAILED_FILE" "$HARBOR_RUNNER_PREPARE_STATUS_FILE"
+    if harbor_prepare_verifier_runtime_bundle && harbor_validate_runner_cli; then
+      touch "$WORKERS_READY_FILE"
+      return 0
+    fi
+    touch "$WORKERS_FAILED_FILE"
+    return 1
+  fi
+
+  if [[ "$HARBOR_ENVIRONMENT_TYPE" == "e2b" || "$HARBOR_ENVIRONMENT_TYPE" == "qz" ]]; then
     mkdir -p "$RUNTIME_DIR"
     rm -f "$WORKERS_FAILED_FILE" "$HARBOR_RUNNER_PREPARE_STATUS_FILE"
     if harbor_validate_runner_cli; then

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -1595,7 +1595,9 @@ harbor_build_verifier_runtime_bundle() {
 
   echo "preparing verifier runtime bundle: $VERIFIER_RUNTIME_BUNDLE_ID"
   if [[ ! -f "$VERIFIER_RUNTIME_BUNDLE_PREPARER" ]] \
-    || ! python3 "$VERIFIER_RUNTIME_BUNDLE_PREPARER" build \
+    || [[ ! -x "$HARBOR_OPIK_PYTHON" ]] \
+    || ! PYTHON_BIN="$HARBOR_OPIK_PYTHON" \
+      "$HARBOR_OPIK_PYTHON" "$VERIFIER_RUNTIME_BUNDLE_PREPARER" build \
     --cache-dir "$HARBOR_CC_PY_WHEEL_DIR_SOURCE" \
     --output "$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE"; then
     echo "failed to prepare verifier runtime bundle: $VERIFIER_RUNTIME_BUNDLE_ID" >&2

--- a/Agents/utils/common/Harbor/harboropik.sh
+++ b/Agents/utils/common/Harbor/harboropik.sh
@@ -636,6 +636,49 @@ verifier_uv_bin_ready() {
     && [[ -x "$VERIFIER_UV_BIN_DIR_SOURCE/curl" ]]
 }
 
+opensandbox_verifier_tool_env_required() {
+  [[ "$HARBOR_ENVIRONMENT_TYPE" == "opensandbox" ]] \
+    && { verifier_uv_bin_ready || verifier_runtime_bundle_required; }
+}
+
+append_opensandbox_verifier_tool_env() {
+  local verifier_path_prefix=""
+  if verifier_uv_bin_ready; then
+    verifier_path_prefix="/root/.local/bin:/home/oai/.local/bin:/home/agent/.local/bin:/home/ubuntu/.local/bin"
+    if [[ -n "${HARBOR_VERIFIER_UV_HOME:-}" ]]; then
+      verifier_path_prefix="$HARBOR_VERIFIER_UV_HOME/.local/bin:$verifier_path_prefix"
+    fi
+    verifier_path_prefix="$verifier_path_prefix:$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH"
+    cmd+=(
+      --ve "HARBOR_VERIFIER_UV_BIN_DIR=$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH"
+    )
+  fi
+
+  if verifier_runtime_bundle_required; then
+    validate_verifier_runtime_bundle_transport || return 1
+    if ! verifier_runtime_bundle_ready; then
+      echo "[ERROR] verifier runtime bundle $VERIFIER_RUNTIME_BUNDLE_ID selected for $HARBOR_OPENSANDBOX_BENCHMARK, but its archive is missing or invalid" >&2
+      return 1
+    fi
+    if [[ -n "$verifier_path_prefix" ]]; then
+      verifier_path_prefix="$VERIFIER_RUNTIME_BUNDLE_ROOT/bin:$verifier_path_prefix"
+    else
+      verifier_path_prefix="$VERIFIER_RUNTIME_BUNDLE_ROOT/bin"
+    fi
+    cmd+=(
+      --ve "HARBOR_VERIFIER_RUNTIME_BUNDLE_ID=$VERIFIER_RUNTIME_BUNDLE_ID"
+      --ve "HARBOR_VERIFIER_RUNTIME_BUNDLE_ARCHIVE=$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_MOUNT_PATH"
+      --ve "HARBOR_VERIFIER_RUNTIME_BUNDLE_ROOT=$VERIFIER_RUNTIME_BUNDLE_ROOT"
+    )
+    echo "[INFO] OpenSandbox verifier runtime bundle: benchmark=$HARBOR_OPENSANDBOX_BENCHMARK bundle=$VERIFIER_RUNTIME_BUNDLE_ID" >&2
+  fi
+  if [[ -n "$verifier_path_prefix" ]]; then
+    cmd+=(
+      --ve "HARBOR_VERIFIER_PATH_PREPEND=$verifier_path_prefix"
+    )
+  fi
+}
+
 configure_e2b_verifier_uv_upload() {
   HARBOR_E2B_VERIFIER_UV_SOURCE=""
   if [[ "$HARBOR_ENVIRONMENT_TYPE" == "e2b" || "$HARBOR_ENVIRONMENT_TYPE" == "qz" ]] \
@@ -886,7 +929,34 @@ run_oracle_task() {
     cmd+=( --path "$DATASET_PATH" )
   fi
   append_environment_backend_args
-  if [[ "$HARBOR_ENVIRONMENT_TYPE" != "e2b" && "$HARBOR_ENVIRONMENT_TYPE" != "qz" ]] \
+  if opensandbox_verifier_tool_env_required; then
+    local verifier_mounts_json
+    local -a verifier_mount_args=()
+    if verifier_uv_bin_ready; then
+      verifier_mount_args+=(
+        --mount "$VERIFIER_UV_BIN_DIR_SOURCE"
+        "$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH" always
+      )
+    fi
+    if verifier_runtime_bundle_required; then
+      if ! verifier_runtime_bundle_ready; then
+        echo "[ERROR] verifier runtime bundle $VERIFIER_RUNTIME_BUNDLE_ID selected for $HARBOR_OPENSANDBOX_BENCHMARK, but its archive is missing" >&2
+        return 1
+      fi
+      verifier_mount_args+=(
+        --mount "$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE"
+        "$VERIFIER_RUNTIME_BUNDLE_ARCHIVE_MOUNT_PATH" always
+      )
+    fi
+    verifier_mounts_json="$(
+      python3 "$SCRIPT_DIR/harbor_shell_utils.py" readonly-mounts \
+        "${verifier_mount_args[@]}"
+    )"
+    cmd+=(
+      --mounts-json "$verifier_mounts_json"
+    )
+    append_opensandbox_verifier_tool_env
+  elif [[ "$HARBOR_ENVIRONMENT_TYPE" != "e2b" && "$HARBOR_ENVIRONMENT_TYPE" != "qz" ]] \
     && verifier_uv_bin_ready; then
     local verifier_mounts_json verifier_uv_path_prefix
     verifier_mounts_json="$(
@@ -1258,9 +1328,10 @@ run_harbor() {
   if [[ "$mounts_json" != "[]" ]]; then
     cmd+=( --mounts-json "$mounts_json" )
   fi
-  if [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" || "$HARBOR_ENVIRONMENT_TYPE" == "e2b" \
-    || "$HARBOR_ENVIRONMENT_TYPE" == "opensandbox" || "$HARBOR_ENVIRONMENT_TYPE" == "qz" ]] \
-    && verifier_uv_bin_ready; then
+  if opensandbox_verifier_tool_env_required; then
+    append_opensandbox_verifier_tool_env
+  elif [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" || "$HARBOR_ENVIRONMENT_TYPE" == "e2b" \
+    || "$HARBOR_ENVIRONMENT_TYPE" == "qz" ]] && verifier_uv_bin_ready; then
     local verifier_uv_path_prefix
     verifier_uv_path_prefix="/root/.local/bin:/home/oai/.local/bin:/home/agent/.local/bin:/home/ubuntu/.local/bin"
     if [[ -n "${HARBOR_VERIFIER_UV_HOME:-}" ]]; then
@@ -1541,9 +1612,10 @@ run_opencode_task() {
     if [[ "$mounts_json" != "[]" ]]; then
       cmd+=( --mounts-json "$mounts_json" )
     fi
-    if [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" || "$HARBOR_ENVIRONMENT_TYPE" == "e2b" \
-      || "$HARBOR_ENVIRONMENT_TYPE" == "opensandbox" || "$HARBOR_ENVIRONMENT_TYPE" == "qz" ]] \
-      && verifier_uv_bin_ready; then
+    if opensandbox_verifier_tool_env_required; then
+      append_opensandbox_verifier_tool_env
+    elif [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" || "$HARBOR_ENVIRONMENT_TYPE" == "e2b" \
+      || "$HARBOR_ENVIRONMENT_TYPE" == "qz" ]] && verifier_uv_bin_ready; then
       cmd+=(
         --ve "PATH=/root/.local/bin:/home/oai/.local/bin:/home/agent/.local/bin:/home/ubuntu/.local/bin:$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         --ve "HARBOR_VERIFIER_UV_BIN_DIR=$HARBOR_VERIFIER_UV_BIN_DIR_MOUNT_PATH"

--- a/Agents/utils/common/Harbor/opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/opensandbox_image_manager.py
@@ -1312,7 +1312,16 @@ def _compose_runtime(
         entrypoint_source = "image-config.entrypoint" if image_entrypoint else None
 
     command_overridden = service.command_present and service.command is not None
-    if command_overridden:
+    if legacy_dockerfile_keepalive:
+        # Harbor's Docker backend overlays every implicit single-Dockerfile
+        # task with ``command: [sh, -c, sleep infinity]``. Mirror that
+        # contract instead of releasing the image's default Cmd as a service
+        # process: language base images commonly default to an interactive
+        # interpreter (for example ``python3``), which exits immediately when
+        # detached from stdin.
+        effective_command = list(LEGACY_DOCKERFILE_KEEPALIVE)
+        command_source = "adapter.legacy-keepalive"
+    elif command_overridden:
         effective_command = _compose_argv(service.command, label="command")
         command_source = "compose.command"
     elif entrypoint_overridden:
@@ -1327,9 +1336,6 @@ def _compose_runtime(
     start_argv = [*effective_entrypoint, *effective_command]
     sources = [source for source in (entrypoint_source, command_source) if source]
     start_source = "+".join(sources) if sources else None
-    if not start_argv and legacy_dockerfile_keepalive:
-        start_argv = list(LEGACY_DOCKERFILE_KEEPALIVE)
-        start_source = "adapter.legacy-keepalive"
 
     if service.working_dir is not None:
         workdir = service.working_dir

--- a/Agents/utils/common/Harbor/opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/opensandbox_image_manager.py
@@ -909,18 +909,27 @@ class RegistryTarget:
         return f"{self.registry}/{self.repository}@{artifact_digest}"
 
 
-def normalize_task_repository(task_identity: str, *, maximum_length: int = 63) -> str:
-    """Make an OCI/Harbor-safe, collision-resistant task repository name."""
-    raw = task_identity.strip()
-    if not raw:
+def check_task_repository(task_identity: str, *, maximum_length: int = 255) -> str:
+    """Validate that a task identity can be used verbatim as its repository."""
+    if not task_identity:
         raise ValueError("task identity must not be empty")
-    normalized = re.sub(r"[^a-z0-9._-]+", "-", raw.lower()).strip("._-")
-    normalized = re.sub(r"[-._]{2,}", "-", normalized) or "task"
-    changed = normalized != raw
-    if changed or len(normalized) > maximum_length:
-        suffix = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
-        normalized = f"{normalized[: maximum_length - len(suffix) - 1].rstrip('._-')}-{suffix}"
-    return normalized[:maximum_length].rstrip("._-")
+    if len(task_identity) > maximum_length:
+        raise ValueError(
+            f"task identity exceeds the {maximum_length}-character repository limit: "
+            f"{task_identity!r}; fix the dataset adapter instead of renaming it during upload"
+        )
+    # OCI/Docker repository path components permit one dot or underscore,
+    # two underscores, or one-or-more dashes between lowercase alphanumeric
+    # runs. In particular, SWE-Rebench's ``owner__repository-issue`` identity
+    # is already valid and must remain unchanged.
+    if not re.fullmatch(
+        r"[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*", task_identity
+    ):
+        raise ValueError(
+            f"task identity is not a valid OCI repository component: {task_identity!r}; "
+            "fix the dataset adapter instead of renaming it during upload"
+        )
+    return task_identity
 
 
 class SkopeoPublisher:
@@ -1968,7 +1977,11 @@ def prepare_bundle(args: argparse.Namespace) -> PreparedBundle:
     target = RegistryTarget(
         registry=args.registry,
         project=args.project,
-        task_repository=args.task_repository or normalize_task_repository(task_dir.name),
+        task_repository=args.task_repository
+        or check_task_repository(
+            task_dir.name,
+            maximum_length=255 - len(args.project) - 1,
+        ),
     )
     reuse_local_upload = bool(getattr(args, "reuse_local_upload_cache", False))
     skip_hash_verification = bool(getattr(args, "skip_hash_verification", False))

--- a/Agents/utils/common/Harbor/prepare_local_deps.py
+++ b/Agents/utils/common/Harbor/prepare_local_deps.py
@@ -5,10 +5,8 @@ import json
 import os
 import re
 import shutil
-import stat
 import subprocess
 import sys
-import sysconfig
 import tarfile
 import tempfile
 import time
@@ -19,6 +17,11 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+try:
+    from . import python_runtime
+except ImportError:
+    import python_runtime
 
 
 def _value(environ: Mapping[str, str], name: str, default: str) -> str:
@@ -450,64 +453,7 @@ class DependencyPreparer:
         )
 
     def _build_py312_runtime_tarball(self) -> None:
-        target = self.config.py312_runtime_tarball
-        if target.is_file():
-            print("[prepare] skip python3.12 runtime tarball (cached)")
-            return
-        target.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.TemporaryDirectory() as temporary_name:
-            temporary = Path(temporary_name)
-            runtime_root = temporary / "python3.12-runtime"
-            runtime_bin = runtime_root / "bin"
-            runtime_lib = runtime_root / "lib"
-            runtime_bin.mkdir(parents=True)
-            runtime_lib.mkdir()
-
-            python_real = Path(sys.executable).resolve()
-            stdlib = Path(sysconfig.get_path("stdlib"))
-            version = sysconfig.get_config_var("VERSION") or "3.12"
-            libdir = Path(sysconfig.get_config_var("LIBDIR") or "")
-            libpython = next(iter(sorted(libdir.glob(f"libpython{version}*.so*"))), None)
-            shutil.copy2(python_real, runtime_bin / "python3.12.real")
-            shutil.copytree(stdlib, runtime_lib / "python3.12", symlinks=True)
-            if libpython and libpython.is_file():
-                shutil.copy2(libpython, runtime_lib / libpython.name, follow_symlinks=False)
-
-            system_lib = runtime_lib / "system"
-            system_lib.mkdir()
-            completed = subprocess.run(
-                ["ldd", str(runtime_bin / "python3.12.real")],
-                check=True,
-                text=True,
-                capture_output=True,
-            )
-            libraries = {
-                Path(field)
-                for field in completed.stdout.split()
-                if field.startswith("/") and Path(field).is_file()
-            }
-            for library in libraries:
-                try:
-                    shutil.copy2(library, system_lib / library.name, follow_symlinks=False)
-                except OSError:
-                    pass
-
-            wrapper = runtime_bin / "python3.12"
-            wrapper.write_text(
-                "#!/usr/bin/env bash\n"
-                "set -euo pipefail\n"
-                'SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
-                'RUNTIME_ROOT="$(cd "${SELF_DIR}/.." && pwd)"\n'
-                'export PYTHONHOME="${RUNTIME_ROOT}"\n'
-                'export LD_LIBRARY_PATH="${RUNTIME_ROOT}/lib/system:'
-                '${RUNTIME_ROOT}/lib:${LD_LIBRARY_PATH:-}"\n'
-                'exec "${SELF_DIR}/python3.12.real" "$@"\n',
-                encoding="utf-8",
-            )
-            wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-            with tarfile.open(target, "w:gz") as archive:
-                archive.add(runtime_root, arcname=runtime_root.name)
-        print(f"[prepare] built python3.12 runtime tarball: {target}")
+        python_runtime.build(self.config.py312_runtime_tarball)
 
     def _prepare_node_runtime_tarball(self) -> None:
         target = self.config.node_runtime_tarball

--- a/Agents/utils/common/Harbor/python_runtime.py
+++ b/Agents/utils/common/Harbor/python_runtime.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import stat
+import sys
+import sysconfig
+import tarfile
+import tempfile
+from pathlib import Path
+
+RUNTIME_ROOT = "python3.12-runtime"
+RUNTIME_MARKER = ".harbor-python-runtime-v2"
+
+
+def archive_ready(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        with tarfile.open(path) as archive:
+            members = {member.name.rstrip("/"): member for member in archive}
+    except (OSError, tarfile.TarError):
+        return False
+
+    wrapper = members.get(f"{RUNTIME_ROOT}/bin/python3.12")
+    executable = members.get(f"{RUNTIME_ROOT}/bin/python3.12.real")
+    stdlib = members.get(f"{RUNTIME_ROOT}/lib/python3.12")
+    marker = members.get(f"{RUNTIME_ROOT}/{RUNTIME_MARKER}")
+    return bool(
+        wrapper
+        and wrapper.isfile()
+        and wrapper.mode & 0o111
+        and executable
+        and executable.isfile()
+        and executable.mode & 0o111
+        and stdlib
+        and stdlib.isdir()
+        and marker
+        and marker.isfile()
+    )
+
+
+def build(target: Path) -> None:
+    if archive_ready(target):
+        print("[prepare] skip python3.12 runtime tarball (cached)")
+        return
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temporary_name:
+        temporary = Path(temporary_name)
+        runtime_root = temporary / RUNTIME_ROOT
+        runtime_bin = runtime_root / "bin"
+        runtime_lib = runtime_root / "lib"
+        runtime_bin.mkdir(parents=True)
+        runtime_lib.mkdir()
+
+        python_real = Path(sys.executable).resolve()
+        stdlib = Path(sysconfig.get_path("stdlib"))
+        version = sysconfig.get_config_var("VERSION") or "3.12"
+        if version != "3.12":
+            raise RuntimeError(f"Python 3.12 is required, got {version}")
+        libdir = Path(sysconfig.get_config_var("LIBDIR") or "")
+        libpython = next(iter(sorted(libdir.glob(f"libpython{version}*.so*"))), None)
+        shutil.copy2(python_real, runtime_bin / "python3.12.real")
+        shutil.copytree(stdlib, runtime_lib / "python3.12", symlinks=True)
+        if libpython and libpython.is_file():
+            shutil.copy2(libpython, runtime_lib / libpython.name)
+
+        # Never carry glibc or other host system libraries into task images.
+        # Mixing the host's libc with a task image's dynamic loader is not a
+        # portable runtime and can crash before Python reports an error. The
+        # managed CPython used here targets glibc 2.17 and must use the target
+        # image's own system libraries.
+        (runtime_root / RUNTIME_MARKER).write_text(
+            "target-system-libraries\n", encoding="utf-8"
+        )
+
+        wrapper = runtime_bin / "python3.12"
+        wrapper.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            'SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+            'RUNTIME_ROOT="$(cd "${SELF_DIR}/.." && pwd)"\n'
+            'export PYTHONHOME="${RUNTIME_ROOT}"\n'
+            'export LD_LIBRARY_PATH="${RUNTIME_ROOT}/lib:${LD_LIBRARY_PATH:-}"\n'
+            'exec "${SELF_DIR}/python3.12.real" "$@"\n',
+            encoding="utf-8",
+        )
+        wrapper.chmod(
+            wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+
+        file_descriptor, temporary_tar_name = tempfile.mkstemp(
+            prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+        )
+        os.close(file_descriptor)
+        temporary_tar = Path(temporary_tar_name)
+        try:
+            with tarfile.open(temporary_tar, "w:gz") as archive:
+                archive.add(runtime_root, arcname=runtime_root.name)
+            if not archive_ready(temporary_tar):
+                raise RuntimeError("generated Python runtime archive is invalid")
+            os.replace(temporary_tar, target)
+        finally:
+            temporary_tar.unlink(missing_ok=True)
+    print(f"[prepare] built python3.12 runtime tarball: {target}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--check", type=Path)
+    args = parser.parse_args()
+    if bool(args.output) == bool(args.check):
+        parser.error("exactly one of --output or --check is required")
+    if args.check:
+        return 0 if archive_ready(args.check) else 1
+    build(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -179,6 +179,14 @@ if grep -F -- 'FAKE_HARBOR_ARG=PATH=' <<< "$rebench" >/dev/null; then
   exit 1
 fi
 
+rebench_agent="$(run_dry \
+  'test-project/manual:immutable' "$tmp/does-not-exist.py" '{}' \
+  agent-fleet-swe-rebench-v2 opensandbox 0 claude-code)"
+grep -F -- 'HARBOR_VERIFIER_RUNTIME_BUNDLE_ARCHIVE=/opt/tb-opik/python-wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz' \
+  <<< "$rebench_agent" >/dev/null
+grep -F -- "\"source\":\"$tmp/deps/wheels\",\"target\":\"/opt/tb-opik/python-wheels\",\"read_only\":true" \
+  <<< "$rebench_agent" >/dev/null
+
 set +e
 http_rebench="$(RUN_DRY_UPLOAD_BACKEND=http run_dry \
   'test-project/manual:immutable' "$tmp/does-not-exist.py" '{}' \

--- a/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
+++ b/Agents/utils/common/Harbor/tests/test_harboropik_opensandbox.sh
@@ -48,6 +48,20 @@ printf 'FROM alpine:3.20\n' > "$tmp/dataset/1/environment/Dockerfile"
 printf 'fake package\n' > "$tmp/deps/claude.tgz"
 printf 'fake wheel\n' > "$tmp/deps/wheels/dependency.whl"
 printf '# fake Claude Opik hook\n' > "$tmp/deps/claude_realtime_trace.py"
+mkdir -p "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/bin"
+printf 'target-system-libraries\n' \
+  > "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/.harbor-python-runtime-v2"
+printf '#!/bin/sh\nexit 0\n' \
+  > "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/bin/python3.12"
+printf '#!/bin/sh\nexit 0\n' \
+  > "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/bin/harbor-verifier-bundle-check"
+chmod +x \
+  "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/bin/python3.12" \
+  "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/bin/harbor-verifier-bundle-check"
+ln -s python3.12 "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/bin/python3"
+ln -s python3.12 "$tmp/verifier-bundle/agent-fleet-swe-rebench-v2-verifier-bundle/bin/python"
+tar -czf "$tmp/deps/wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz" \
+  -C "$tmp/verifier-bundle" agent-fleet-swe-rebench-v2-verifier-bundle
 
 run_dry() {
   local image_ref="$1"
@@ -98,6 +112,8 @@ run_dry() {
     HARBOR_CC_CLAUDE_TGZ_SOURCE="$tmp/deps/claude.tgz" \
     HARBOR_CC_PY_WHEEL_DIR_SOURCE="$tmp/deps/wheels" \
     HARBOR_ENVIRONMENT_TYPE="$environment_type" \
+    YICLOUD_SANDBOX_UPLOAD_BACKEND="${RUN_DRY_UPLOAD_BACKEND:-auto}" \
+    YICLOUD_SANDBOX_S3_PROFILE= \
     HARBOR_OPENSANDBOX_IMAGE_REF="$image_ref" \
     HARBOR_OPENSANDBOX_BUNDLE_MANIFEST="$bundle_manifest" \
     YICLOUD_HARBOR_HOST=harbor.example.internal \
@@ -126,6 +142,82 @@ grep -F -- '--ek lifecycle_minutes=120' <<< "$automatic" >/dev/null
 grep -F -- '--mounts-json' <<< "$automatic" >/dev/null
 grep -F -- 'HARBOR_VERIFIER_UV_BIN_DIR=/opt/tb-uv-backup/bin' \
   <<< "$automatic" >/dev/null
+grep -F -- 'HARBOR_VERIFIER_PATH_PREPEND=/root/.local/bin:' \
+  <<< "$automatic" >/dev/null
+if grep -F -- 'HARBOR_VERIFIER_RUNTIME_BUNDLE_' <<< "$automatic" >/dev/null; then
+  echo 'non-Rebench OpenSandbox verifier unexpectedly receives a runtime bundle' >&2
+  exit 1
+fi
+if grep -F -- 'FAKE_HARBOR_ARG=PATH=' <<< "$automatic" >/dev/null; then
+  echo 'OpenSandbox verifier unexpectedly replaces the task image PATH' >&2
+  exit 1
+fi
+
+rebench="$(run_dry \
+  'test-project/manual:immutable' "$tmp/does-not-exist.py" '{}' \
+  agent-fleet-swe-rebench-v2)"
+grep -F -- '[INFO] OpenSandbox verifier runtime bundle: benchmark=agent-fleet-swe-rebench-v2 bundle=agent-fleet-swe-rebench-v2-verifier-bundle' \
+  <<< "$rebench" >/dev/null
+grep -F -- 'HARBOR_VERIFIER_PATH_PREPEND=/tmp/harbor-verifier-bundles/agent-fleet-swe-rebench-v2-verifier-bundle/bin:' \
+  <<< "$rebench" >/dev/null
+grep -F -- 'HARBOR_VERIFIER_RUNTIME_BUNDLE_ID=agent-fleet-swe-rebench-v2-verifier-bundle' \
+  <<< "$rebench" >/dev/null
+if grep -F -- 'HARBOR_VERIFIER_RUNTIME_BUNDLE_KIND=' <<< "$rebench" >/dev/null; then
+  echo 'Rebench verifier runtime bundle unexpectedly exposes a kind' >&2
+  exit 1
+fi
+grep -F -- 'HARBOR_VERIFIER_RUNTIME_BUNDLE_ARCHIVE=/opt/tb-opik/python-wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz' \
+  <<< "$rebench" >/dev/null
+grep -F -- 'HARBOR_VERIFIER_RUNTIME_BUNDLE_ROOT=/tmp/harbor-verifier-bundles/agent-fleet-swe-rebench-v2-verifier-bundle' \
+  <<< "$rebench" >/dev/null
+grep -F -- "$tmp/deps/wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz" \
+  <<< "$rebench" >/dev/null
+grep -F -- '/opt/tb-opik/python-wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz' \
+  <<< "$rebench" >/dev/null
+if grep -F -- 'FAKE_HARBOR_ARG=PATH=' <<< "$rebench" >/dev/null; then
+  echo 'Rebench OpenSandbox verifier unexpectedly replaces the task image PATH' >&2
+  exit 1
+fi
+
+set +e
+http_rebench="$(RUN_DRY_UPLOAD_BACKEND=http run_dry \
+  'test-project/manual:immutable' "$tmp/does-not-exist.py" '{}' \
+  agent-fleet-swe-rebench-v2)"
+http_rebench_status="$?"
+set -e
+if [[ "$http_rebench_status" == "0" ]]; then
+  echo 'Rebench verifier runtime bundle unexpectedly accepted HTTP-only transport' >&2
+  exit 1
+fi
+grep -F -- 'requires YICLOUD_SANDBOX_UPLOAD_BACKEND=s3 or auto' \
+  <<< "$http_rebench" >/dev/null
+
+legacy_rebench_alias="$(run_dry \
+  'test-project/manual:immutable' "$tmp/does-not-exist.py" '{}' \
+  swe-rebench-v2)"
+if grep -F -- 'HARBOR_VERIFIER_RUNTIME_BUNDLE_' \
+  <<< "$legacy_rebench_alias" >/dev/null; then
+  echo 'legacy Rebench alias unexpectedly selects a verifier runtime bundle' >&2
+  exit 1
+fi
+
+mv "$tmp/deps/wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz" \
+  "$tmp/deps/wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz.saved"
+set +e
+missing_rebench_runtime="$(run_dry \
+  'test-project/manual:immutable' "$tmp/does-not-exist.py" '{}' \
+  agent-fleet-swe-rebench-v2)"
+missing_rebench_status="$?"
+set -e
+mv "$tmp/deps/wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz.saved" \
+  "$tmp/deps/wheels/agent-fleet-swe-rebench-v2-verifier-bundle.tar.gz"
+if [[ "$missing_rebench_status" == "0" ]]; then
+  echo 'Rebench OpenSandbox verifier unexpectedly accepted a missing runtime' >&2
+  exit 1
+fi
+grep -F -- 'runtime bundle agent-fleet-swe-rebench-v2-verifier-bundle selected for agent-fleet-swe-rebench-v2, but its archive is missing' \
+  <<< "$missing_rebench_runtime" >/dev/null
+
 grep -F -- '[INFO] OpenSandbox Bundle Manifest ready:' <<< "$automatic" >/dev/null
 automatic_bundle="$(sed -n \
   's/^\[INFO\] OpenSandbox Bundle Manifest ready: //p' \

--- a/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
@@ -314,7 +314,7 @@ services:
             "image-config.entrypoint+compose.command",
         )
 
-    def test_commandless_implicit_dockerfile_gets_legacy_keepalive_only(self) -> None:
+    def test_implicit_dockerfile_overrides_image_cmd_with_keepalive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             task = self.make_task(Path(tmp), "commandless")
             from compose_bundle import resolve_bundle_spec
@@ -324,7 +324,7 @@ services:
             artifact = {
                 "config": {
                     "entrypoint": None,
-                    "cmd": None,
+                    "cmd": ["python3"],
                     "exposed_ports": [],
                     "healthcheck": None,
                 },
@@ -356,8 +356,11 @@ services:
             implicit["runtime"]["start_argv_source"],
             "adapter.legacy-keepalive",
         )
-        self.assertEqual(explicit_compose["runtime"]["start_argv"], [])
-        self.assertIsNone(explicit_compose["runtime"]["start_argv_source"])
+        self.assertEqual(explicit_compose["runtime"]["start_argv"], ["python3"])
+        self.assertEqual(
+            explicit_compose["runtime"]["start_argv_source"],
+            "image-config.cmd",
+        )
 
     def test_compose_dry_run_writes_versioned_bundle_and_keeps_main_ref(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
@@ -25,6 +25,7 @@ from opensandbox_image_manager import (
     _compose_runtime,
     _service_manifest,
     apt_404_requires_cache_refresh,
+    check_task_repository,
     environment_content_hash,
     github_mirror_config_content,
     mirror_image_ref,
@@ -914,6 +915,28 @@ networks:
             target.digest_ref("sha256:" + "b" * 64),
             "registry.example/seta/973@sha256:" + "b" * 64,
         )
+
+    def test_task_repository_preserves_valid_task_identity_verbatim(self) -> None:
+        self.assertEqual(
+            check_task_repository("aeon-toolkit__aeon-2822"),
+            "aeon-toolkit__aeon-2822",
+        )
+        self.assertEqual(
+            check_task_repository("task_000002_8be5378a"),
+            "task_000002_8be5378a",
+        )
+        long_identity = f"owner__{'repository-' * 10}123"
+        self.assertEqual(check_task_repository(long_identity), long_identity)
+
+    def test_task_repository_rejects_identity_that_requires_renaming(self) -> None:
+        for identity in ("Owner__Repo-1", "owner/repo-1", "owner repo-1"):
+            with self.subTest(identity=identity), self.assertRaisesRegex(
+                ValueError, "fix the dataset adapter"
+            ):
+                check_task_repository(identity)
+
+        with self.assertRaisesRegex(ValueError, "exceeds the 8-character"):
+            check_task_repository("valid-name", maximum_length=8)
 
     def test_skopeo_login_password_uses_subprocess_input_only(self) -> None:
         target = RegistryTarget("registry.example", "seta", "973")

--- a/Agents/utils/common/Harbor/tests/test_opensandbox_s3_auto_fallback.sh
+++ b/Agents/utils/common/Harbor/tests/test_opensandbox_s3_auto_fallback.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HARBOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Isolate the helper so this contract test does not source the full runner.
+eval "$(sed -n '/^harbor_prewarm_s3_upload_sources()/,/^}/p' "$HARBOR_DIR/env.sh")"
+eval "$(sed -n '/^harbor_prewarm_s3_upload_cache()/,/^}/p' "$HARBOR_DIR/env.sh")"
+
+mkdir -p "$tmp/deps"
+HARBOR_ENVIRONMENT_TYPE=opensandbox
+YICLOUD_SANDBOX_UPLOAD_BACKEND=auto
+LOCAL_WHEEL_DIR="$tmp/deps"
+AGENT=claude-code
+HARBOR_CC_CLAUDE_TGZ_SOURCE="$tmp/missing-claude.tgz"
+HARBOR_CC_HOOK_SOURCE="$tmp/missing-hook.py"
+SCRIPT_DIR="$HARBOR_DIR"
+
+# Simulate an unavailable S3 prewarm without touching external state.
+python3() { return 1; }
+
+output="$(harbor_prewarm_s3_upload_cache 2>&1)"
+grep -Fx -- 'prewarming immutable OpenSandbox S3 objects...' <<< "$output" >/dev/null
+grep -Fx -- '[WARN] OpenSandbox S3 attempt failed backend=auto phase=prewarm; runtime will retry S3 and warn before any HTTP fallback' <<< "$output" >/dev/null
+
+echo 'OpenSandbox S3 auto fallback warning test passed.'

--- a/Agents/utils/common/Harbor/tests/test_python_runtime.py
+++ b/Agents/utils/common/Harbor/tests/test_python_runtime.py
@@ -1,0 +1,58 @@
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from Agents.utils.common.Harbor import python_runtime
+
+
+class PreparePythonRuntimeTest(unittest.TestCase):
+    def test_archive_ready_checks_only_runtime_primitive(self):
+        with tempfile.TemporaryDirectory() as temporary_name:
+            root = Path(temporary_name)
+            valid = root / "python-runtime.tar.gz"
+            with tarfile.open(valid, "w:gz") as archive:
+                for name in (
+                    "python3.12-runtime/bin/python3.12",
+                    "python3.12-runtime/bin/python3.12.real",
+                ):
+                    payload = b"#!/bin/sh\nexit 0\n"
+                    info = tarfile.TarInfo(name)
+                    info.mode = 0o755
+                    info.size = len(payload)
+                    archive.addfile(info, io.BytesIO(payload))
+                stdlib = tarfile.TarInfo("python3.12-runtime/lib/python3.12")
+                stdlib.type = tarfile.DIRTYPE
+                archive.addfile(stdlib)
+                marker_payload = b"target-system-libraries\n"
+                marker = tarfile.TarInfo("python3.12-runtime/.harbor-python-runtime-v2")
+                marker.size = len(marker_payload)
+                archive.addfile(marker, io.BytesIO(marker_payload))
+
+            self.assertTrue(python_runtime.archive_ready(valid))
+            self.assertFalse(python_runtime.archive_ready(root / "missing"))
+
+    def test_archive_ready_rejects_runtime_without_portability_marker(self):
+        with tempfile.TemporaryDirectory() as temporary_name:
+            root = Path(temporary_name)
+            legacy = root / "legacy-python-runtime.tar.gz"
+            with tarfile.open(legacy, "w:gz") as archive:
+                for name in (
+                    "python3.12-runtime/bin/python3.12",
+                    "python3.12-runtime/bin/python3.12.real",
+                ):
+                    payload = b"#!/bin/sh\nexit 0\n"
+                    info = tarfile.TarInfo(name)
+                    info.mode = 0o755
+                    info.size = len(payload)
+                    archive.addfile(info, io.BytesIO(payload))
+                stdlib = tarfile.TarInfo("python3.12-runtime/lib/python3.12")
+                stdlib.type = tarfile.DIRTYPE
+                archive.addfile(stdlib)
+
+            self.assertFalse(python_runtime.archive_ready(legacy))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_swe_rebench_v2_bundle_preparer.py
+++ b/Agents/utils/common/Harbor/tests/test_swe_rebench_v2_bundle_preparer.py
@@ -1,0 +1,77 @@
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from Agents.utils.common.Harbor.verifier_runtime import (
+    swe_rebench_v2_bundle_preparer,
+)
+
+
+class SweRebenchV2BundlePreparerTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.python_runtime = self.root / "python3.12-runtime.tar.gz"
+        with tarfile.open(self.python_runtime, "w:gz") as archive:
+            for name in (
+                "python3.12-runtime/bin/python3.12",
+                "python3.12-runtime/bin/python3.12.real",
+            ):
+                payload = b"#!/bin/sh\nexit 0\n"
+                info = tarfile.TarInfo(name)
+                info.mode = 0o755
+                info.size = len(payload)
+                archive.addfile(info, io.BytesIO(payload))
+            stdlib = tarfile.TarInfo("python3.12-runtime/lib/python3.12")
+            stdlib.type = tarfile.DIRTYPE
+            archive.addfile(stdlib)
+            marker_payload = b"target-system-libraries\n"
+            marker = tarfile.TarInfo("python3.12-runtime/.harbor-python-runtime-v2")
+            marker.size = len(marker_payload)
+            archive.addfile(marker, io.BytesIO(marker_payload))
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_builds_rebench_bundle_around_runtime_primitive(self):
+        output = self.root / "bundle.tar.gz"
+
+        swe_rebench_v2_bundle_preparer.build(self.python_runtime, output)
+
+        self.assertTrue(swe_rebench_v2_bundle_preparer.archive_ready(output))
+        root = swe_rebench_v2_bundle_preparer.BUNDLE_ID
+        with tarfile.open(output) as archive:
+            members = {member.name.rstrip("/"): member for member in archive}
+        self.assertIn(f"{root}/bin/python3.12.real", members)
+        self.assertEqual(members[f"{root}/bin/python3"].linkname, "python3.12")
+        self.assertEqual(members[f"{root}/bin/python"].linkname, "python3.12")
+        self.assertTrue(
+            members[f"{root}/bin/harbor-verifier-bundle-check"].mode & 0o111
+        )
+        self.assertIn(f"{root}/.harbor-python-runtime-v2", members)
+
+    def test_preparer_owns_runtime_source_selection(self):
+        cache_dir = self.root / "cache"
+        cache_dir.mkdir()
+        cached_runtime = cache_dir / "python3.12-runtime.tar.gz"
+        self.python_runtime.replace(cached_runtime)
+        output = self.root / "bundle.tar.gz"
+
+        swe_rebench_v2_bundle_preparer.prepare(cache_dir, output)
+
+        self.assertTrue(swe_rebench_v2_bundle_preparer.archive_ready(output))
+
+    def test_rejects_invalid_runtime_primitive(self):
+        invalid = self.root / "invalid.tar.gz"
+        invalid.write_text("not an archive", encoding="utf-8")
+
+        with self.assertRaisesRegex(RuntimeError, "invalid Python runtime archive"):
+            swe_rebench_v2_bundle_preparer.build(
+                invalid, self.root / "bundle.tar.gz"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Agents/utils/common/Harbor/tests/test_swe_rebench_v2_bundle_preparer.py
+++ b/Agents/utils/common/Harbor/tests/test_swe_rebench_v2_bundle_preparer.py
@@ -1,4 +1,6 @@
 import io
+import os
+import subprocess
 import tarfile
 import tempfile
 import unittest
@@ -62,6 +64,60 @@ class SweRebenchV2BundlePreparerTest(unittest.TestCase):
         swe_rebench_v2_bundle_preparer.prepare(cache_dir, output)
 
         self.assertTrue(swe_rebench_v2_bundle_preparer.archive_ready(output))
+
+    def test_shell_builder_uses_configured_runner_python(self):
+        env_sh = Path(__file__).parents[1] / "env.sh"
+        runner_python = self.root / "runner-python"
+        invocation_log = self.root / "runner-invocation.txt"
+        preparer = self.root / "preparer.py"
+        preparer.touch()
+        runner_python.write_text(
+            "#!/bin/sh\n"
+            'printf "%s\\n" "$PYTHON_BIN" "$@" > "$INVOCATION_LOG"\n'
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        runner_python.chmod(0o755)
+        script = r'''
+set -euo pipefail
+eval "$(sed -n '/^harbor_build_verifier_runtime_bundle()/,/^}/p' "$1")"
+verifier_runtime_bundle_required() { return 0; }
+validate_verifier_runtime_bundle_transport() { return 0; }
+verifier_runtime_bundle_ready() { return 1; }
+HARBOR_OPIK_PYTHON="$2"
+VERIFIER_RUNTIME_BUNDLE_PREPARER="$3"
+VERIFIER_RUNTIME_BUNDLE_ID=test-bundle
+HARBOR_CC_PY_WHEEL_DIR_SOURCE="$4"
+VERIFIER_RUNTIME_BUNDLE_ARCHIVE_SOURCE="$4/bundle.tar.gz"
+if harbor_build_verifier_runtime_bundle; then
+  exit 90
+fi
+'''
+        environment = os.environ.copy()
+        environment["INVOCATION_LOG"] = str(invocation_log)
+
+        completed = subprocess.run(
+            [
+                "bash",
+                "-c",
+                script,
+                "bash",
+                str(env_sh),
+                str(runner_python),
+                str(preparer),
+                str(self.root),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=environment,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        invocation = invocation_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(invocation[0], str(runner_python))
+        self.assertEqual(invocation[1:3], [str(preparer), "build"])
+        self.assertNotIn("python3.12", invocation)
 
     def test_rejects_invalid_runtime_primitive(self):
         invalid = self.root / "invalid.tar.gz"

--- a/Agents/utils/common/Harbor/tests/test_yicloud_opensandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_yicloud_opensandbox.py
@@ -165,7 +165,7 @@ class YiCloudOpenSandboxTest(unittest.TestCase):
             runtime_root = root / "runtime" / source_root.name
             tools = root / "tools"
             tools.mkdir()
-            for name in ("gzip", "mkdir", "tar"):
+            for name in ("gzip", "mkdir", "rm", "tar"):
                 target = shutil.which(name)
                 self.assertIsNotNone(target)
                 os.symlink(target, tools / name)
@@ -204,25 +204,40 @@ class YiCloudOpenSandboxTest(unittest.TestCase):
             [str(runtime_root / "bin" / "python3"), "portable-python"],
         )
 
-    def test_verifier_runtime_reuses_materialized_portable_python(self) -> None:
+    def test_verifier_runtime_replaces_agent_writable_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            source_root = root / "source" / "python3.12-runtime"
+            source_bin = source_root / "bin"
+            source_bin.mkdir(parents=True)
+            python = source_bin / "python3.12"
+            python.write_text("#!/bin/sh\nprintf 'portable-python\\n'\n")
+            python.chmod(0o755)
+            (source_bin / "python3").symlink_to("python3.12")
+            (source_bin / "python").symlink_to("python3.12")
+            check = source_bin / "harbor-verifier-bundle-check"
+            check.write_text('#!/bin/sh\nexec "${0%/*}/python3" >/dev/null\n')
+            check.chmod(0o755)
+            archive = root / "python3.12-runtime.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                bundle.add(source_root, arcname=source_root.name)
+
             runtime_root = root / "runtime" / "python3.12-runtime"
             runtime_bin = runtime_root / "bin"
             runtime_bin.mkdir(parents=True)
             python = runtime_bin / "python3.12"
-            python.write_text("#!/bin/sh\nprintf 'reused-python\\n'\n")
+            python.write_text("#!/bin/sh\nprintf 'agent-python\\n'\n")
             python.chmod(0o755)
             (runtime_bin / "python3").symlink_to("python3.12")
             (runtime_bin / "python").symlink_to("python3.12")
             check = runtime_bin / "harbor-verifier-bundle-check"
-            check.write_text('#!/bin/sh\nexec "${0%/*}/python3" >/dev/null\n')
+            check.write_text("#!/bin/sh\nexit 0\n")
             check.chmod(0o755)
             (runtime_root / ".harbor-verifier-bundle-materialized-v1").touch()
 
             tools = root / "tools"
             tools.mkdir()
-            for name in ("touch",):
+            for name in ("gzip", "mkdir", "rm", "tar"):
                 target = shutil.which(name)
                 self.assertIsNotNone(target)
                 os.symlink(target, tools / name)
@@ -237,7 +252,7 @@ class YiCloudOpenSandboxTest(unittest.TestCase):
                         "test-python-verifier-bundle"
                     ),
                     yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ARCHIVE_ENV: str(
-                        root / "already-consumed.tar.gz"
+                        archive
                     ),
                     yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ROOT_ENV: str(
                         runtime_root
@@ -251,9 +266,13 @@ class YiCloudOpenSandboxTest(unittest.TestCase):
                 check=False,
                 env={"PATH": str(tools), **(env or {})},
             )
+            legacy_marker_exists = (
+                runtime_root / ".harbor-verifier-bundle-materialized-v1"
+            ).exists()
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
-        self.assertEqual(completed.stdout.strip(), "reused-python")
+        self.assertEqual(completed.stdout.strip(), "portable-python")
+        self.assertFalse(legacy_marker_exists)
 
     def test_verifier_runtime_bundle_settings_must_be_complete(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be configured together"):

--- a/Agents/utils/common/Harbor/tests/test_yicloud_opensandbox.py
+++ b/Agents/utils/common/Harbor/tests/test_yicloud_opensandbox.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 import types
@@ -113,6 +114,191 @@ class FakeSandbox:
 
 
 class YiCloudOpenSandboxTest(unittest.TestCase):
+    def test_exec_runtime_keeps_missing_environment_as_none(self) -> None:
+        command, env = yicloud_opensandbox._prepare_exec_runtime("true", None)
+
+        self.assertEqual(command, "true")
+        self.assertIsNone(env)
+
+    def test_verifier_runtime_prepends_without_replacing_image_path(self) -> None:
+        wrapped, env = yicloud_opensandbox._prepare_exec_runtime(
+            'printf "%s\\n" "$PATH"',
+            {
+                yicloud_opensandbox.VERIFIER_PATH_PREPEND_ENV: "/verifier/bin",
+                "KEEP": "value",
+            },
+        )
+
+        completed = subprocess.run(
+            ["/bin/sh", "-c", wrapped],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": "/image/runtime/bin:/usr/bin:/bin", **env},
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(
+            completed.stdout.strip(),
+            "/verifier/bin:/image/runtime/bin:/usr/bin:/bin",
+        )
+        self.assertEqual(env, {"KEEP": "value"})
+
+    def test_verifier_runtime_materializes_portable_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_root = root / "source" / "python3.12-runtime"
+            source_bin = source_root / "bin"
+            source_bin.mkdir(parents=True)
+            python = source_bin / "python3.12"
+            python.write_text("#!/bin/sh\nprintf 'portable-python\\n'\n")
+            python.chmod(0o755)
+            (source_bin / "python3").symlink_to("python3.12")
+            (source_bin / "python").symlink_to("python3.12")
+            check = source_bin / "harbor-verifier-bundle-check"
+            check.write_text('#!/bin/sh\nexec "${0%/*}/python3" >/dev/null\n')
+            check.chmod(0o755)
+            archive = root / "python3.12-runtime.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                bundle.add(source_root, arcname=source_root.name)
+
+            runtime_root = root / "runtime" / source_root.name
+            tools = root / "tools"
+            tools.mkdir()
+            for name in ("gzip", "mkdir", "tar"):
+                target = shutil.which(name)
+                self.assertIsNotNone(target)
+                os.symlink(target, tools / name)
+            image_python = tools / "python3"
+            image_python.write_text("#!/bin/sh\nprintf 'image-python\\n'\n")
+            image_python.chmod(0o755)
+
+            wrapped, env = yicloud_opensandbox._prepare_exec_runtime(
+                "command -v python3 && python3",
+                {
+                    yicloud_opensandbox.VERIFIER_PATH_PREPEND_ENV: str(
+                        runtime_root / "bin"
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ID_ENV: (
+                        "test-python-verifier-bundle"
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ARCHIVE_ENV: str(
+                        archive
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ROOT_ENV: str(
+                        runtime_root
+                    ),
+                },
+            )
+            completed = subprocess.run(
+                ["/bin/sh", "-c", wrapped],
+                capture_output=True,
+                text=True,
+                check=False,
+                env={"PATH": str(tools), **env},
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(
+            completed.stdout.splitlines(),
+            [str(runtime_root / "bin" / "python3"), "portable-python"],
+        )
+
+    def test_verifier_runtime_reuses_materialized_portable_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime_root = root / "runtime" / "python3.12-runtime"
+            runtime_bin = runtime_root / "bin"
+            runtime_bin.mkdir(parents=True)
+            python = runtime_bin / "python3.12"
+            python.write_text("#!/bin/sh\nprintf 'reused-python\\n'\n")
+            python.chmod(0o755)
+            (runtime_bin / "python3").symlink_to("python3.12")
+            (runtime_bin / "python").symlink_to("python3.12")
+            check = runtime_bin / "harbor-verifier-bundle-check"
+            check.write_text('#!/bin/sh\nexec "${0%/*}/python3" >/dev/null\n')
+            check.chmod(0o755)
+            (runtime_root / ".harbor-verifier-bundle-materialized-v1").touch()
+
+            tools = root / "tools"
+            tools.mkdir()
+            for name in ("touch",):
+                target = shutil.which(name)
+                self.assertIsNotNone(target)
+                os.symlink(target, tools / name)
+
+            wrapped, env = yicloud_opensandbox._prepare_exec_runtime(
+                "python3",
+                {
+                    yicloud_opensandbox.VERIFIER_PATH_PREPEND_ENV: str(
+                        runtime_bin
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ID_ENV: (
+                        "test-python-verifier-bundle"
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ARCHIVE_ENV: str(
+                        root / "already-consumed.tar.gz"
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ROOT_ENV: str(
+                        runtime_root
+                    ),
+                },
+            )
+            completed = subprocess.run(
+                ["/bin/sh", "-c", wrapped],
+                capture_output=True,
+                text=True,
+                check=False,
+                env={"PATH": str(tools), **(env or {})},
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.strip(), "reused-python")
+
+    def test_verifier_runtime_bundle_settings_must_be_complete(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be configured together"):
+            yicloud_opensandbox._prepare_exec_runtime(
+                "true",
+                {
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ARCHIVE_ENV: (
+                        "/runtime.tar.gz"
+                    )
+                },
+            )
+
+    def test_missing_verifier_runtime_bundle_stops_before_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tools = root / "tools"
+            tools.mkdir()
+            wrapped, env = yicloud_opensandbox._prepare_exec_runtime(
+                "printf 'command-ran\\n'",
+                {
+                    yicloud_opensandbox.VERIFIER_PATH_PREPEND_ENV: str(tools),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ID_ENV: (
+                        "test-python-verifier-bundle"
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ARCHIVE_ENV: str(
+                        root / "missing.tar.gz"
+                    ),
+                    yicloud_opensandbox.VERIFIER_RUNTIME_BUNDLE_ROOT_ENV: str(
+                        root / "runtime" / "python3.12-runtime"
+                    ),
+                },
+            )
+            completed = subprocess.run(
+                ["/bin/sh", "-c", wrapped],
+                capture_output=True,
+                text=True,
+                check=False,
+                env={"PATH": str(tools), **(env or {})},
+            )
+
+        self.assertEqual(completed.returncode, 127)
+        self.assertNotIn("command-ran", completed.stdout)
+        self.assertIn("runtime bundle archive is missing", completed.stderr)
+        self.assertIn("/logs/verifier/runtime-bootstrap.log", wrapped)
+
     def test_v2_bundle_loads_digest_refs_and_rejects_unsupported_capabilities(self) -> None:
         instance = object.__new__(
             yicloud_opensandbox.YiCloudOpenSandboxEnvironment
@@ -1026,7 +1212,53 @@ class YiCloudOpenSandboxTest(unittest.TestCase):
         instance._upload_file_http.assert_awaited_once_with(
             source, "/opt/agent.tgz", "640"
         )
-        instance.logger.warning.assert_called_once()
+        instance.logger.warning.assert_called_once_with(
+            "YiCloud upload fallback backend=auto "
+            "attempted_backend=s3 fallback_backend=http kind=file "
+            "phase=%s target=%s error=%s",
+            "stage",
+            "/opt/agent.tgz",
+            instance._s3_upload_store.stage_file.side_effect,
+        )
+
+    def test_auto_file_upload_warns_and_falls_back_after_s3_setup_failure(
+        self,
+    ) -> None:
+        instance = object.__new__(
+            yicloud_opensandbox.YiCloudOpenSandboxEnvironment
+        )
+        instance._upload_backend = "auto"
+        instance._s3_upload_store = None
+        instance._s3_upload_setup_error = ValueError("invalid S3 profile")
+        instance._upload_file_http = AsyncMock()
+        instance.logger = Mock()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "agent.tgz"
+            source.write_bytes(b"agent")
+            source.chmod(0o640)
+            asyncio.run(instance.upload_file(source, "/opt/agent.tgz"))
+
+        instance._upload_file_http.assert_awaited_once_with(
+            source, "/opt/agent.tgz", "640"
+        )
+        warning = instance.logger.warning.call_args
+        self.assertEqual(
+            warning.args[:3],
+            (
+                (
+                    "YiCloud upload fallback backend=auto "
+                    "attempted_backend=s3 fallback_backend=http kind=file "
+                    "phase=%s target=%s error=%s"
+                ),
+                "stage",
+                "/opt/agent.tgz",
+            ),
+        )
+        self.assertIn(
+            "YiCloud S3 upload backend setup failed: invalid S3 profile",
+            str(warning.args[3]),
+        )
 
     def test_strict_s3_file_upload_does_not_hide_transport_failure(self) -> None:
         instance = object.__new__(
@@ -1084,6 +1316,14 @@ class YiCloudOpenSandboxTest(unittest.TestCase):
         instance._upload_file_http.assert_awaited_once_with(
             source, "/opt/agent.tgz", "644"
         )
+        instance.logger.warning.assert_called_once_with(
+            "YiCloud upload fallback backend=auto "
+            "attempted_backend=s3 fallback_backend=http kind=file "
+            "phase=%s target=%s error=%s",
+            "materialize",
+            "/opt/agent.tgz",
+            instance._materialize_s3_file.side_effect,
+        )
 
     def test_auto_directory_upload_falls_back_to_existing_http_transport(self) -> None:
         instance = object.__new__(
@@ -1103,7 +1343,14 @@ class YiCloudOpenSandboxTest(unittest.TestCase):
             asyncio.run(instance.upload_dir(source, "/opt/deps"))
 
         instance._upload_dir_http.assert_awaited_once_with(source, "/opt/deps")
-        instance.logger.warning.assert_called_once()
+        instance.logger.warning.assert_called_once_with(
+            "YiCloud upload fallback backend=auto "
+            "attempted_backend=s3 fallback_backend=http "
+            "kind=directory phase=%s target=%s error=%s",
+            "stage",
+            "/opt/deps",
+            instance._s3_upload_store.stage_directory.side_effect,
+        )
 
     def test_s3_bootstrap_is_uploaded_once_only_when_native_tools_are_missing(
         self,

--- a/Agents/utils/common/Harbor/verifier_runtime/__init__.py
+++ b/Agents/utils/common/Harbor/verifier_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark-specific verifier runtime preparation."""

--- a/Agents/utils/common/Harbor/verifier_runtime/swe_rebench_v2_bundle_preparer.py
+++ b/Agents/utils/common/Harbor/verifier_runtime/swe_rebench_v2_bundle_preparer.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+try:
+    from .. import python_runtime
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    import python_runtime
+
+BUNDLE_ID = "agent-fleet-swe-rebench-v2-verifier-bundle"
+SELF_CHECK = "bin/harbor-verifier-bundle-check"
+
+
+def _members(path: Path) -> dict[str, tarfile.TarInfo] | None:
+    if not path.is_file():
+        return None
+    try:
+        with tarfile.open(path) as archive:
+            return {member.name.rstrip("/"): member for member in archive}
+    except (OSError, tarfile.TarError):
+        return None
+
+
+def archive_ready(path: Path) -> bool:
+    members = _members(path)
+    if members is None:
+        return False
+    bin_root = f"{BUNDLE_ID}/bin"
+    check = members.get(f"{BUNDLE_ID}/{SELF_CHECK}")
+    python312 = members.get(f"{bin_root}/python3.12")
+    python3 = members.get(f"{bin_root}/python3")
+    python = members.get(f"{bin_root}/python")
+    runtime_marker = members.get(
+        f"{BUNDLE_ID}/{python_runtime.RUNTIME_MARKER}"
+    )
+    return bool(
+        check
+        and check.isfile()
+        and check.mode & 0o111
+        and python312
+        and python312.isfile()
+        and python312.mode & 0o111
+        and python3
+        and python3.issym()
+        and python3.linkname == "python3.12"
+        and python
+        and python.issym()
+        and python.linkname == "python3.12"
+        and runtime_marker
+        and runtime_marker.isfile()
+    )
+
+
+def _extract_safely(archive_path: Path, destination: Path) -> None:
+    with tarfile.open(archive_path) as archive:
+        for member in archive:
+            member_path = PurePosixPath(member.name)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise RuntimeError(f"unsafe archive member: {member.name}")
+        archive.extractall(destination)
+
+
+def build(python_runtime_archive: Path, output: Path) -> None:
+    if archive_ready(output):
+        print(f"[prepare] skip verifier runtime bundle (cached): {output}")
+        return
+    if not python_runtime.archive_ready(python_runtime_archive):
+        raise RuntimeError(
+            f"invalid Python runtime archive: {python_runtime_archive}"
+        )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temporary_name:
+        temporary = Path(temporary_name)
+        _extract_safely(python_runtime_archive, temporary)
+        source_root = temporary / python_runtime.RUNTIME_ROOT
+        bundle_root = temporary / BUNDLE_ID
+        source_root.rename(bundle_root)
+
+        runtime_bin = bundle_root / "bin"
+        for name in ("python", "python3", "harbor-verifier-bundle-check"):
+            (runtime_bin / name).unlink(missing_ok=True)
+        (runtime_bin / "python3").symlink_to("python3.12")
+        (runtime_bin / "python").symlink_to("python3.12")
+        self_check = runtime_bin / "harbor-verifier-bundle-check"
+        self_check.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            'SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+            'exec "${SELF_DIR}/python3" -c "import sys"\n',
+            encoding="utf-8",
+        )
+        self_check.chmod(
+            self_check.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+
+        file_descriptor, temporary_tar_name = tempfile.mkstemp(
+            prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+        )
+        os.close(file_descriptor)
+        temporary_tar = Path(temporary_tar_name)
+        try:
+            with tarfile.open(temporary_tar, "w:gz") as archive:
+                archive.add(bundle_root, arcname=BUNDLE_ID)
+            if not archive_ready(temporary_tar):
+                raise RuntimeError("generated verifier runtime bundle is invalid")
+            os.replace(temporary_tar, output)
+        finally:
+            temporary_tar.unlink(missing_ok=True)
+    print(f"[prepare] built verifier runtime bundle: {output}")
+
+
+def prepare(cache_dir: Path, output: Path) -> None:
+    python_runtime_archive = cache_dir / "python3.12-runtime.tar.gz"
+    if not python_runtime.archive_ready(python_runtime_archive):
+        python_bin = os.environ.get("PYTHON_BIN") or "python3.12"
+        subprocess.run(
+            [
+                python_bin,
+                str(Path(__file__).resolve().parent.parent / "python_runtime.py"),
+                "--output",
+                str(python_runtime_archive),
+            ],
+            check=True,
+        )
+    build(python_runtime_archive, output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build_parser = subparsers.add_parser("build")
+    build_parser.add_argument("--cache-dir", required=True, type=Path)
+    build_parser.add_argument("--output", required=True, type=Path)
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("--archive", required=True, type=Path)
+    args = parser.parse_args()
+    if args.command == "check":
+        return 0 if archive_ready(args.archive) else 1
+    prepare(args.cache_dir, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Agents/utils/common/Harbor/verifier_runtime/swe_rebench_v2_bundle_preparer.py
+++ b/Agents/utils/common/Harbor/verifier_runtime/swe_rebench_v2_bundle_preparer.py
@@ -121,7 +121,7 @@ def build(python_runtime_archive: Path, output: Path) -> None:
 def prepare(cache_dir: Path, output: Path) -> None:
     python_runtime_archive = cache_dir / "python3.12-runtime.tar.gz"
     if not python_runtime.archive_ready(python_runtime_archive):
-        python_bin = os.environ.get("PYTHON_BIN") or "python3.12"
+        python_bin = os.environ.get("PYTHON_BIN") or sys.executable
         subprocess.run(
             [
                 python_bin,

--- a/Agents/utils/common/Harbor/yicloud_opensandbox.py
+++ b/Agents/utils/common/Harbor/yicloud_opensandbox.py
@@ -58,6 +58,10 @@ EXECD_DETACHED_COMMAND_MIN_TIMEOUT_SEC = 300
 EXECD_DETACHED_POLL_INTERVAL_SEC = 5
 DETACHED_PENDING_MARKER = "__HARBOR_YICLOUD_DETACHED_PENDING__"
 S3_HTTP_BOOTSTRAP_PATH = "/tmp/.harbor-s3-http-get-v1.sh"
+VERIFIER_PATH_PREPEND_ENV = "HARBOR_VERIFIER_PATH_PREPEND"
+VERIFIER_RUNTIME_BUNDLE_ID_ENV = "HARBOR_VERIFIER_RUNTIME_BUNDLE_ID"
+VERIFIER_RUNTIME_BUNDLE_ARCHIVE_ENV = "HARBOR_VERIFIER_RUNTIME_BUNDLE_ARCHIVE"
+VERIFIER_RUNTIME_BUNDLE_ROOT_ENV = "HARBOR_VERIFIER_RUNTIME_BUNDLE_ROOT"
 # Current YiCloud task images are Linux/amd64 glibc images and normally carry
 # curl, wget, or python3. A few minimal images only carry Bash. For those
 # images, upload this small downloader once per Sandbox instead of uploading a
@@ -138,6 +142,104 @@ def _retryable_execd_error(error: requests.RequestException) -> bool:
             requests.exceptions.ChunkedEncodingError,
         ),
     )
+
+
+def _prepare_exec_runtime(
+    command: str,
+    env: dict[str, str] | None,
+) -> tuple[str, dict[str, str] | None]:
+    """Expand verifier-only runtime settings inside the Sandbox shell.
+
+    Execd environment values are literal and cannot express ``prefix:$PATH``
+    without replacing the image's configured PATH. Remove the private control
+    variables from the payload and render the expansion in the command shell
+    instead. A selected runtime bundle is an opaque filesystem bundle: the
+    provider only materializes it, runs its standard self-check entrypoint,
+    and prepends the bundle's ``bin`` directory. Runtime-specific activation
+    belongs in wrappers shipped by the bundle itself.
+    """
+    if env is None:
+        return command, None
+    effective_env = dict(env)
+    path_prepend = effective_env.pop(VERIFIER_PATH_PREPEND_ENV, "").strip()
+    bundle_id = effective_env.pop(VERIFIER_RUNTIME_BUNDLE_ID_ENV, "").strip()
+    bundle_archive = effective_env.pop(
+        VERIFIER_RUNTIME_BUNDLE_ARCHIVE_ENV, ""
+    ).strip()
+    bundle_root = effective_env.pop(VERIFIER_RUNTIME_BUNDLE_ROOT_ENV, "").strip()
+    bundle_settings = (bundle_id, bundle_archive, bundle_root)
+
+    if any(bundle_settings) and not all(bundle_settings):
+        raise ValueError(
+            "verifier runtime bundle id, archive, and root must be configured "
+            "together"
+        )
+    if bundle_archive and (
+        not Path(bundle_archive).is_absolute()
+        or not Path(bundle_root).is_absolute()
+        or Path(bundle_root) == Path("/")
+    ):
+        raise ValueError("verifier runtime bundle paths must be safe absolute paths")
+    if not path_prepend and not bundle_archive:
+        return command, effective_env
+
+    bootstrap = ["set -e"]
+    if bundle_archive:
+        archive = shlex.quote(bundle_archive)
+        root = shlex.quote(bundle_root)
+        parent = shlex.quote(str(Path(bundle_root).parent))
+        check = f"{root}/bin/harbor-verifier-bundle-check"
+        marker = f"{root}/.harbor-verifier-bundle-materialized-v1"
+        bootstrap_log = "/logs/verifier/runtime-bootstrap.log"
+        ready_message = shlex.quote(
+            f"verifier runtime bundle ready: {bundle_id}"
+        )
+        bootstrap.extend(
+            [
+                (
+                    "harbor_verifier_runtime_fail() { "
+                    "message=$1; printf '%s\\n' \"$message\" >&2; "
+                    f"printf '%s\\n' \"$message\" > {bootstrap_log} "
+                    "2>/dev/null || true; exit 127; }"
+                ),
+                f"if [ ! -f {marker} ]; then",
+                (
+                    f"    [ -f {archive} ] || harbor_verifier_runtime_fail "
+                    "'verifier runtime bundle archive is missing'"
+                ),
+                (
+                    "    command -v tar >/dev/null 2>&1 || "
+                    "harbor_verifier_runtime_fail "
+                    "'tar is required to materialize verifier runtime bundle'"
+                ),
+                f"    mkdir -p {parent}",
+                (
+                    f"    tar -xzf {archive} -C {parent} || "
+                    "harbor_verifier_runtime_fail "
+                    "'failed to extract verifier runtime bundle'"
+                ),
+                "fi",
+                (
+                    f"[ -x {check} ] || harbor_verifier_runtime_fail "
+                    "'verifier runtime bundle is missing its self-check'"
+                ),
+                (
+                    f"{check} >/dev/null 2>&1 || harbor_verifier_runtime_fail "
+                    "'verifier runtime bundle failed its self-check'"
+                ),
+                f": > {marker}",
+                (
+                    f"printf '%s\\n' {ready_message} "
+                    f"> {bootstrap_log} 2>/dev/null || true"
+                ),
+            ]
+        )
+    if path_prepend:
+        bootstrap.append(
+            f"export PATH={shlex.quote(path_prepend)}:\"$PATH\""
+        )
+    bootstrap.append("set +e")
+    return "\n".join([*bootstrap, command]), effective_env
 
 
 class ServiceRuntime:
@@ -509,11 +611,18 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
             ),
             "YICLOUD_SANDBOX_S3_DOWNLOAD_TIMEOUT_SEC",
         )
-        self._s3_upload_store = (
-            S3UploadStore.from_environment()
-            if self._upload_backend in {"s3", "auto"}
-            else None
-        )
+        self._s3_upload_store: S3UploadStore | None = None
+        self._s3_upload_setup_error: Exception | None = None
+        if self._upload_backend in {"s3", "auto"}:
+            try:
+                self._s3_upload_store = S3UploadStore.from_environment()
+            except ValueError as exc:
+                if self._upload_backend == "s3":
+                    raise
+                # Preserve auto's HTTP fallback even when S3 configuration
+                # cannot be initialized. The first actual upload logs the
+                # same structured fallback warning as runtime S3 failures.
+                self._s3_upload_setup_error = exc
         self._s3_downloader_ready = False
         self._s3_downloader_lock: asyncio.Lock | None = None
         self._base_client: Any | None = None
@@ -2140,7 +2249,7 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
         self,
         command: str,
         cwd: str | None,
-        env: dict[str, str],
+        env: dict[str, str] | None,
         timeout_sec: int | None,
         uid: int | None = None,
     ) -> ExecResult:
@@ -2276,7 +2385,7 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
         self,
         command: str,
         cwd: str | None,
-        env: dict[str, str],
+        env: dict[str, str] | None,
         timeout_sec: int,
         uid: int | None = None,
     ) -> ExecResult:
@@ -2460,7 +2569,7 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
         self,
         command: str,
         cwd: str | None,
-        env: dict[str, str],
+        env: dict[str, str] | None,
         timeout_sec: int | None,
         uid: int | None = None,
     ) -> ExecResult:
@@ -2513,11 +2622,15 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
     ) -> ExecResult:
         uid = self._resolve_exec_uid(self._resolve_user(user))
         effective_cwd = cwd or self.task_env_config.workdir
+        command, effective_env = _prepare_exec_runtime(
+            command,
+            self._merge_env(env),
+        )
         result = await asyncio.to_thread(
             self._run_command_sync,
             command,
             effective_cwd,
-            self._merge_env(env),
+            effective_env,
             timeout_sec,
             uid,
         )
@@ -2562,6 +2675,11 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
     def _s3_store(self) -> S3UploadStore:
         store = getattr(self, "_s3_upload_store", None)
         if store is None:
+            setup_error = getattr(self, "_s3_upload_setup_error", None)
+            if setup_error is not None:
+                raise RuntimeError(
+                    f"YiCloud S3 upload backend setup failed: {setup_error}"
+                ) from setup_error
             raise RuntimeError("YiCloud S3 upload backend is not configured")
         return store
 
@@ -2734,17 +2852,21 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
         mode = f"{stat.S_IMODE(source.stat().st_mode):o}"
         if self._uses_s3_upload():
             started = time.monotonic()
+            phase = "stage"
             try:
                 artifact = await asyncio.to_thread(
                     self._s3_store().stage_file, source
                 )
+                phase = "materialize"
                 await self._materialize_s3_file(artifact, target_path, mode)
             except Exception as exc:
                 if not self._allows_http_upload_fallback():
                     raise
                 self.logger.warning(
-                    "YiCloud S3 file transport failed; falling back to HTTP "
-                    "target=%s error=%s",
+                    "YiCloud upload fallback backend=auto "
+                    "attempted_backend=s3 fallback_backend=http kind=file "
+                    "phase=%s target=%s error=%s",
+                    phase,
                     target_path,
                     exc,
                 )
@@ -2835,17 +2957,21 @@ class YiCloudOpenSandboxEnvironment(BaseEnvironment):
             raise RuntimeError(f"upload source is not a directory: {source}")
         if self._uses_s3_upload():
             started = time.monotonic()
+            phase = "stage"
             try:
                 artifact = await asyncio.to_thread(
                     self._s3_store().stage_directory, source
                 )
+                phase = "materialize"
                 await self._materialize_s3_directory(artifact, target_dir)
             except Exception as exc:
                 if not self._allows_http_upload_fallback():
                     raise
                 self.logger.warning(
-                    "YiCloud S3 directory transport failed; falling back to "
-                    "HTTP target=%s error=%s",
+                    "YiCloud upload fallback backend=auto "
+                    "attempted_backend=s3 fallback_backend=http "
+                    "kind=directory phase=%s target=%s error=%s",
+                    phase,
                     target_dir,
                     exc,
                 )

--- a/Agents/utils/common/Harbor/yicloud_opensandbox.py
+++ b/Agents/utils/common/Harbor/yicloud_opensandbox.py
@@ -189,7 +189,6 @@ def _prepare_exec_runtime(
         root = shlex.quote(bundle_root)
         parent = shlex.quote(str(Path(bundle_root).parent))
         check = f"{root}/bin/harbor-verifier-bundle-check"
-        marker = f"{root}/.harbor-verifier-bundle-materialized-v1"
         bootstrap_log = "/logs/verifier/runtime-bootstrap.log"
         ready_message = shlex.quote(
             f"verifier runtime bundle ready: {bundle_id}"
@@ -202,23 +201,28 @@ def _prepare_exec_runtime(
                     f"printf '%s\\n' \"$message\" > {bootstrap_log} "
                     "2>/dev/null || true; exit 127; }"
                 ),
-                f"if [ ! -f {marker} ]; then",
                 (
-                    f"    [ -f {archive} ] || harbor_verifier_runtime_fail "
+                    f"[ -f {archive} ] || harbor_verifier_runtime_fail "
                     "'verifier runtime bundle archive is missing'"
                 ),
                 (
-                    "    command -v tar >/dev/null 2>&1 || "
+                    "command -v tar >/dev/null 2>&1 || "
                     "harbor_verifier_runtime_fail "
                     "'tar is required to materialize verifier runtime bundle'"
                 ),
-                f"    mkdir -p {parent}",
                 (
-                    f"    tar -xzf {archive} -C {parent} || "
+                    f"rm -rf {root} || harbor_verifier_runtime_fail "
+                    "'failed to clear verifier runtime bundle root'"
+                ),
+                (
+                    f"mkdir -p {parent} || harbor_verifier_runtime_fail "
+                    "'failed to create verifier runtime bundle parent'"
+                ),
+                (
+                    f"tar -xzf {archive} -C {parent} || "
                     "harbor_verifier_runtime_fail "
                     "'failed to extract verifier runtime bundle'"
                 ),
-                "fi",
                 (
                     f"[ -x {check} ] || harbor_verifier_runtime_fail "
                     "'verifier runtime bundle is missing its self-check'"
@@ -227,7 +231,6 @@ def _prepare_exec_runtime(
                     f"{check} >/dev/null 2>&1 || harbor_verifier_runtime_fail "
                     "'verifier runtime bundle failed its self-check'"
                 ),
-                f": > {marker}",
                 (
                     f"printf '%s\\n' {ready_message} "
                     f"> {bootstrap_log} 2>/dev/null || true"

--- a/Agents/utils/rl/run_rl_rollout_worker.sh
+++ b/Agents/utils/rl/run_rl_rollout_worker.sh
@@ -6,6 +6,7 @@ HARBOR_SCRIPT_DIR="${HARBOR_SCRIPT_DIR:-$(cd "$RL_SCRIPT_DIR/../common/Harbor" &
 . "$HARBOR_SCRIPT_DIR/env.sh"
 
 WORKER_ID="${1:?worker id required}"
+WORKER_STARTUP_ENVIRONMENT_TYPE="$HARBOR_ENVIRONMENT_TYPE"
 PENDING_DIR="$RL_QUEUE_DIR/pending"
 ACTIVE_QUEUE_DIR="$RL_QUEUE_DIR/active"
 RESULTS_DIR="$RL_QUEUE_DIR/results"
@@ -56,6 +57,15 @@ json_get_first() {
 
 json_build_result() {
   python3 "$RL_SCRIPT_DIR/rollout_worker_utils.py" build-result "$@"
+}
+
+prepare_request_verifier_runtime_bundle() {
+  if [[ "$HARBOR_ENVIRONMENT_TYPE" != "opensandbox" \
+    || "$WORKER_STARTUP_ENVIRONMENT_TYPE" == "opensandbox" ]]; then
+    return 0
+  fi
+  resolve_verifier_runtime_bundle "$(select_verifier_runtime_bundle)"
+  harbor_prepare_verifier_runtime_bundle
 }
 
 find_latest_trial_result() {
@@ -283,6 +293,10 @@ while true; do
       # A per-request backend override must not inherit the listener's default
       # environment import path.
       export HARBOR_ENVIRONMENT_SPEC="$environment_type"
+    fi
+    if ! prepare_request_verifier_runtime_bundle; then
+      echo "[ERROR] failed to prepare verifier runtime bundle for request backend: $environment_type" >&2
+      exit 1
     fi
     export HARBOR_E2B_SANDBOX_TIMEOUT_SEC="${RL_E2B_SANDBOX_TIMEOUT_SEC:-${HARBOR_E2B_SANDBOX_TIMEOUT_SEC:-}}"
     # Rollout may target Polar gateways with smaller context windows than the

--- a/Agents/utils/rl/tests/test_rollout_request_verifier_runtime.sh
+++ b/Agents/utils/rl/tests/test_rollout_request_verifier_runtime.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+worker="$RL_DIR/run_rl_rollout_worker.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+
+eval "$(sed -n '/^prepare_request_verifier_runtime_bundle()/,/^}/p' "$worker")"
+
+select_verifier_runtime_bundle() {
+  printf '%s\n' "test-bundle"
+}
+
+resolve_verifier_runtime_bundle() {
+  printf '%s\n' "$1" >> "$tmp/resolved"
+}
+
+harbor_prepare_verifier_runtime_bundle() {
+  printf '%s\n' "prepared" >> "$tmp/prepared"
+}
+
+WORKER_STARTUP_ENVIRONMENT_TYPE=docker
+HARBOR_ENVIRONMENT_TYPE=opensandbox
+prepare_request_verifier_runtime_bundle
+grep -Fx -- 'test-bundle' "$tmp/resolved" >/dev/null
+grep -Fx -- 'prepared' "$tmp/prepared" >/dev/null
+
+: > "$tmp/resolved"
+: > "$tmp/prepared"
+WORKER_STARTUP_ENVIRONMENT_TYPE=opensandbox
+HARBOR_ENVIRONMENT_TYPE=opensandbox
+prepare_request_verifier_runtime_bundle
+[[ ! -s "$tmp/resolved" ]]
+[[ ! -s "$tmp/prepared" ]]
+
+WORKER_STARTUP_ENVIRONMENT_TYPE=docker
+HARBOR_ENVIRONMENT_TYPE=docker
+prepare_request_verifier_runtime_bundle
+[[ ! -s "$tmp/resolved" ]]
+[[ ! -s "$tmp/prepared" ]]
+
+echo 'rollout request verifier runtime test passed'


### PR DESCRIPTION
## 1. Why the change?

Harbor shared verifiers reuse task sandboxes, but some task images lack runtimes required by `tests/test.sh`. For example, SWE-rebench-V2 needs Python for log parsing even when the task itself uses another language.

The OpenSandbox image publisher must also preserve the exact task-to-repository mapping instead of silently renaming task identities.

## 2. Summary of the change

- Add benchmark-specific verifier runtime bundles.
- Inject bundles from S3 before verifier execution.
- Add a portable Python bundle for SWE-rebench-V2.
- Preserve the standard `tests/test.sh` and `reward.*` workflow.
- Preserve task identities verbatim as Harbor repository names and reject invalid identities instead of silently normalizing them.

## 3. Other details

Other benchmarks remain unchanged. No automatic dependency inference or host-side grading is introduced. Task identities that are not valid OCI repository components now fail early and must be fixed by the dataset adapter.