### PR TITLE
ci: add four-hour Harbor self-hosted nightly

### DIFF
--- a/.github/harbor-nightly-benchmarks.txt
+++ b/.github/harbor-nightly-benchmarks.txt
@@ -1,0 +1,29 @@
+# Built-in Harbor aliases. Terminal-Bench is covered by the dedicated E2E
+# nightly and is intentionally excluded here.
+seta
+smith
+sweverify
+
+# Harbor Hub datasets with at least 20 tasks.
+swe-bench/swe-bench-verified
+scale-ai/swe-bench-pro
+openthoughts/openthoughts-tblite
+harveyai/lab
+datacurve/deep-swe
+scale-ai/swe-atlas-qna
+snorkel-ai/senior-swe-bench-v2026.06
+harbor-index/harbor-index-1.0
+datacurve/deep-swe-1-1
+sierra-research/tau3-bench
+benchflow/skillsbench
+abundant/swe-marathon
+maxbittker/runebench
+aider/aider-polyglot
+gabeorlanski/slopcodebench
+android-bench/android-bench
+vmax-modal/modal-port-v1-eval-patched
+orca-bench/orca-bench
+aime/aime
+tmax/TMax-15K-Harbor
+swe-rebench/swe-rebench-leaderboard
+gaia/gaia

--- a/.github/scripts/harbor_nightly_select.py
+++ b/.github/scripts/harbor_nightly_select.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Select a random task sample for one Harbor benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import random
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+LOCAL_TASK_LISTS = {
+    "seta": Path("Tasks/SETA/harbor_tasks.txt"),
+    "smith": Path("Tasks/SWE-smith/harbor_tasks.txt"),
+    "sweverify": Path("Tasks/SWE-verify/harbor_tasks.txt"),
+}
+SAMPLE_SIZE = 20
+
+
+def unique_names(names: list[str]) -> list[str]:
+    unique = list(
+        dict.fromkeys(
+            name.strip()
+            for name in names
+            if name.strip() and not name.lstrip().startswith("#")
+        )
+    )
+    if any("," in name for name in unique):
+        raise RuntimeError("task names containing commas are unsupported")
+    return unique
+
+
+def local_task_names(repo_root: Path, benchmark: str) -> list[str] | None:
+    relative_path = LOCAL_TASK_LISTS.get(benchmark)
+    if relative_path is None:
+        return None
+    path = repo_root / relative_path
+    if not path.is_file():
+        raise RuntimeError(f"task list does not exist: {path}")
+    return unique_names(path.read_text(encoding="utf-8").splitlines())
+
+
+async def _registry_task_names(
+    benchmark: str, client_factory: Callable[[], Any] | None = None
+) -> list[str]:
+    """Read task names from Harbor's package metadata API."""
+    try:
+        if client_factory is None:
+            from harbor.registry.client.package import PackageDatasetClient
+
+            client_factory = PackageDatasetClient
+        metadata = await client_factory().get_dataset_metadata(benchmark)
+        return unique_names([task_id.get_name() for task_id in metadata.task_ids])
+    except Exception as exc:
+        raise RuntimeError(f"unable to read Harbor metadata for {benchmark}") from exc
+
+
+def registry_task_names(
+    benchmark: str, client_factory: Callable[[], Any] | None = None
+) -> list[str]:
+    return asyncio.run(_registry_task_names(benchmark, client_factory))
+
+
+def task_names(repo_root: Path, benchmark: str) -> list[str]:
+    local_names = local_task_names(repo_root, benchmark)
+    return local_names if local_names is not None else registry_task_names(benchmark)
+
+
+def select_tasks(
+    repo_root: Path, benchmark: str, rng: Any | None = None
+) -> list[str]:
+    available = task_names(repo_root, benchmark)
+    if len(available) < SAMPLE_SIZE:
+        raise RuntimeError(
+            f"{benchmark} has only {len(available)} selectable tasks; need {SAMPLE_SIZE}"
+        )
+    randomizer = rng or random.SystemRandom()
+    return randomizer.sample(available, SAMPLE_SIZE)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--benchmark", required=True)
+    args = parser.parse_args(argv)
+    try:
+        selected = select_tasks(args.repo_root, args.benchmark)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+    print(len(selected))
+    print(",".join(selected))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_self_hosted_nightly_workflow.py
+++ b/.github/scripts/tests/test_self_hosted_nightly_workflow.py
@@ -1,0 +1,133 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "harbor-self-hosted-nightly.yml"
+BENCHMARKS = ROOT / ".github" / "harbor-nightly-benchmarks.txt"
+SELECTOR = ROOT / ".github" / "scripts" / "harbor_nightly_select.py"
+
+SPEC = importlib.util.spec_from_file_location("harbor_nightly_select", SELECTOR)
+assert SPEC and SPEC.loader
+selector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(selector)
+
+
+class FakeTaskId:
+    def __init__(self, name):
+        self.name = name
+
+    def get_name(self):
+        return self.name
+
+
+class FakeClient:
+    async def get_dataset_metadata(self, _benchmark):
+        return SimpleNamespace(
+            task_ids=[FakeTaskId("publisher/task-a"), FakeTaskId("publisher/task-b")]
+        )
+
+
+class FakeRandom:
+    def sample(self, values, count):
+        self.count = count
+        return values[:count]
+
+
+class SelectorTest(unittest.TestCase):
+    def test_reads_local_task_lists(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            task_list = root / selector.LOCAL_TASK_LISTS["seta"]
+            task_list.parent.mkdir(parents=True)
+            task_list.write_text("# comment\ntask-a\ntask-b\ntask-a\n", encoding="utf-8")
+            self.assertEqual(selector.task_names(root, "seta"), ["task-a", "task-b"])
+
+    def test_reads_harbor_machine_metadata(self):
+        self.assertEqual(
+            selector.registry_task_names("publisher/dataset", FakeClient),
+            ["publisher/task-a", "publisher/task-b"],
+        )
+
+    def test_selects_twenty_unique_tasks(self):
+        available = [f"task-{index}" for index in range(20)]
+        randomizer = FakeRandom()
+        with mock.patch.object(selector, "task_names", return_value=available):
+            selected = selector.select_tasks(Path("."), "seta", randomizer)
+        self.assertEqual(len(selected), 20)
+        self.assertEqual(len(set(selected)), 20)
+        self.assertEqual(randomizer.count, 20)
+
+    def test_rejects_benchmarks_with_fewer_than_twenty_tasks(self):
+        available = [f"task-{index}" for index in range(19)]
+        with (
+            mock.patch.object(selector, "task_names", return_value=available),
+            self.assertRaisesRegex(RuntimeError, "need 20"),
+        ):
+            selector.select_tasks(Path("."), "seta", FakeRandom())
+
+
+class WorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        cls.benchmarks = [
+            line.strip()
+            for line in BENCHMARKS.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+
+    def test_targets_self_hosted_runner_on_a_schedule(self):
+        self.assertIn("runs-on: [self-hosted, Linux, X64, bare-metal]", self.workflow)
+        self.assertIn('- cron: "47 */4 * * *"', self.workflow)
+        self.assertNotIn("pull_request", self.workflow)
+
+    def test_catalog_excludes_terminal_bench_and_adds_harbor_hub(self):
+        self.assertFalse(any("terminal-bench" in item.lower() for item in self.benchmarks))
+        self.assertGreaterEqual(sum("/" in item for item in self.benchmarks), 10)
+        self.assertIn("tmax/TMax-15K-Harbor", self.benchmarks)
+
+    def test_randomizes_benchmark_and_selects_twenty_tasks(self):
+        self.assertIn("shuf -n 1", self.workflow)
+        self.assertIn("SAMPLE_SIZE = 20", SELECTOR.read_text())
+        self.assertIn("harbor_nightly_select.py", self.workflow)
+
+    def test_passes_the_sample_to_harbor(self):
+        self.assertIn("INCLUDE_TASKS: ${{ steps.params.outputs.tasks }}", self.workflow)
+        self.assertIn("HARBOR_INCLUDE_TASKS: ${{ steps.params.outputs.tasks }}", self.workflow)
+        self.assertIn('scripts/run_fleet.sh --taskset "$BENCHMARK"', self.workflow)
+        self.assertIn("Verify sampled tasks completed", self.workflow)
+        self.assertIn("--expected-trials", self.workflow)
+
+    def test_pins_environment_values_that_can_change_the_run(self):
+        self.assertIn(
+            "ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_REVIEW_API_KEY }}", self.workflow
+        )
+        self.assertIn(
+            "HARBOR_ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_REVIEW_API_KEY }}",
+            self.workflow,
+        )
+        self.assertIn('HARBOR_LIMIT: ""', self.workflow)
+        self.assertIn('MIN_TEST: "0"', self.workflow)
+
+    def test_smith_rejects_excess_harness_failures(self):
+        self.assertIn('failed_count="$(grep -c . "$queue_dir/failed.txt"', self.workflow)
+        self.assertIn("$4 != \"\" { count++ }", self.workflow)
+        self.assertIn("errors * 100 > EXPECTED_TASKS * 10", self.workflow)
+
+    def test_uses_least_privilege_and_pinned_checkout(self):
+        self.assertIn("permissions:\n  contents: read", self.workflow)
+        self.assertRegex(self.workflow, r"actions/checkout@[0-9a-f]{40} # v")
+        self.assertIn("persist-credentials: false", self.workflow)
+
+    def test_cleans_up_without_pruning_the_shared_daemon(self):
+        self.assertIn("zellij kill-session", self.workflow)
+        self.assertNotIn("docker system prune", self.workflow)
+        self.assertNotIn("docker image prune", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/harbor-self-hosted-nightly.yml
+++ b/.github/workflows/harbor-self-hosted-nightly.yml
@@ -1,0 +1,194 @@
+name: Harbor Self-Hosted Nightly
+
+"on":
+  workflow_dispatch:
+    inputs:
+      agent:
+        description: claude-code or opencode
+        required: false
+        default: claude-code
+        type: string
+  schedule:
+    - cron: "47 */4 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: harbor-self-hosted-nightly
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Harbor self-hosted nightly
+    runs-on: [self-hosted, Linux, X64, bare-metal]
+    environment: self-hosted-env
+    timeout-minutes: 480
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Validate prerequisites
+        run: |
+          set -euo pipefail
+          export AGENT_FLEET_REQUIRE_DOCKER=1
+          source scripts/prerequisites.sh
+          agent_fleet_bootstrap_setup_prerequisites
+          runner_dir="$RUNNER_TEMP/harbor-self-hosted-nightly-runner"
+          no_image_dir="$RUNNER_TEMP/harbor-self-hosted-nightly-no-image"
+          HARBOR_RUNNER_IMAGE_DIR="$no_image_dir" \
+          HARBOR_RUNNER_HOST_DIR="$runner_dir" \
+            bash Agents/utils/common/Harbor/setup_runner_env.sh
+          {
+            printf 'HARBOR_RUNNER_IMAGE_DIR=%s\n' "$no_image_dir"
+            printf 'HARBOR_RUNNER_HOST_DIR=%s\n' "$runner_dir"
+            printf 'HARBOR_NIGHTLY_PYTHON=%s/bin/python\n' "$runner_dir"
+          } >> "$GITHUB_ENV"
+
+      - name: Select benchmark and tasks
+        id: params
+        env:
+          INPUT_AGENT: ${{ inputs.agent }}
+          SMITH_DATASET_PATH: ${{ vars.SMITH_DATASET_PATH }}
+          RUN_ID: harbor-self-hosted-nightly-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          mapfile -t benchmarks < <(
+            awk 'NF && $1 !~ /^#/' .github/harbor-nightly-benchmarks.txt
+          )
+          if printf '%s\n' "${benchmarks[@]}" | grep -Eiq 'terminal-?bench'; then
+            echo "::error::Terminal-Bench must remain excluded" >&2
+            exit 1
+          fi
+
+          smith_path="${SMITH_DATASET_PATH:-/workspace/harbor/datasets/swesmith}"
+          if [[ ! -d "$smith_path" ]]; then
+            benchmarks=("${benchmarks[@]/#smith/}")
+          fi
+          benchmark="$(printf '%s\n' "${benchmarks[@]}" | awk 'NF' | shuf -n 1)"
+          mapfile -t selection < <("$HARBOR_NIGHTLY_PYTHON" \
+            .github/scripts/harbor_nightly_select.py \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --benchmark "$benchmark")
+          if (( ${#selection[@]} != 2 )); then
+            echo "::error::task selector returned invalid output" >&2
+            exit 1
+          fi
+          task_count="${selection[0]}"
+          tasks="${selection[1]}"
+
+          agent="${INPUT_AGENT:-claude-code}"
+          case "$agent" in
+            claude-code|opencode) ;;
+            *) echo "::error::unsupported agent: $agent" >&2; exit 1 ;;
+          esac
+          dataset_path=""
+          [[ "$benchmark" != "smith" ]] || dataset_path="$smith_path"
+          {
+            printf 'benchmark=%s\n' "$benchmark"
+            printf 'tasks=%s\n' "$tasks"
+            printf 'task_count=%s\n' "$task_count"
+            printf 'agent=%s\n' "$agent"
+            printf 'dataset_path=%s\n' "$dataset_path"
+            printf 'run_id=%s\n' "$RUN_ID"
+            printf 'output_path=%s/runs/%s\n' "$GITHUB_WORKSPACE" "$RUN_ID"
+          } >> "$GITHUB_OUTPUT"
+          printf 'Selected %s tasks from %s: %s\n' "$task_count" "$benchmark" "$tasks"
+
+      - name: Run Harbor benchmark
+        env:
+          BASE_URL_RAW: ${{ vars.LLM_REVIEW_BASE_URL }}
+          API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_REVIEW_API_KEY }}
+          HARBOR_ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_REVIEW_API_KEY }}
+          MODEL: ${{ vars.LLM_REVIEW_MODEL }}
+          OPIK_URL: ${{ vars.OPIK_URL }}
+          OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
+          OPIK_WORKSPACE: ${{ vars.OPIK_WORKSPACE }}
+          AGENT: ${{ steps.params.outputs.agent }}
+          BENCHMARK: ${{ steps.params.outputs.benchmark }}
+          DATASET_PATH: ${{ steps.params.outputs.dataset_path }}
+          INCLUDE_TASKS: ${{ steps.params.outputs.tasks }}
+          HARBOR_INCLUDE_TASKS: ${{ steps.params.outputs.tasks }}
+          OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
+          RUN_ID: ${{ steps.params.outputs.run_id }}
+          ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
+          TOTAL_WORKERS: "10"
+          HARBOR_N_CONCURRENT: "10"
+          HARBOR_ENVIRONMENT_TYPE: docker
+          HARBOR_RUNS: "1"
+          HARBOR_LIMIT: ""
+          HARBOR_MAX_RETRIES: "0"
+          MIN_TEST: "0"
+          HARBOR_ONLINE_ANALYSIS: "0"
+          HARBOR_ZELLIJ_CLOSE_ON_COMPLETE: "1"
+          HARBOR_ZELLIJ_KEEP_ON_FAILURE: "0"
+        run: |
+          set -euo pipefail
+          if [[ -z "$API_KEY" ]]; then
+            echo "::error::LLM_REVIEW_API_KEY is empty" >&2
+            exit 1
+          fi
+          export BASE_URL="${BASE_URL_RAW%/chat/completions}"
+          export OPIK_PROJECT_NAME="$(date -u +'%Y-%m-%d-%H')-harbor-self-hosted-nightly"
+          export HARBOR_OPENSANDBOX_BENCHMARK="$BENCHMARK"
+
+          status=0
+          timeout --signal=TERM --kill-after=5m 450m \
+            script -e -q -c \
+              "$(printf '%q ' scripts/run_fleet.sh --taskset "$BENCHMARK" --agent "$AGENT" --workers "$TOTAL_WORKERS")" \
+              /dev/null || status=$?
+          if (( status == 124 || status == 137 )); then
+            echo "::error::Harbor exceeded its 450-minute budget" >&2
+          fi
+          exit "$status"
+
+      - name: Verify sampled tasks completed
+        env:
+          BENCHMARK: ${{ steps.params.outputs.benchmark }}
+          EXPECTED_TASKS: ${{ steps.params.outputs.task_count }}
+          OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
+        run: |
+          set -euo pipefail
+          if [[ "$BENCHMARK" != "smith" ]]; then
+            python3 .github/scripts/e2e_harbor_gate.py \
+              --output-path "$OUTPUT_PATH" \
+              --harbor-status 0 \
+              --expected-trials "$EXPECTED_TASKS" \
+              --max-harness-failure-ratio 0.10
+            exit 0
+          fi
+
+          shopt -s nullglob
+          done_files=("$OUTPUT_PATH"/queue/*/done.txt)
+          if (( ${#done_files[@]} != 1 )); then
+            echo "::error::expected one Smith completion queue" >&2
+            exit 1
+          fi
+          queue_dir="${done_files[0]%/done.txt}"
+          done_count="$(grep -c . "${done_files[0]}" || true)"
+          failed_count="$(grep -c . "$queue_dir/failed.txt" || true)"
+          exception_count="$(awk -F '\t' '$4 != "" { count++ } END { print count + 0 }' "${done_files[0]}")"
+          accounted=$((done_count + failed_count))
+          errors=$((exception_count + failed_count))
+          if (( accounted != EXPECTED_TASKS )); then
+            echo "::error::Smith accounted for $accounted of $EXPECTED_TASKS sampled tasks" >&2
+            exit 1
+          fi
+          if (( errors * 100 > EXPECTED_TASKS * 10 )); then
+            echo "::error::Smith had $errors harness failures across $EXPECTED_TASKS tasks" >&2
+            exit 1
+          fi
+
+      - name: Clean up
+        if: always()
+        env:
+          ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+          zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Why this change

Add a recurring self-hosted Harbor run that samples a non-Terminal-Bench benchmark. Terminal-Bench remains covered by the existing dedicated nightly.

## Summary of the change

- Add a curated catalog of built-in Harbor aliases and Harbor Hub datasets, explicitly excluding Terminal-Bench.
- Randomly choose one available benchmark and sample exactly 20 unique tasks from its Harbor metadata.
- Run the sample on the bare-metal self-hosted runner, verify the expected tasks completed, and add focused selector/workflow tests.

## Other details

- Schedule: `47 */4 * * *` (UTC).
- Smith is omitted from a run when its configured local dataset is unavailable.
- Local checks: 288 workflow/script tests, Ruff, YAML parsing, built-in selection, and a live Harbor metadata sample.
