### PR TITLE
feat(web-research): add standalone Exa MCP proxy

### DIFF
--- a/Agents/utils/common/mcp/README.md
+++ b/Agents/utils/common/mcp/README.md
@@ -1,0 +1,11 @@
+# Exa Web MCP
+Build the stdio proxy before Agent Fleet starts:
+```bash
+python3 -m zipapp Agents/utils/common/mcp/exa -o /data/exa-web-mcp.pyz
+```
+Configure existing S3/Claude integration; replace `anonymous` with a paid key when needed:
+```bash
+export HARBOR_CC_WEB_MCP_SOURCE=/data/exa-web-mcp.pyz
+export HARBOR_CC_WEB_MCP_MOUNT_PATH=/opt/agent-fleet/exa-web-mcp.pyz
+export EXA_API_KEY=anonymous
+```

--- a/Agents/utils/common/mcp/exa/__main__.py
+++ b/Agents/utils/common/mcp/exa/__main__.py
@@ -1,0 +1,86 @@
+import json
+import os
+import sys
+import urllib.request
+
+from config import ANONYMOUS_KEY, API_KEY_HEADER, MCP_URL
+
+LOCAL_TO_REMOTE = {
+    "web_search": "web_search_exa",
+    "web_fetch": "web_fetch_exa",
+}
+REMOTE_TO_LOCAL = {value: key for key, value in LOCAL_TO_REMOTE.items()}
+SESSION_ID = ""
+
+
+def _decode(body: str, request_id) -> dict:
+    if not body.startswith("event:"):
+        return json.loads(body)
+    for event in body.split("\n\n"):
+        data = [line[5:].lstrip() for line in event.splitlines() if line.startswith("data:")]
+        if data and data != ["[DONE]"]:
+            message = json.loads("\n".join(data))
+            if message.get("id") == request_id:
+                return message
+    raise ValueError("hosted MCP returned no JSON-RPC message")
+
+
+def _request(message: dict) -> dict:
+    global SESSION_ID
+    key = os.environ.get("EXA_API_KEY", ANONYMOUS_KEY).strip()
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+        "User-Agent": "agent-fleet-exa-mcp/1",
+    }
+    headers.update({"Mcp-Session-Id": SESSION_ID} if SESSION_ID else {})
+    if key and key != ANONYMOUS_KEY:
+        headers[API_KEY_HEADER] = key
+    request = urllib.request.Request(
+        MCP_URL,
+        data=json.dumps(message).encode(),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        SESSION_ID = response.headers.get("Mcp-Session-Id", SESSION_ID)
+        return _decode(response.read().decode(), message.get("id")) if "id" in message else {}
+
+
+def _forward(message: dict) -> dict:
+    outgoing = dict(message)
+    if message.get("method") == "tools/call":
+        outgoing["params"] = dict(message.get("params") or {})
+        name = outgoing["params"].get("name")
+        outgoing["params"]["name"] = LOCAL_TO_REMOTE.get(name, name)
+    result = _request(outgoing)
+    if message.get("method") == "tools/list":
+        for tool in result.get("result", {}).get("tools", []):
+            tool["name"] = REMOTE_TO_LOCAL.get(tool.get("name"), tool.get("name"))
+            tool["description"] = tool.get("description", "").replace("_exa", "")
+    return result
+
+
+def main() -> None:
+    for line in sys.stdin:
+        message = {}
+        try:
+            message = json.loads(line)
+            if "id" not in message:
+                _request(message)
+                continue
+            response = _forward(message)
+        except Exception as exc:  # noqa: BLE001 - keep serving after a bad request.
+            if "id" not in message:
+                continue
+            response = {
+                "jsonrpc": "2.0",
+                "id": message.get("id") if isinstance(message, dict) else None,
+                "error": {"code": -32000, "message": str(exc)},
+            }
+        print(json.dumps(response, separators=(",", ":")), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/Agents/utils/common/mcp/exa/config.py
+++ b/Agents/utils/common/mcp/exa/config.py
@@ -1,0 +1,3 @@
+MCP_URL = "https://mcp.exa.ai/mcp"
+API_KEY_HEADER = "x-api-key"
+ANONYMOUS_KEY = "anonymous"


### PR DESCRIPTION
## 1. Why the change?

Claude agent need MCP to search web

## 2. Summary of the change 

Add a stand alone MCP for Claude Agent to use
Reuse Agent Fleet's existing external MCP source code, S3 staging, and Claude stdio interfaces. The zipapp proxy adapts Exa's free hosted MCP tool names and supports an optional paid Exa key without modifying launcher or provider code.

