### PR TITLE
fix(harbor): enable authless Opik tracing

### DIFF
--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -53,19 +53,23 @@ class E2eValidationWorkflowTest(unittest.TestCase):
     def test_checks_out_submodules_for_opik_tracing(self):
         self.assertIn("submodules: recursive", self.workflow)
 
-    def test_enables_tracing_only_with_a_real_opik_credential(self):
-        # env.sh substitutes the literal local-dev-key for a missing
-        # OPIK_API_KEY and harboropik.sh's preflight accepts 401/403, so an
-        # unconditionally non-empty OPIK_URL would look healthy while no
-        # trace reached Opik. OPIK_URL is the single switch: clear it unless
-        # both it and OPIK_API_KEY are real.
+    def test_enables_tracing_with_an_opik_url_and_optional_api_key(self):
+        # Self-hosted Opik may allow unauthenticated ingestion, so OPIK_URL is
+        # the tracing switch and OPIK_API_KEY remains optional.
         self.assertNotIn("TRACE_TO_OPIK", self.workflow)
         self.assertIn("secrets.OPIK_API_KEY", self.workflow)
         self.assertIn(
-            'if [[ -n "${OPIK_API_KEY:-}" && -n "${OPIK_URL:-}" ]]; then',
+            'if [[ -n "${OPIK_URL:-}" ]]; then',
             self.workflow,
         )
         self.assertIn('export OPIK_URL=""', self.workflow)
+
+    def test_uses_hourly_tb21_opik_project_names(self):
+        self.assertIn(
+            'export OPIK_PROJECT_NAME="$(date -u +\'%Y-%m-%d-%H\')'
+            '-harbor-e2e-validation-tb21"',
+            self.workflow,
+        )
 
     def test_redacts_every_credential_it_injects(self):
         redact = self.workflow[self.workflow.index("Stage and redact artifacts"):]

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -155,7 +155,6 @@ jobs:
           OPIK_URL: ${{ vars.OPIK_URL }}
           OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
           OPIK_WORKSPACE: ${{ vars.OPIK_WORKSPACE }}
-          OPIK_PROJECT_NAME: harbor-e2e-validation
           AGENT: ${{ steps.params.outputs.agent }}
           TASKS: ${{ steps.params.outputs.tasks }}
           WORKERS: ${{ steps.capacity.outputs.workers }}
@@ -177,16 +176,16 @@ jobs:
           export BASE_URL="${BASE_URL_RAW%/chat/completions}"
           export TOTAL_WORKERS="$WORKERS"
           export HARBOR_N_CONCURRENT="$WORKERS"
-          # Only trace when a real Opik credential is present. env.sh
-          # substitutes the literal 'local-dev-key' for a missing OPIK_API_KEY,
-          # and harboropik.sh's preflight accepts 401/403, so tracing would
-          # appear healthy while no trace reached Opik. Clearing OPIK_URL is the
-          # switch: run untraced instead of silently pretending.
-          if [[ -n "${OPIK_API_KEY:-}" && -n "${OPIK_URL:-}" ]]; then
-            printf 'Opik tracing enabled for %s\n' "$OPIK_URL"
+          export OPIK_PROJECT_NAME="$(date -u +'%Y-%m-%d-%H')-harbor-e2e-validation-tb21"
+          # OPIK_URL is the tracing switch. OPIK_API_KEY is optional because
+          # self-hosted Opik deployments may allow unauthenticated ingestion;
+          # env.sh supplies the default workspace when OPIK_WORKSPACE is empty.
+          if [[ -n "${OPIK_URL:-}" ]]; then
+            printf 'Opik tracing enabled for %s in project %s\n' \
+              "$OPIK_URL" "$OPIK_PROJECT_NAME"
           else
             export OPIK_URL=""
-            echo "::warning::OPIK_API_KEY or OPIK_URL is unset; running without tracing. Add OPIK_API_KEY to the self-hosted-env environment to enable it."
+            echo "::warning::OPIK_URL is unset; running without tracing. Add OPIK_URL to the self-hosted-env environment to enable it."
           fi
           # OUTPUT_PATH is exported, not left to env.sh's default. A runner-level
           # OUTPUT_ROOT or OUTPUT_PATH would otherwise win (config_loader.sh gives


### PR DESCRIPTION
## 1. Why the change?

The Harbor E2E workflow disabled Opik tracing whenever `OPIK_API_KEY` was empty, even when the configured self-hosted Opik endpoint accepts unauthenticated ingestion. Its static project name also mixed unrelated hourly runs.

## 2. Summary of the change

- Use `OPIK_URL` as the tracing switch and keep `OPIK_API_KEY` optional.
- Continue using the existing `default` workspace fallback when no workspace override is configured.
- Name projects by UTC hour using `YYYY-MM-DD-HH-harbor-e2e-validation-tb21`.
- Update workflow regression coverage.

## 3. Other details

Validated with 27 workflow tests and shell syntax checking of the rendered benchmark step.
