### PR TITLE
fix(harbor): bound nightly setup and runtime

### DIFF
--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -111,7 +111,15 @@ class E2eValidationWorkflowTest(unittest.TestCase):
         self.assertIn("cancel-in-progress: false", self.workflow)
 
     def test_caps_job_duration(self):
-        self.assertIn("timeout-minutes: 720", self.workflow)
+        self.assertIn("timeout-minutes: 480", self.workflow)
+
+    def test_preserves_cleanup_and_artifact_time_after_benchmark_budget(self):
+        self.assertIn("BENCHMARK_TIMEOUT: 450m", self.workflow)
+        self.assertIn(
+            'timeout --signal=TERM --kill-after=5m "$BENCHMARK_TIMEOUT"',
+            self.workflow,
+        )
+        self.assertIn("status == 124", self.workflow)
 
     def test_strips_the_chat_completions_suffix_from_the_gateway_url(self):
         # env.sh strips a trailing /v1 but not /chat/completions.
@@ -119,6 +127,10 @@ class E2eValidationWorkflowTest(unittest.TestCase):
 
     def test_bounds_per_task_time_and_enables_online_analysis(self):
         self.assertIn('HARBOR_TIMEOUT_MULTIPLIER: "1.0"', self.workflow)
+        self.assertIn(
+            'HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER: "2.0"', self.workflow
+        )
+        self.assertIn("AgentSetupTimeoutError", self.workflow)
         self.assertIn('HARBOR_ONLINE_ANALYSIS: "1"', self.workflow)
 
     def test_pins_zellij_cleanup_for_a_pty_run(self):

--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -120,6 +120,7 @@ class E2eValidationWorkflowTest(unittest.TestCase):
             self.workflow,
         )
         self.assertIn('if [[ -f "$timeout_marker" ]]; then', self.workflow)
+        self.assertIn('while kill -0 "$child" 2>/dev/null; do', self.workflow)
 
     def test_strips_the_chat_completions_suffix_from_the_gateway_url(self):
         # env.sh strips a trailing /v1 but not /chat/completions.

--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -119,7 +119,7 @@ class E2eValidationWorkflowTest(unittest.TestCase):
             'timeout --signal=TERM --kill-after=5m "$BENCHMARK_TIMEOUT"',
             self.workflow,
         )
-        self.assertIn("status == 124", self.workflow)
+        self.assertIn('if [[ -f "$timeout_marker" ]]; then', self.workflow)
 
     def test_strips_the_chat_completions_suffix_from_the_gateway_url(self):
         # env.sh strips a trailing /v1 but not /chat/completions.

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -31,7 +31,7 @@ jobs:
     name: Harbor terminalbench21 e2e
     runs-on: [self-hosted, Linux, X64, bare-metal]
     environment: self-hosted-env
-    timeout-minutes: 720
+    timeout-minutes: 480
 
     steps:
       - name: Check out repository
@@ -163,8 +163,11 @@ jobs:
           OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
           ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
           HARBOR_TIMEOUT_MULTIPLIER: "1.0"
+          HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER: "2.0"
+          HARBOR_RETRY_EXCLUDE_EXCEPTIONS: RewardFileNotFoundError,RewardFileEmptyError,VerifierOutputParseError,AgentSetupTimeoutError
           HARBOR_ONLINE_ANALYSIS: "1"
           HARBOR_ZELLIJ_KEEP_ON_FAILURE: "0"
+          BENCHMARK_TIMEOUT: 450m
         run: |
           set -euo pipefail
           if [[ -z "$API_KEY" ]]; then
@@ -198,7 +201,13 @@ jobs:
           fi
 
           status=0
-          script -e -q -c "$(printf '%q ' "${command[@]}")" /dev/null || status=$?
+          timeout --signal=TERM --kill-after=5m "$BENCHMARK_TIMEOUT" \
+            script -e -q -c "$(printf '%q ' "${command[@]}")" /dev/null || status=$?
+          if (( status == 124 )); then
+            echo "::error::Harbor exceeded its $BENCHMARK_TIMEOUT benchmark budget"
+            # Stop detached workers before health evaluation and artifact staging.
+            zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+          fi
           printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
           printf 'Harbor exit status: %s\n' "$status"
 

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -200,14 +200,26 @@ jobs:
             command+=(--task "$TASKS")
           fi
 
+          timeout_marker="${RUNNER_TEMP}/harbor-benchmark-timeout"
+          rm -f "$timeout_marker"
           status=0
           timeout --signal=TERM --kill-after=5m "$BENCHMARK_TIMEOUT" \
+            bash -c '
+              marker="$1"
+              shift
+              child=""
+              trap '\''touch "$marker"; [[ -z "$child" ]] || kill -TERM "$child" 2>/dev/null || true'\'' TERM
+              "$@" &
+              child=$!
+              wait "$child"
+            ' bash "$timeout_marker" \
             script -e -q -c "$(printf '%q ' "${command[@]}")" /dev/null || status=$?
-          if (( status == 124 )); then
+          if [[ -f "$timeout_marker" ]]; then
             echo "::error::Harbor exceeded its $BENCHMARK_TIMEOUT benchmark budget"
             # Stop detached workers before health evaluation and artifact staging.
             zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
           fi
+          rm -f "$timeout_marker"
           printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
           printf 'Harbor exit status: %s\n' "$status"
 

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -211,7 +211,11 @@ jobs:
               trap '\''touch "$marker"; [[ -z "$child" ]] || kill -TERM "$child" 2>/dev/null || true'\'' TERM
               "$@" &
               child=$!
-              wait "$child"
+              child_status=0
+              while kill -0 "$child" 2>/dev/null; do
+                wait "$child" || child_status=$?
+              done
+              exit "$child_status"
             ' bash "$timeout_marker" \
             script -e -q -c "$(printf '%q ' "${command[@]}")" /dev/null || status=$?
           if [[ -f "$timeout_marker" ]]; then

--- a/Agents/utils/common/Harbor/env.py
+++ b/Agents/utils/common/Harbor/env.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import math
 import os
+import re
 import sys
 import tarfile
 import tempfile
@@ -509,9 +510,13 @@ def npm_tarball_version_ready(path: Path, expected_version: str) -> None:
             if package_json is None:
                 raise SystemExit(1)
             metadata = json.load(package_json)
-        ready = (
-            isinstance(metadata, dict)
-            and metadata.get("version") == expected_version
+        version = metadata.get("version") if isinstance(metadata, dict) else None
+        exact_version = re.fullmatch(
+            r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?",
+            expected_version,
+        )
+        ready = isinstance(version, str) and (
+            version == expected_version if exact_version else bool(version)
         )
     except (KeyError, OSError, tarfile.TarError, UnicodeDecodeError, ValueError):
         ready = False

--- a/Agents/utils/common/Harbor/env.py
+++ b/Agents/utils/common/Harbor/env.py
@@ -500,6 +500,24 @@ def tar_file_ready(path: Path) -> None:
         raise SystemExit(1) from None
 
 
+def npm_tarball_version_ready(path: Path, expected_version: str) -> None:
+    if not path.is_file():
+        raise SystemExit(1)
+    try:
+        with tarfile.open(path) as archive:
+            package_json = archive.extractfile("package/package.json")
+            if package_json is None:
+                raise SystemExit(1)
+            metadata = json.load(package_json)
+        ready = (
+            isinstance(metadata, dict)
+            and metadata.get("version") == expected_version
+        )
+    except (KeyError, OSError, tarfile.TarError, UnicodeDecodeError, ValueError):
+        ready = False
+    raise SystemExit(0 if ready else 1)
+
+
 def build_portable_tar(source_path: Path, output_path: Path) -> None:
     """Rewrite an xz tar as gzip so task images only need ubiquitous gzip."""
 
@@ -568,6 +586,9 @@ def parse_args() -> argparse.Namespace:
     filter_parser.add_argument("tasks")
     tar_parser = subparsers.add_parser("tar-file-ready")
     tar_parser.add_argument("path", type=Path)
+    npm_tar_parser = subparsers.add_parser("npm-tarball-version-ready")
+    npm_tar_parser.add_argument("path", type=Path)
+    npm_tar_parser.add_argument("expected_version")
     portable_tar_parser = subparsers.add_parser("portable-tar")
     portable_tar_parser.add_argument("source", type=Path)
     portable_tar_parser.add_argument("output", type=Path)
@@ -589,6 +610,9 @@ def main() -> None:
         return
     if args.command == "tar-file-ready":
         tar_file_ready(args.path)
+        return
+    if args.command == "npm-tarball-version-ready":
+        npm_tarball_version_ready(args.path, args.expected_version)
         return
     if args.command == "portable-tar":
         build_portable_tar(args.source, args.output)

--- a/Agents/utils/common/Harbor/env.sh
+++ b/Agents/utils/common/Harbor/env.sh
@@ -1346,6 +1346,12 @@ harbor_tar_file_ready() {
   python3 "$SCRIPT_DIR/env.py" tar-file-ready "$path" >/dev/null 2>&1
 }
 
+harbor_npm_tarball_version_ready() {
+  local path="$1" expected_version="$2"
+  python3 "$SCRIPT_DIR/env.py" npm-tarball-version-ready \
+    "$path" "$expected_version" >/dev/null 2>&1
+}
+
 harbor_local_cache_ready() {
   [[ -f "$LOCAL_WHEEL_DIR/manifest.txt" ]] \
     && grep -qx 'cache_schema=3' "$LOCAL_WHEEL_DIR/manifest.txt" \
@@ -1363,9 +1369,11 @@ harbor_local_cache_ready() {
           && harbor_tar_file_ready "$LOCAL_WHEEL_DIR/${PI_RUNTIME_BASENAME}" \
           && grep -qx "pi_runtime_version=${PI_VERSION}" "$LOCAL_WHEEL_DIR/manifest.txt"
       else
-        [[ -f "$LOCAL_WHEEL_DIR/${CLAUDE_CODE_TGZ_BASENAME}" ]] \
+        harbor_npm_tarball_version_ready \
+          "$LOCAL_WHEEL_DIR/${CLAUDE_CODE_TGZ_BASENAME}" \
+          "$CLAUDE_CODE_VERSION" \
           && [[ -d "$LOCAL_WHEEL_DIR/npm-cache/_cacache" ]] \
-          && [[ -f "$LOCAL_WHEEL_DIR/npm-cache-ready" ]] \
+          && grep -qx "$CLAUDE_CODE_VERSION" "$LOCAL_WHEEL_DIR/npm-cache-ready" \
           && grep -qx "claude_npm_cache_version=${CLAUDE_CODE_VERSION}" "$LOCAL_WHEEL_DIR/manifest.txt"
       fi
     }
@@ -1375,6 +1383,15 @@ harbor_pick_remote_wheel_url() {
   # Pi unpacks its pinned runtime from the read-only dependency mount. A
   # remote URL cannot materialize that mount, so Pi always prepares locally.
   if harbor_agent_is_pi; then
+    return 1
+  fi
+  # Claude's npm package has platform-specific optional dependencies. The
+  # remote cache path exposes only the top-level tarball to Docker trials, not
+  # the accompanying npm cache, so it can silently fall back to an online npm
+  # install in every task container. Prepare a complete local cache instead so
+  # the tarball and npm cache are mounted together.
+  if harbor_agent_is_claude_code \
+    && [[ "$HARBOR_ENVIRONMENT_TYPE" == "docker" ]]; then
     return 1
   fi
   local candidates=()

--- a/Agents/utils/common/Harbor/prepare_local_deps.py
+++ b/Agents/utils/common/Harbor/prepare_local_deps.py
@@ -151,6 +151,25 @@ def tarball_ready(path: Path) -> bool:
     return True
 
 
+def npm_tarball_version(path: Path) -> str | None:
+    """Return the npm package version embedded in a package tarball."""
+
+    if not tarball_ready(path):
+        return None
+    try:
+        with tarfile.open(path) as archive:
+            package_json = archive.extractfile("package/package.json")
+            if package_json is None:
+                return None
+            metadata = json.load(package_json)
+    except (KeyError, OSError, tarfile.TarError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    version = metadata.get("version")
+    return version if isinstance(version, str) and version else None
+
+
 def npm_tarball_urls(original_url: str, registry_url: str) -> list[str]:
     parsed = urllib.parse.urlparse(original_url)
     registry_origin = registry_url.rstrip("/")
@@ -309,7 +328,7 @@ class DependencyPreparer:
             self.config.claude_code_npm_spec,
             self.config.claude_code_tgz_basename,
             claude_meta_url,
-            "anthropic-ai-claude-code-*.tgz",
+            self.config.claude_code_version,
         )
         self._prepare_claude_npm_cache()
         (self.config.wheel_dir / "npm-cache-ready").write_text(
@@ -562,49 +581,63 @@ class DependencyPreparer:
         npm_spec: str,
         target_basename: str,
         registry_meta_url: str,
-        latest_glob: str,
+        expected_version: str,
     ) -> None:
         target = self.config.wheel_dir / target_basename
-        if shutil.which("npm"):
-            if not target.is_file():
-                with tempfile.TemporaryDirectory() as temporary_name:
-                    completed = subprocess.run(
-                        [
-                            "npm",
-                            "pack",
-                            "--registry",
-                            self.config.npm_registry_url,
-                            npm_spec,
-                        ],
-                        cwd=temporary_name,
-                        check=True,
-                        text=True,
-                        capture_output=True,
-                    )
-                    package_name = completed.stdout.splitlines()[-1].strip()
-                    shutil.move(
-                        str(Path(temporary_name) / package_name),
-                        self.config.wheel_dir / package_name,
-                    )
-            candidates = sorted(
-                self.config.wheel_dir.glob(latest_glob),
-                key=lambda path: path.stat().st_mtime,
-                reverse=True,
-            )
-            if candidates:
-                shutil.copy2(candidates[0], target)
-            return
-
-        if target.is_file():
+        if npm_tarball_version(target) == expected_version:
             print(f"[prepare] skip {target_basename} (cached)")
             return
+        target.unlink(missing_ok=True)
+        if shutil.which("npm"):
+            with tempfile.TemporaryDirectory() as temporary_name:
+                completed = subprocess.run(
+                    [
+                        "npm",
+                        "pack",
+                        "--registry",
+                        self.config.npm_registry_url,
+                        npm_spec,
+                    ],
+                    cwd=temporary_name,
+                    check=True,
+                    text=True,
+                    capture_output=True,
+                )
+                package_name = completed.stdout.splitlines()[-1].strip()
+                source = Path(temporary_name) / package_name
+                actual_version = npm_tarball_version(source)
+                if actual_version != expected_version:
+                    raise RuntimeError(
+                        "npm pack version mismatch: "
+                        f"expected {expected_version}, got {actual_version or '<invalid>'}"
+                    )
+                file_descriptor, temporary_target_name = tempfile.mkstemp(
+                    prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+                )
+                os.close(file_descriptor)
+                temporary_target = Path(temporary_target_name)
+                try:
+                    shutil.copy2(source, temporary_target)
+                    os.replace(temporary_target, target)
+                finally:
+                    temporary_target.unlink(missing_ok=True)
+            return
+
         metadata = _read_json(registry_meta_url)
         dist = metadata["dist"]
         if not isinstance(dist, dict):
             raise TypeError(f"invalid npm metadata from {registry_meta_url}")
-        url = str(dist["tarball"])
-        urllib.request.urlretrieve(url, target)
-        print(f"downloaded npm tarball: {url}")
+        urls = npm_tarball_urls(str(dist["tarball"]), self.config.npm_registry_url)
+        downloaded = _download_atomic(
+            urls,
+            target,
+            prefix="npm-pack-",
+            suffix=".tgz",
+            validate=lambda path: npm_tarball_version(path) == expected_version,
+            label="npm package",
+            timeout=120,
+        )
+        print(f"downloaded npm tarball: {downloaded}")
 
     def _download_npm_tgz_to_cache(
         self, target_basename: str, registry_meta_url: str
@@ -671,7 +704,7 @@ class DependencyPreparer:
             self.config.pi_npm_spec,
             self.config.pi_tgz_basename,
             pi_metadata_url,
-            "earendil-works-pi-coding-agent-*.tgz",
+            self.config.pi_version,
         )
         target = self.config.pi_runtime_tarball
         if tarball_ready(target) and self._manifest_has(

--- a/Agents/utils/common/Harbor/prepare_local_deps.py
+++ b/Agents/utils/common/Harbor/prepare_local_deps.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -146,7 +147,7 @@ def tarball_ready(path: Path) -> bool:
     try:
         with tarfile.open(path) as archive:
             archive.getmembers()
-    except (OSError, tarfile.TarError):
+    except (EOFError, OSError, tarfile.TarError):
         return False
     return True
 
@@ -168,6 +169,16 @@ def npm_tarball_version(path: Path) -> str | None:
         return None
     version = metadata.get("version")
     return version if isinstance(version, str) and version else None
+
+
+def npm_version_matches_selector(version: str | None, selector: str) -> bool:
+    if version is None:
+        return False
+    exact_version = re.fullmatch(
+        r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?",
+        selector,
+    )
+    return version == selector if exact_version else True
 
 
 def npm_tarball_urls(original_url: str, registry_url: str) -> list[str]:
@@ -257,17 +268,23 @@ def _download_atomic(
             for candidate in urls:
                 try:
                     _download(candidate, temporary, timeout=timeout)
-                    downloaded_url = candidate
-                    break
                 except OSError as exc:
                     last_error = exc
                     temporary.unlink(missing_ok=True)
                     temporary.touch()
+                    continue
+                if not validate(temporary):
+                    last_error = ValueError(
+                        f"downloaded archive is invalid: {candidate}"
+                    )
+                    temporary.unlink(missing_ok=True)
+                    temporary.touch()
+                    continue
+                downloaded_url = candidate
+                break
             if not downloaded_url:
                 assert last_error is not None
                 raise last_error
-            if not validate(temporary):
-                raise ValueError(f"downloaded archive is invalid: {downloaded_url}")
             os.replace(temporary, target)
             return downloaded_url
         except Exception as exc:
@@ -329,6 +346,7 @@ class DependencyPreparer:
             self.config.claude_code_tgz_basename,
             claude_meta_url,
             self.config.claude_code_version,
+            "anthropic-ai-claude-code-*.tgz",
         )
         self._prepare_claude_npm_cache()
         (self.config.wheel_dir / "npm-cache-ready").write_text(
@@ -581,10 +599,14 @@ class DependencyPreparer:
         npm_spec: str,
         target_basename: str,
         registry_meta_url: str,
-        expected_version: str,
+        version_selector: str,
+        stale_glob: str,
     ) -> None:
         target = self.config.wheel_dir / target_basename
-        if npm_tarball_version(target) == expected_version:
+        if npm_version_matches_selector(
+            npm_tarball_version(target), version_selector
+        ):
+            self._remove_stale_npm_pack_archives(stale_glob)
             print(f"[prepare] skip {target_basename} (cached)")
             return
         target.unlink(missing_ok=True)
@@ -606,10 +628,12 @@ class DependencyPreparer:
                 package_name = completed.stdout.splitlines()[-1].strip()
                 source = Path(temporary_name) / package_name
                 actual_version = npm_tarball_version(source)
-                if actual_version != expected_version:
+                if not npm_version_matches_selector(
+                    actual_version, version_selector
+                ):
                     raise RuntimeError(
                         "npm pack version mismatch: "
-                        f"expected {expected_version}, got {actual_version or '<invalid>'}"
+                        f"expected {version_selector}, got {actual_version or '<invalid>'}"
                     )
                 file_descriptor, temporary_target_name = tempfile.mkstemp(
                     prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
@@ -621,23 +645,37 @@ class DependencyPreparer:
                     os.replace(temporary_target, target)
                 finally:
                     temporary_target.unlink(missing_ok=True)
+            self._remove_stale_npm_pack_archives(stale_glob)
             return
 
         metadata = _read_json(registry_meta_url)
         dist = metadata["dist"]
         if not isinstance(dist, dict):
             raise TypeError(f"invalid npm metadata from {registry_meta_url}")
+        resolved_version = metadata.get("version")
+        if not isinstance(resolved_version, str) or not npm_version_matches_selector(
+            resolved_version, version_selector
+        ):
+            raise RuntimeError(
+                "npm metadata version mismatch: "
+                f"expected {version_selector}, got {resolved_version or '<invalid>'}"
+            )
         urls = npm_tarball_urls(str(dist["tarball"]), self.config.npm_registry_url)
         downloaded = _download_atomic(
             urls,
             target,
             prefix="npm-pack-",
             suffix=".tgz",
-            validate=lambda path: npm_tarball_version(path) == expected_version,
+            validate=lambda path: npm_tarball_version(path) == resolved_version,
             label="npm package",
             timeout=120,
         )
+        self._remove_stale_npm_pack_archives(stale_glob)
         print(f"downloaded npm tarball: {downloaded}")
+
+    def _remove_stale_npm_pack_archives(self, stale_glob: str) -> None:
+        for stale in self.config.wheel_dir.glob(stale_glob):
+            stale.unlink(missing_ok=True)
 
     def _download_npm_tgz_to_cache(
         self, target_basename: str, registry_meta_url: str
@@ -705,6 +743,7 @@ class DependencyPreparer:
             self.config.pi_tgz_basename,
             pi_metadata_url,
             self.config.pi_version,
+            "earendil-works-pi-coding-agent-*.tgz",
         )
         target = self.config.pi_runtime_tarball
         if tarball_ready(target) and self._manifest_has(

--- a/Agents/utils/common/Harbor/tests/test_env_helpers.py
+++ b/Agents/utils/common/Harbor/tests/test_env_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
@@ -163,6 +164,27 @@ class HarborEnvHelperTests(unittest.TestCase):
 
             self.assertEqual(ready.returncode, 0, ready.stderr)
             self.assertNotEqual(not_ready.returncode, 0)
+
+    def test_npm_tarball_version_ready_requires_exact_embedded_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = Path(temp_dir) / "package.tgz"
+            package_json = json.dumps(
+                {"name": "@anthropic-ai/claude-code", "version": "1.2.3"}
+            ).encode()
+            with tarfile.open(archive_path, "w:gz") as archive:
+                member = tarfile.TarInfo("package/package.json")
+                member.size = len(package_json)
+                archive.addfile(member, io.BytesIO(package_json))
+
+            matching = run_env_helper(
+                "npm-tarball-version-ready", archive_path, "1.2.3"
+            )
+            mismatched = run_env_helper(
+                "npm-tarball-version-ready", archive_path, "9.9.9"
+            )
+
+            self.assertEqual(matching.returncode, 0, matching.stderr)
+            self.assertNotEqual(mismatched.returncode, 0)
 
     def test_portable_tar_removes_external_xz_runtime_requirement(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/Agents/utils/common/Harbor/tests/test_env_helpers.py
+++ b/Agents/utils/common/Harbor/tests/test_env_helpers.py
@@ -182,9 +182,13 @@ class HarborEnvHelperTests(unittest.TestCase):
             mismatched = run_env_helper(
                 "npm-tarball-version-ready", archive_path, "9.9.9"
             )
+            tagged = run_env_helper(
+                "npm-tarball-version-ready", archive_path, "latest"
+            )
 
             self.assertEqual(matching.returncode, 0, matching.stderr)
             self.assertNotEqual(mismatched.returncode, 0)
+            self.assertEqual(tagged.returncode, 0, tagged.stderr)
 
     def test_portable_tar_removes_external_xz_runtime_requirement(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/Agents/utils/common/Harbor/tests/test_prepare_local_deps.py
+++ b/Agents/utils/common/Harbor/tests/test_prepare_local_deps.py
@@ -1,9 +1,12 @@
 import io
+import json
 import tarfile
 import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 from Agents.utils.common.Harbor import prepare_local_deps
 
@@ -58,6 +61,67 @@ class PrepareLocalDepsTest(unittest.TestCase):
         self.assertTrue(prepare_local_deps.tarball_ready(valid))
         self.assertFalse(prepare_local_deps.tarball_ready(corrupt))
         self.assertFalse(prepare_local_deps.tarball_ready(self.root / "missing"))
+
+    @staticmethod
+    def _write_npm_tarball(path: Path, version: str) -> None:
+        payload = json.dumps({"name": "fixture", "version": version}).encode()
+        with tarfile.open(path, "w:gz") as archive:
+            info = tarfile.TarInfo("package/package.json")
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+
+    def test_npm_tarball_version_reads_embedded_package_version(self):
+        archive = self.root / "package.tgz"
+        self._write_npm_tarball(archive, "1.2.3")
+
+        self.assertEqual(
+            prepare_local_deps.npm_tarball_version(archive), "1.2.3"
+        )
+        self.assertIsNone(
+            prepare_local_deps.npm_tarball_version(self.root / "missing.tgz")
+        )
+
+    def test_npm_pack_uses_exact_result_instead_of_newest_cached_archive(self):
+        wheel_dir = self.root / "wheels"
+        wheel_dir.mkdir()
+        target = wheel_dir / "claude-code-1.2.3.tgz"
+        stale = wheel_dir / "anthropic-ai-claude-code-9.9.9.tgz"
+        self._write_npm_tarball(target, "9.9.9")
+        self._write_npm_tarball(stale, "9.9.9")
+        config = prepare_local_deps.Config.from_environment(
+            {
+                "WHEEL_DIR": str(wheel_dir),
+                "CLAUDE_CODE_VERSION": "1.2.3",
+            },
+            script_dir=self.root,
+        )
+
+        def npm_pack(*args, **kwargs):
+            package_name = "anthropic-ai-claude-code-1.2.3.tgz"
+            self._write_npm_tarball(
+                Path(kwargs["cwd"]) / package_name, "1.2.3"
+            )
+            return SimpleNamespace(stdout=f"{package_name}\n")
+
+        with (
+            mock.patch.object(prepare_local_deps.shutil, "which", return_value="npm"),
+            mock.patch.object(
+                prepare_local_deps.subprocess, "run", side_effect=npm_pack
+            ),
+        ):
+            prepare_local_deps.DependencyPreparer(config)._pack_npm_to_cache(
+                config.claude_code_npm_spec,
+                config.claude_code_tgz_basename,
+                "https://registry.example.invalid/metadata",
+                config.claude_code_version,
+            )
+
+        self.assertEqual(
+            prepare_local_deps.npm_tarball_version(target), "1.2.3"
+        )
+        self.assertEqual(
+            prepare_local_deps.npm_tarball_version(stale), "9.9.9"
+        )
 
     def test_npm_tarball_urls_prefers_configured_mirror_then_origin(self):
         original = (

--- a/Agents/utils/common/Harbor/tests/test_prepare_local_deps.py
+++ b/Agents/utils/common/Harbor/tests/test_prepare_local_deps.py
@@ -61,6 +61,10 @@ class PrepareLocalDepsTest(unittest.TestCase):
         self.assertTrue(prepare_local_deps.tarball_ready(valid))
         self.assertFalse(prepare_local_deps.tarball_ready(corrupt))
         self.assertFalse(prepare_local_deps.tarball_ready(self.root / "missing"))
+        with mock.patch.object(
+            prepare_local_deps.tarfile, "open", side_effect=EOFError
+        ):
+            self.assertFalse(prepare_local_deps.tarball_ready(valid))
 
     @staticmethod
     def _write_npm_tarball(path: Path, version: str) -> None:
@@ -79,6 +83,12 @@ class PrepareLocalDepsTest(unittest.TestCase):
         )
         self.assertIsNone(
             prepare_local_deps.npm_tarball_version(self.root / "missing.tgz")
+        )
+        self.assertTrue(
+            prepare_local_deps.npm_version_matches_selector("1.2.3", "latest")
+        )
+        self.assertFalse(
+            prepare_local_deps.npm_version_matches_selector("9.9.9", "1.2.3")
         )
 
     def test_npm_pack_uses_exact_result_instead_of_newest_cached_archive(self):
@@ -114,13 +124,45 @@ class PrepareLocalDepsTest(unittest.TestCase):
                 config.claude_code_tgz_basename,
                 "https://registry.example.invalid/metadata",
                 config.claude_code_version,
+                "anthropic-ai-claude-code-*.tgz",
             )
 
         self.assertEqual(
             prepare_local_deps.npm_tarball_version(target), "1.2.3"
         )
+        self.assertFalse(stale.exists())
+
+    def test_atomic_download_tries_origin_after_invalid_mirror_archive(self):
+        target = self.root / "package.tgz"
+        mirror = "https://mirror.example.invalid/package.tgz"
+        origin = "https://registry.example.invalid/package.tgz"
+        calls = []
+
+        def download(url, destination, *, timeout=None):
+            calls.append(url)
+            if url == mirror:
+                destination.write_text("invalid", encoding="utf-8")
+            else:
+                self._write_npm_tarball(destination, "1.2.3")
+
+        with mock.patch.object(
+            prepare_local_deps, "_download", side_effect=download
+        ):
+            selected = prepare_local_deps._download_atomic(
+                [mirror, origin],
+                target,
+                prefix="fixture-",
+                suffix=".tgz",
+                validate=lambda path: (
+                    prepare_local_deps.npm_tarball_version(path) == "1.2.3"
+                ),
+                label="fixture",
+            )
+
+        self.assertEqual(selected, origin)
+        self.assertEqual(calls, [mirror, origin])
         self.assertEqual(
-            prepare_local_deps.npm_tarball_version(stale), "9.9.9"
+            prepare_local_deps.npm_tarball_version(target), "1.2.3"
         )
 
     def test_npm_tarball_urls_prefers_configured_mirror_then_origin(self):


### PR DESCRIPTION
## 1. Why the change?

The Harbor E2E nightly remained active past eight hours because its job limit was twelve hours, while repeated Claude setup failures could consume two hours per attempt and were retried twice. Investigation also found that dependency-cache preparation could copy the newest wildcard-matching npm archive over a version-specific target, producing a tarball whose embedded Claude version did not match its filename and manifest.

## 2. Summary of the change

- Publish only the exact archive returned by `npm pack`, atomically, after validating its embedded package version.
- Reject mismatched local npm tarballs during cache readiness checks and fall back from invalid mirrors to the npm origin.
- Avoid the incomplete remote-only Claude cache path for Docker so the tarball and npm cache are mounted together.
- Bound agent setup to 12 minutes and exclude setup timeouts from task retries.
- Add a 7.5-hour benchmark soft limit and an 8-hour job hard limit, preserving time for cleanup and artifact upload.
- Add regression tests for cache version integrity, tagged npm selectors, mirror fallback, truncated archives, and workflow timeout policy.

## 3. Other details

Follow-up to #159.

Validation completed:
- 567 Harbor tests pass under the pinned Python 3.12 runner environment.
- Focused dependency-cache and workflow tests pass.
- Workflow shell blocks and `env.sh` pass syntax validation.
- Complete local caches are installed and version-validated for the `siisyslab` service account on both bare-metal runners (`cpu-nat-093` and `cpu-nat-360`).
- Offline Claude installation from the cache reports Claude Code 2.1.90 on both hosts.
