### PR TITLE
feat(web-research): add BrowseComp and DeepSearchQA adapters

### DIFF
--- a/Tasks/README.md
+++ b/Tasks/README.md
@@ -12,6 +12,7 @@ Benchmarks, task lists, and automated task workflows.
 | [`TMax/`](./TMax/) | TMax Harbor registry dataset entrypoint. |
 | [`Terminal-bench-2/`](./Terminal-bench-2/) | Terminal-Bench task lists for Harbor. |
 | [`SETA/`](./SETA/) | SETA task lists. |
+| [`WebResearchAdapter/`](./WebResearchAdapter/) | BrowseComp and DeepSearchQA Harbor task generator. |
 
 ## Other Harbor supported datasets
 

--- a/Tasks/WebResearchAdapter/.gitignore
+++ b/Tasks/WebResearchAdapter/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+*.egg-info/
+__pycache__/
+.ruff_cache/

--- a/Tasks/WebResearchAdapter/README.md
+++ b/Tasks/WebResearchAdapter/README.md
@@ -1,0 +1,80 @@
+# Web Research Harbor Adapter
+
+Generates native Harbor tasks for the official BrowseComp and DeepSearchQA
+datasets. The two commands share task materialization while keeping source
+validation and reward semantics separate.
+
+Official task counts:
+
+| Dataset | Tasks |
+| --- | ---: |
+| BrowseComp | 1266 |
+| DeepSearchQA | 900 |
+| Total | 2166 |
+
+Counts were verified with Python's CSV parser against these source hashes:
+
+```text
+browse_comp_test_set.csv  7b24471cd5b3eb2a46830a14802b5c029ea62f488ff75a0f88af7923d1454abf
+DSQA-full.csv              25d48dcf7efa872e5467032e8b8eedf38d301f59a252d0da95cda584baa78396
+```
+
+Generation rejects a source whose parsed task count or SHA-256 does not match
+these official files. Validation runs before `--limit` or `--task-ids` filtering.
+
+## Generate
+
+```bash
+cd Tasks/WebResearchAdapter
+uv run browsecomp-adapter \
+  --input /data/browse_comp_test_set.csv \
+  --output-dir /data/harbor/browsecomp
+
+uv run deepsearchqa-adapter \
+  --input /data/DSQA-full.csv \
+  --output-dir /data/harbor/deepsearchqa
+```
+
+Use `--limit`, `--task-ids`, `--overwrite`, and `--image` for smaller or
+environment-specific generations. `--image` selects both the Dockerfile base
+and Harbor's prebuilt `environment.docker_image`; it defaults to
+`python:3.12-slim`. OpenSandbox deployments should pass an image already
+available to their configured registry.
+
+## Agent Fleet
+
+Register the generated directories with the existing rollout listener:
+
+```bash
+export RL_AGENT=claude-code
+export RL_ENVIRONMENT_TYPE=opensandbox
+export RL_DATASET_ROOTS="browsecomp=/data/harbor/browsecomp,deepsearchqa=/data/harbor/deepsearchqa"
+export HARBOR_DISALLOWED_TOOLS="RemoteTrigger AskUserQuestion"
+```
+
+Requests select `dataset_name=browsecomp` or `dataset_name=deepsearchqa` and a
+generated task ID. Reward and trajectory collection use the existing Harbor
+verifier and `rollout_details` path; do not configure `RL_RESULT_PROCESSOR`.
+
+The adapter intentionally does not bundle a search provider or MCP runtime.
+Provision search and fetch tools at deployment time, either through native
+Claude tools backed by a compatible endpoint or through a deployment-managed
+MCP configured for the task or Claude installation. A self-hosted model does
+not gain internet access merely because native tool names are visible. When an
+external MCP is authoritative, add `WebSearch WebFetch` to
+`HARBOR_DISALLOWED_TOOLS` so rollout cannot silently use another backend.
+
+The verifier reuses the current trial's OpenAI-compatible `HARBOR_API_BASE`,
+`API_KEY`, and `HARBOR_MODEL`, including trusted request headers. It does not
+require a second judge endpoint.
+
+## Test
+
+```bash
+uv run python -m unittest discover -s tests -v
+```
+
+Validation generated all 2166 tasks and parsed every `task.toml` with Harbor
+0.18.0. A Claude Code OpenSandbox smoke also completed the external MCP search,
+answer, verifier, and reward path. Search service capacity and judge choice
+remain deployment concerns and must be fixed before reporting benchmark scores.

--- a/Tasks/WebResearchAdapter/pyproject.toml
+++ b/Tasks/WebResearchAdapter/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "harbor-web-research-adapter"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["toml>=0.10.2"]
+
+[project.scripts]
+browsecomp-adapter = "web_research_adapter.main:browsecomp_main"
+deepsearchqa-adapter = "web_research_adapter.main:deepsearchqa_main"
+
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+web_research_adapter = ["task-template/**/*"]

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/__init__.py
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import WebResearchAdapter
+
+__all__ = ["WebResearchAdapter"]

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/adapter.py
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/adapter.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import json
+import os
+import re
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import toml
+import tomllib
+
+PACKAGE_DIR = Path(__file__).parent
+TEMPLATE_DIR = PACKAGE_DIR / "task-template"
+EXPECTED_COUNTS = {"browsecomp": 1266, "deepsearchqa": 900}
+EXPECTED_SHA256 = {
+    "browsecomp": "7b24471cd5b3eb2a46830a14802b5c029ea62f488ff75a0f88af7923d1454abf",
+    "deepsearchqa": "25d48dcf7efa872e5467032e8b8eedf38d301f59a252d0da95cda584baa78396",
+}
+AUTHORS = {"browsecomp": "OpenAI", "deepsearchqa": "Google"}
+IMAGE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/@:+-]*")
+
+
+@dataclass(frozen=True, slots=True)
+class Example:
+    id: str
+    question: str
+    answer: str
+    topic: str = ""
+    answer_type: str | None = None
+
+
+def _decrypt(value: str, password: str) -> str:
+    encrypted = base64.b64decode(value, validate=True)
+    digest = hashlib.sha256(password.encode()).digest()
+    key = (digest * (len(encrypted) // len(digest) + 1))[: len(encrypted)]
+    return bytes(a ^ b for a, b in zip(encrypted, key)).decode()
+
+
+def _rows(path: Path, required: set[str]) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as source:
+        reader = csv.DictReader(source)
+        missing = required.difference(reader.fieldnames or ())
+        if missing:
+            raise ValueError(f"missing columns: {', '.join(sorted(missing))}")
+        return list(reader)
+
+
+def load_browsecomp(path: Path) -> list[Example]:
+    rows = _rows(path, {"problem", "answer", "canary"})
+    return [
+        Example(
+            str(i),
+            _decrypt(row["problem"], row["canary"]),
+            _decrypt(row["answer"], row["canary"]),
+            row.get("problem_topic", "").strip(),
+        )
+        for i, row in enumerate(rows)
+    ]
+
+
+def load_deepsearchqa(path: Path) -> list[Example]:
+    rows = _rows(path, {"problem", "problem_category", "answer", "answer_type"})
+    examples = []
+    for i, row in enumerate(rows):
+        answer_type = row["answer_type"].strip()
+        if answer_type not in {"Single Answer", "Set Answer"}:
+            raise ValueError(f"invalid answer_type at row {i}: {answer_type!r}")
+        examples.append(
+            Example(
+                str(i),
+                row["problem"].strip(),
+                row["answer"].strip(),
+                row["problem_category"].strip(),
+                answer_type,
+            )
+        )
+    return examples
+
+
+class WebResearchAdapter:
+    def __init__(
+        self,
+        benchmark: str,
+        input_path: Path,
+        output_dir: Path,
+        *,
+        image: str = "python:3.12-slim",
+        overwrite: bool = False,
+    ) -> None:
+        if benchmark not in EXPECTED_COUNTS:
+            raise ValueError(f"unsupported benchmark: {benchmark}")
+        if not IMAGE_RE.fullmatch(image):
+            raise ValueError(f"invalid image reference: {image!r}")
+        self.benchmark = benchmark
+        self.input_path = Path(input_path)
+        self.output_dir = Path(output_dir)
+        self.image = image
+        self.overwrite = overwrite
+
+    def _load(self) -> list[Example]:
+        loader = (
+            load_browsecomp if self.benchmark == "browsecomp" else load_deepsearchqa
+        )
+        return loader(self.input_path)
+
+    def _task_id(self, source_id: str) -> str:
+        return f"{self.benchmark}-{int(source_id):06d}"
+
+    def _config(self, example: Example, task_id: str) -> str:
+        config = tomllib.loads((TEMPLATE_DIR / "task.toml").read_text())
+        config["task"].update(
+            name=f"agent-fleet/{task_id}",
+            description=f"{self.benchmark} web research task",
+            authors=[{"name": AUTHORS[self.benchmark]}],
+            keywords=[self.benchmark, "web-research", "rl"],
+        )
+        config["metadata"].update(
+            benchmark=self.benchmark,
+            source_id=example.id,
+            topic=example.topic,
+        )
+        config["environment"]["docker_image"] = self.image
+        return toml.dumps(config)
+
+    def _write_task(self, example: Example) -> str:
+        task_id = self._task_id(example.id)
+        target = self.output_dir / task_id
+        staged = self.output_dir / f".{task_id}.tmp-{os.getpid()}"
+        backup = self.output_dir / f".{task_id}.bak-{os.getpid()}"
+        if target.exists() and not self.overwrite:
+            raise FileExistsError(target)
+        shutil.rmtree(staged, ignore_errors=True)
+        shutil.copytree(TEMPLATE_DIR, staged)
+        (staged / "instruction.md").write_text(
+            (staged / "instruction.md").read_text().rstrip()
+            + f"\n\nQuestion:\n{example.question}\n"
+        )
+        (staged / "task.toml").write_text(self._config(example, task_id))
+        dockerfile = (
+            (staged / "environment/Dockerfile")
+            .read_text()
+            .replace("{image}", self.image)
+        )
+        (staged / "environment/Dockerfile").write_text(dockerfile)
+        reference = {"benchmark": self.benchmark, **asdict(example)}
+        if reference["answer_type"] is None:
+            reference.pop("answer_type")
+        (staged / "tests/reference.json").write_text(
+            json.dumps(reference, ensure_ascii=False, indent=2) + "\n"
+        )
+        shutil.copy2(PACKAGE_DIR / "grader.py", staged / "tests/grader.py")
+        (staged / "solution/answer.txt").write_text(example.answer + "\n")
+        tomllib.loads((staged / "task.toml").read_text())
+        for script in (staged / "tests/test.sh", staged / "solution/solve.sh"):
+            script.chmod(0o755)
+        if target.exists():
+            target.rename(backup)
+        try:
+            staged.rename(target)
+        except Exception:
+            if backup.exists():
+                backup.rename(target)
+            raise
+        shutil.rmtree(backup, ignore_errors=True)
+        return task_id
+
+    def run(
+        self, task_ids: list[str] | None = None, limit: int | None = None
+    ) -> list[str]:
+        if limit is not None and limit < 0:
+            raise ValueError("limit must be non-negative")
+        examples = self._load()
+        source_count = len(examples)
+        source_sha256 = hashlib.sha256(self.input_path.read_bytes()).hexdigest()
+        expected_count = EXPECTED_COUNTS[self.benchmark]
+        expected_sha256 = EXPECTED_SHA256[self.benchmark]
+        if source_count != expected_count or source_sha256 != expected_sha256:
+            raise ValueError(
+                f"unexpected {self.benchmark} source: expected "
+                f"count={expected_count} sha256={expected_sha256}, got "
+                f"count={source_count} sha256={source_sha256}"
+            )
+        if task_ids:
+            requested = {
+                value.removeprefix(f"{self.benchmark}-").lstrip("0") or "0"
+                for value in task_ids
+            }
+            known = {example.id for example in examples}
+            if unknown := requested - known:
+                raise ValueError(f"unknown task ids: {', '.join(sorted(unknown))}")
+            examples = [example for example in examples if example.id in requested]
+        examples = examples[:limit]
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        generated = [self._write_task(example) for example in examples]
+        manifest = {
+            "benchmark": self.benchmark,
+            "expected_tasks": EXPECTED_COUNTS[self.benchmark],
+            "source_tasks": source_count,
+            "source_file": self.input_path.name,
+            "source_sha256": source_sha256,
+            "generated_tasks": len(generated),
+            "task_ids": generated,
+            "image": self.image,
+        }
+        (self.output_dir / "generation-manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n"
+        )
+        return generated

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/grader.py
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/grader.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import textwrap
+import urllib.request
+from pathlib import Path
+
+ROLLOUT_SESSION_HEADERS = {"x-session-id", "proxy-x-session-id"}
+
+BROWSE_PROMPT = """Judge whether the following [response] to [question] is correct or not based on the precise and unambiguous [correct_answer] below.
+
+[question]: {question}
+
+[response]: {response}
+
+Your judgement must be in the format and criteria specified below:
+
+extracted_final_answer: The final exact answer extracted from the [response]. Put the extracted answer as 'None' if there is no exact, final answer to extract from the response.
+
+[correct_answer]: {correct_answer}
+
+reasoning: Explain why the extracted_final_answer is correct or incorrect based on [correct_answer], focusing only on if there are meaningful differences between [correct_answer] and the extracted_final_answer. Do not comment on any background to the problem, do not attempt to solve the problem, do not argue for any answer different than [correct_answer], focus only on whether the answers match.
+
+correct: Answer 'yes' if extracted_final_answer matches the [correct_answer] given above, or is within a small margin of error for numerical problems. Answer 'no' otherwise, i.e. if there if there is any inconsistency, ambiguity, non-equivalency, or if the extracted answer is incorrect.
+
+
+confidence: The extracted confidence score between 0% and 100% from [response]. Put 100 if there is no confidence score available."""
+
+DEEPSEARCH_PROMPT = textwrap.dedent(
+    """\
+    Your task is to evaluate whether a given "AI Response" for a specific "User Prompt" arrived at the correct answer.
+
+    **Answer Correctness Task**
+
+    *   **Purpose:** Assess whether the AI response provides the correct answer(s) based on the provided "Correct Answer" and "Prompt Type".
+    *   **Process:**
+        *   Identify the "Prompt Type": "<prompt_type>".
+        *   Refer to the "Correct Answer": "<answer>".
+        *   Based on the "Prompt Type", determine if the "AI Response" contains the expected answer(s).
+            *   **'Single Answer'**: Check if the response provides the answer that addresses the user's question. It does not have to match the exact wording of the provided answer.
+            *   **'Set Answer'**: Check if the response includes *each* item from the provided ground truth answers. The order might not matter unless specified otherwise. The response might include more answers than the list. Determine the correctness *only* based on the list first and then check if the response includes answers not in the list.
+        *   **Explanation:** Provide a brief explanation justifying your assessment of answer correctness, referencing specific parts of the AI response and the correct answer.
+        *   **Correctness Details:** Provide a dictionary, one key for each expected answer part, and value is a boolean indicating whether each expected answer part was found.
+            *   For 'Set Answer', this will be a list of attributes, one for each item/part in the "Correct Answer". Each key will be a string indicating the expected answer part, and the value will be a boolean indicating whether that part was found in the response.
+        *   **Excessive Answers:** Provide a list of strings, each indicating an excessive answer part. If the response provides answers that are **not** in the "Correct Answer" list, add these answers as excessive answers. Return an empty list when there's no excessive answers in the response.
+
+
+    **Output Format:**
+
+    Your evaluation *must* be structured as a nested JSON dictionary with the following top-level keys: `"Answer Correctness"`. Please return NULL if any of "Prompt", "AI Response" or "Correct Answer" is empty.
+    The value for `"Answer Correctness"` should be a dictionary containing `"Explanation"` (a string), `"Correctness Details"` (a dictionary where each key is the expected correct answer, and the value is a boolean indicating whether the response contains the correct answer), and `"Excessive Answers"` (a list of strings indicating the excessive answers).
+
+    Make sure you return a valid JSON string. Pay special attention to quotes, commas and special characters in the JSON string. Make sure to escape all special characters and quotes in the JSON string.
+
+
+    """
+)
+
+DEEPSEARCH_EXAMPLE = r"""**Example (Partial):**
+
+"```json
+{{
+  "Answer Correctness": {{
+    "Explanation": "The response correctly identified Belgium and France but also includes an excessive answer, Italy.",
+    "Correctness Details": {{
+      "Belgium": true,
+      "France": true,
+    }},
+    "Excessive Answers": [ "Italy" ]
+  }}
+}}
+```"
+
+**Now, proceed with the evaluation using the provided User Prompt, AI Response, and Correct Answer.**
+
+User Prompt (Wrapped in <prompt> and </prompt>):
+<prompt>
+{question}
+</prompt>
+--------------------
+**  Correct Answer (Wrapped in <answer> and </answer>):
+Prompt Type: {answer_type}
+<answer>
+{answer}
+</answer>
+--------------------
+AI assistant response (Wrapped in <response> and </response>):
+<response>
+{response}
+</response>
+
+--------------------
+Rating:"""
+
+
+def _answer() -> str:
+    for name in ("/logs/agent/response.txt", "/workspace/answer.txt"):
+        path = Path(name)
+        if path.exists() and (text := path.read_text().strip()):
+            return text
+    path = Path("/logs/agent/claude-code.txt")
+    if path.exists():
+        for line in reversed(path.read_text().splitlines()):
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "result" and event.get("result"):
+                return str(event["result"]).strip()
+    return ""
+
+
+def _chat(prompt: str) -> str:
+    llm_kwargs = json.loads(os.environ.get("JUDGE_LLM_KWARGS", "{}"))
+    extra_headers = llm_kwargs.get("extra_headers", {})
+    if not isinstance(extra_headers, dict):
+        raise TypeError("invalid judge extra_headers")
+    headers = {
+        str(name): str(value)
+        for name, value in extra_headers.items()
+        if str(name).lower() not in ROLLOUT_SESSION_HEADERS
+    }
+    headers.update(
+        {
+            "Authorization": f"Bearer {os.environ.get('JUDGE_API_KEY', '')}",
+            "Content-Type": "application/json",
+        }
+    )
+    payload = json.dumps(
+        {
+            "model": os.environ["JUDGE_MODEL"],
+            "temperature": 0,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+    ).encode()
+    request = urllib.request.Request(
+        os.environ["JUDGE_API_URL"],
+        data=payload,
+        headers=headers,
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        body = json.load(response)
+    return body["choices"][0]["message"]["content"].strip()
+
+
+def _json(text: str) -> dict:
+    match = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL | re.IGNORECASE)
+    return json.loads(match.group(1) if match else text)
+
+
+def grade_browsecomp(reference: dict, response: str) -> dict[str, float]:
+    reply = _chat(
+        BROWSE_PROMPT.format(
+            question=reference["question"],
+            correct_answer=reference["answer"],
+            response=response,
+        )
+    )
+    match = re.search(
+        r"(?im)(?:^\s*(?:[*_]{1,2})?(?:correct|judge)\s*:\s*(?:[*_]{1,2})?\s*|[\"']correct[\"']\s*:\s*[\"']?)(yes|no)\b",
+        reply,
+    )
+    if not match:
+        raise ValueError(f"invalid BrowseComp grader response: {reply}")
+    return {"reward": float(match.group(1).lower() == "yes")}
+
+
+def grade_deepsearchqa(reference: dict, response: str) -> dict[str, float]:
+    reply = _chat(
+        DEEPSEARCH_PROMPT + DEEPSEARCH_EXAMPLE.format(response=response, **reference)
+    )
+    result = _json(reply)["Answer Correctness"]
+    details, excessive = (
+        result["Correctness Details"],
+        result.get("Excessive Answers", []),
+    )
+    if (
+        not isinstance(details, dict)
+        or not details
+        or not all(type(v) is bool for v in details.values())
+    ):
+        raise ValueError("invalid Correctness Details")
+    if not isinstance(excessive, list):
+        raise TypeError("invalid Excessive Answers")
+    tp, fp = sum(details.values()), len(excessive)
+    fn = len(details) - tp
+    precision = tp / (tp + fp) if tp + fp else 0.0
+    recall = tp / (tp + fn) if tp + fn else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {
+        "reward": f1,
+        "precision": precision,
+        "recall": recall,
+        "fully_correct": float(fn == 0 and fp == 0),
+        "fully_incorrect": float(tp == 0),
+        "partially_correct": float(tp > 0 and fn > 0),
+        "correct_with_extraneous": float(fn == 0 and fp > 0),
+    }
+
+
+def main() -> None:
+    output = Path("/logs/verifier/reward.json")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    reference = json.loads(Path("/tests/reference.json").read_text())
+    response = _answer()
+    if not response:
+        output.write_text('{"reward": 0.0}\n')
+        return
+    grader = (
+        grade_browsecomp
+        if reference["benchmark"] == "browsecomp"
+        else grade_deepsearchqa
+    )
+    output.write_text(json.dumps(grader(reference, response)) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/main.py
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/main.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .adapter import WebResearchAdapter
+
+
+def _run(benchmark: str) -> None:
+    parser = argparse.ArgumentParser(description=f"Generate Harbor {benchmark} tasks")
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--task-ids", nargs="+")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--image", default="python:3.12-slim")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+    adapter = WebResearchAdapter(
+        benchmark,
+        args.input,
+        args.output_dir,
+        image=args.image,
+        overwrite=args.overwrite,
+    )
+    generated = adapter.run(args.task_ids, args.limit)
+    print(f"generated {len(generated)} {benchmark} tasks in {args.output_dir}")
+
+
+def browsecomp_main() -> None:
+    _run("browsecomp")
+
+
+def deepsearchqa_main() -> None:
+    _run("deepsearchqa")

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/environment/Dockerfile
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM {image}
+
+WORKDIR /workspace

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/instruction.md
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/instruction.md
@@ -1,0 +1,7 @@
+Research the question using the available web search and web fetch tools.
+
+Write the final response to `/logs/agent/response.txt` in this format:
+
+Explanation: your concise evidence-based explanation
+Exact Answer: your succinct final answer
+Confidence: your confidence from 0% to 100%

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/solution/solve.sh
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/solution/solve.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p /logs/agent
+cp /solution/answer.txt /logs/agent/response.txt

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/task.toml
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.3"
+
+[task]
+name = "agent-fleet/template"
+authors = [{ name = "Agent Fleet" }]
+keywords = ["web-research"]
+
+[metadata]
+
+[agent]
+timeout_sec = 7200.0
+
+[verifier]
+timeout_sec = 300.0
+
+[verifier.env]
+JUDGE_API_URL = "${HARBOR_API_BASE}"
+JUDGE_API_KEY = "${API_KEY:-}"
+JUDGE_MODEL = "${HARBOR_MODEL}"
+JUDGE_LLM_KWARGS = "${HARBOR_LLM_KWARGS:-{}}"
+
+[environment]
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 10240
+allow_internet = true
+
+[environment.env]
+HOME = "/root"

--- a/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/tests/test.sh
+++ b/Tasks/WebResearchAdapter/src/web_research_adapter/task-template/tests/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+# grader writes /logs/verifier/reward.json
+python3 /tests/grader.py

--- a/Tasks/WebResearchAdapter/tests/test_adapter.py
+++ b/Tasks/WebResearchAdapter/tests/test_adapter.py
@@ -1,0 +1,170 @@
+import base64
+import csv
+import hashlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import tomllib
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "src"))
+
+from web_research_adapter.adapter import WebResearchAdapter
+from web_research_adapter.grader import _chat, grade_browsecomp, grade_deepsearchqa
+
+
+def encrypt(value: str, password: str) -> str:
+    raw = value.encode()
+    digest = hashlib.sha256(password.encode()).digest()
+    key = (digest * (len(raw) // len(digest) + 1))[: len(raw)]
+    return base64.b64encode(bytes(a ^ b for a, b in zip(raw, key))).decode()
+
+
+class AdapterTest(unittest.TestCase):
+    def test_judge_inherits_model_headers(self):
+        env = {
+            "JUDGE_API_URL": "https://judge.test/v1/chat/completions",
+            "JUDGE_API_KEY": "key",
+            "JUDGE_MODEL": "judge",
+            "JUDGE_LLM_KWARGS": (
+                '{"extra_headers":{"X-Backend":"gpu:1",'
+                '"X-Session-Id":"rollout","proxy-x-session-id":"rollout"}}'
+            ),
+        }
+        body = '{"choices":[{"message":{"content":"ok"}}]}'
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("web_research_adapter.grader.urllib.request.urlopen") as call,
+        ):
+            call.return_value.__enter__.return_value = io.StringIO(body)
+            self.assertEqual(_chat("question"), "ok")
+        request = call.call_args.args[0]
+        self.assertEqual(request.get_header("X-backend"), "gpu:1")
+        header_names = {name.lower() for name, _ in request.header_items()}
+        self.assertNotIn("x-session-id", header_names)
+        self.assertNotIn("proxy-x-session-id", header_names)
+
+    def test_browsecomp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "browse.csv"
+            with source.open("w", newline="") as output:
+                writer = csv.DictWriter(
+                    output, fieldnames=["problem", "answer", "canary", "problem_topic"]
+                )
+                writer.writeheader()
+                writer.writerow(
+                    {
+                        "problem": encrypt('Who said "hello"?', "x"),
+                        "answer": encrypt("Gold marker 42", "x"),
+                        "canary": "x",
+                        "problem_topic": "Test",
+                    }
+                )
+            output = root / "tasks"
+            image = "registry.test/web-research:latest"
+            digest = hashlib.sha256(source.read_bytes()).hexdigest()
+            with self.assertRaisesRegex(ValueError, "unexpected browsecomp source"):
+                WebResearchAdapter("browsecomp", source, output, image=image).run()
+            with (
+                patch.dict(
+                    "web_research_adapter.adapter.EXPECTED_COUNTS", {"browsecomp": 1}
+                ),
+                self.assertRaisesRegex(ValueError, "sha256="),
+            ):
+                WebResearchAdapter("browsecomp", source, output, image=image).run()
+            with (
+                patch.dict(
+                    "web_research_adapter.adapter.EXPECTED_COUNTS", {"browsecomp": 1}
+                ),
+                patch.dict(
+                    "web_research_adapter.adapter.EXPECTED_SHA256",
+                    {"browsecomp": digest},
+                ),
+            ):
+                generated = WebResearchAdapter(
+                    "browsecomp", source, output, image=image
+                ).run()
+            self.assertEqual(generated, ["browsecomp-000000"])
+            task = output / generated[0]
+            config = tomllib.loads((task / "task.toml").read_text())
+            self.assertEqual(config["metadata"]["source_id"], "0")
+            self.assertEqual(config["environment"]["docker_image"], image)
+            self.assertEqual(config["environment"]["env"]["HOME"], "/root")
+            self.assertNotIn("mcp_servers", config["environment"])
+            self.assertEqual(
+                config["verifier"]["env"]["JUDGE_API_URL"], "${HARBOR_API_BASE}"
+            )
+            self.assertEqual(
+                config["verifier"]["env"]["JUDGE_LLM_KWARGS"],
+                "${HARBOR_LLM_KWARGS:-{}}",
+            )
+            self.assertNotIn("Gold marker 42", (task / "instruction.md").read_text())
+            self.assertEqual(
+                json.loads((task / "tests/reference.json").read_text())["answer"],
+                "Gold marker 42",
+            )
+
+    def test_deepsearchqa_and_graders(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "deep.csv"
+            with source.open("w", newline="") as output:
+                writer = csv.DictWriter(
+                    output,
+                    fieldnames=["problem", "problem_category", "answer", "answer_type"],
+                )
+                writer.writeheader()
+                writer.writerow(
+                    {
+                        "problem": "Find A and B",
+                        "problem_category": "Test",
+                        "answer": "A, B",
+                        "answer_type": "Set Answer",
+                    }
+                )
+            output = root / "tasks"
+            digest = hashlib.sha256(source.read_bytes()).hexdigest()
+            with (
+                patch.dict(
+                    "web_research_adapter.adapter.EXPECTED_COUNTS",
+                    {"deepsearchqa": 1},
+                ),
+                patch.dict(
+                    "web_research_adapter.adapter.EXPECTED_SHA256",
+                    {"deepsearchqa": digest},
+                ),
+            ):
+                generated = WebResearchAdapter("deepsearchqa", source, output).run()
+            reference = json.loads(
+                (output / generated[0] / "tests/reference.json").read_text()
+            )
+            self.assertEqual(reference["answer_type"], "Set Answer")
+        with patch("web_research_adapter.grader._chat", return_value="correct: yes"):
+            self.assertEqual(
+                grade_browsecomp({"question": "q", "answer": "a"}, "a")["reward"], 1.0
+            )
+        reply = '{"Answer Correctness":{"Explanation":"","Correctness Details":{"A":true,"B":false},"Excessive Answers":[]}}'
+        with patch("web_research_adapter.grader._chat", return_value=reply):
+            reward = grade_deepsearchqa(reference, "A")
+            self.assertEqual(
+                reward,
+                {
+                    "reward": 2 / 3,
+                    "precision": 1.0,
+                    "recall": 0.5,
+                    "fully_correct": 0.0,
+                    "fully_incorrect": 0.0,
+                    "partially_correct": 1.0,
+                    "correct_with_extraneous": 0.0,
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 1. Why the change?

Some tasks/datasets are not Harbor Hub style and need a adapter for them to run
Web search datasets (BrowseComp and DeepSearchQA) need this adapter

## 2. Summary of the change 

Add a adapter for BrowseComp and DeepSearchQA dataset
details:
Materialize official benchmark rows as Harbor tasks, reuse the rollout model as the OpenAI-compatible judge, and leave search tooling to the deployment so Agent Fleet's existing Claude Code and OpenSandbox path remains unchanged.


