### PR TITLE
fix: update pip to resolve Dependabot alerts

### DIFF
--- a/Agents/utils/common/Harbor/runner-requirements.txt
+++ b/Agents/utils/common/Harbor/runner-requirements.txt
@@ -6,7 +6,7 @@ harbor==0.18.0
 e2b==2.32.1
 dockerfile-parse==2.0.1
 opik==2.1.32
-pip==25.2
+pip==26.2
 PyYAML==6.0.3
 s3cmd==2.4.0
 yicloud-sdk-python==0.3.1

--- a/Agents/utils/common/Harbor/tests/test_harbor_prepare_runner_cli.py
+++ b/Agents/utils/common/Harbor/tests/test_harbor_prepare_runner_cli.py
@@ -66,7 +66,7 @@ class RunnerValidationTest(unittest.TestCase):
             "[ \"$3\" = e2b ] && echo 2.32.1 && exit 0\n"
             "[ \"$3\" = dockerfile-parse ] && echo 2.0.1 && exit 0\n"
             "[ \"$3\" = opik ] && echo 2.1.32 && exit 0\n"
-            "[ \"$3\" = pip ] && echo 25.2 && exit 0\n"
+            "[ \"$3\" = pip ] && echo 26.2 && exit 0\n"
             "[ \"$3\" = PyYAML ] && echo 6.0.3 && exit 0\n"
             "[ \"$3\" = s3cmd ] && echo 2.4.0 && exit 0\n"
             "[ \"$3\" = yicloud-sdk-python ] && echo 0.3.1 && exit 0\n"
@@ -81,7 +81,7 @@ class RunnerValidationTest(unittest.TestCase):
                 ("e2b", "2.32.1"),
                 ("dockerfile-parse", "2.0.1"),
                 ("opik", "2.1.32"),
-                ("pip", "25.2"),
+                ("pip", "26.2"),
                 ("PyYAML", "6.0.3"),
                 ("s3cmd", "2.4.0"),
                 ("yicloud-sdk-python", "0.3.1"),

--- a/Agents/utils/common/Harbor/tests/test_setup_runner_env.sh
+++ b/Agents/utils/common/Harbor/tests/test_setup_runner_env.sh
@@ -22,7 +22,7 @@ elif [[ "\${3:-}" == "opik" ]]; then
 elif [[ "\${3:-}" == "yicloud-sdk-python" ]]; then
   printf '%s\n' '0.3.1'
 elif [[ "\${3:-}" == "pip" ]]; then
-  printf '%s\n' '25.2'
+  printf '%s\n' '26.2'
 elif [[ "\${3:-}" == "PyYAML" ]]; then
   printf '%s\n' '6.0.3'
 elif [[ "\${3:-}" == "s3cmd" ]]; then


### PR DESCRIPTION
## 1. Why the change?

The Harbor runner pins `pip==25.2`, which is affected by six open Dependabot alerts: GHSA-4xh5-x5gv-qwph, GHSA-6vgw-5pg2-w6jp, GHSA-58qw-9mgm-455v, GHSA-jp4c-xjxw-mgf9, GHSA-wf93-45jw-7689, and GHSA-qwm4-qh6w-59xr.

## 2. Summary of the change 

- Update the exact Harbor runner pin from pip 25.2 to pip 26.2, the latest patched release.
- Update the Python and shell runner-validation fixtures to require the same version.

Dependabot reports the latest minimum patched version as `26.2.0`. The published Python package metadata uses the PEP 440-equivalent version `26.2`, which is required here because the runner validator compares installed metadata to the pin as a literal string.

## 3. Other details

Validation performed:

```text
python3 -m unittest Agents.utils.common.Harbor.tests.test_harbor_prepare_runner_cli -v
Ran 3 tests — OK

bash Agents/utils/common/Harbor/tests/test_setup_runner_env.sh
Passed

Python 3.12 install and metadata check: pip 26.2
```

Addresses Dependabot alerts #1 through #6.