### PR TITLE
docs: refresh agent guidance for current workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,24 +7,40 @@ live in [Agents/AGENTS.md](Agents/AGENTS.md) and
 ## What This Repo Is
 
 Runnable agent integrations and benchmark assets for agent evaluation:
-Harbor-based benchmark runs (Claude Code, OpenCode), a Dockerized OpenClaw
-gateway fleet, and its benchmarks (PinchBench, ClawBio).
+Harbor-based benchmark runs (Claude Code, OpenCode, Pi), a remote rollout
+service, and a Dockerized OpenClaw gateway fleet with PinchBench and ClawBio.
+Shared launchers support direct arguments, FleetSpec JSON, and prompt mode.
 
 ## Map
 
 | Directory | Owns | Agent guidance |
 | --- | --- | --- |
+| `scripts/` | Host setup, fleet launch/FleetSpec, DinD, shared configuration | `scripts/README.md` |
 | `Agents/utils/common/Harbor/` | Shared Harbor benchmark runner | `Agents/AGENTS.md` |
-| `Agents/Harbor-claude-code/`, `Agents/Harbor-opencode/` | Agent-specific Harbor integration | per-directory `STRUCT.md` |
+| `Agents/utils/rl/` | Remote rollout listener, queue, and workers | `Agents/AGENTS.md` |
+| `Agents/Harbor-claude-code/`, `Agents/Harbor-opencode/`, `Agents/Harbor-pi/` | Agent-specific Harbor integration | per-directory `STRUCT.md` |
 | `Agents/Openclaw/` | Dockerized OpenClaw gateway fleet | `Agents/AGENTS.md` |
-| `Tasks/` | Harbor task lists; PinchBench and ClawBio runners | `Tasks/AGENTS.md` |
+| `Tasks/` | Harbor task inputs/adapters; PinchBench and ClawBio runners | `Tasks/AGENTS.md` |
+| `skills/` | Repository operation skills and end-to-end prompts | `skills/README.md` |
+| `.github/` | CI workflows, review automation, and validation helpers | `.github/workflows/`, `.github/scripts/tests/` |
 | `third_party/agent-opik-plugin/` | Opik tracing plugin (git submodule) | — |
 
 ## First-Time Setup
 
 ```bash
 git submodule update --init --recursive   # required for Opik-enabled runs
-cp config.env config.local.env            # put real values in the local copy
+./scripts/setup.sh                       # gather config and prepare host tools/runner
+```
+
+Setup saves private values in ignored `config.local.env`. To configure
+manually, copy `config.env` only if the local file does not already exist.
+Prerequisites, managed paths, and DinD setup: [scripts/README.md](scripts/README.md).
+
+Preview a launch with `--dry-run`; use `MIN_TEST=1` for an initial canary:
+
+```bash
+./scripts/run_fleet.sh --taskset terminalbench21 --agent claude-code --workers 1 --dry-run
+MIN_TEST=1 ./scripts/run_fleet.sh --taskset terminalbench21 --agent claude-code --workers 1
 ```
 
 ## Configuration Rules
@@ -32,11 +48,18 @@ cp config.env config.local.env            # put real values in the local copy
 - `config.env` is the committed, public-safe template. `config.local.env`
   (git-ignored) is sourced after it and overrides it. Runtime environment
   variables override both.
+- Reuse `scripts/config_loader.sh` for shell entry points. Preserve explicit
+  empty caller values as well as nonempty overrides.
+- `OPIK_URL` is the only tracing switch: an endpoint enables upload; empty
+  disables it. `OPIK_API_KEY` is optional for authless endpoints.
+  Do not reintroduce `TRACE_TO_OPIK`, `OPIK_PLUGIN`, or `OPIK_MODE` gates.
 - OpenClaw-family runners (fleet setup, PinchBench, ClawBio) also read
   `Agents/Openclaw/config/fleet.env` for fleet-wide values such as `COUNT`.
 - Secrets (`API_KEY`, `OPIK_API_KEY`, gateway tokens) go only in
   `config.local.env` or the shell environment — never in committed files.
   Use obviously fake placeholders in docs and tests.
+  Provider credential files such as `.s3-profiles/` also remain git-ignored;
+  see the backend runbooks before changing their handling.
 
 ## Hard Rules
 
@@ -46,9 +69,32 @@ cp config.env config.local.env            # put real values in the local copy
   - `Agents/Openclaw/.env` (generated gateway tokens)
   - `$CONFIG_BASE/<N>/openclaw.json` (default `~/openclaw-instances/<N>/`)
 - Every shell script uses `set -euo pipefail`; keep that in new scripts.
-- Tests live next to each subsystem (`Agents/Openclaw/tests/`,
-  `Tasks/Pinchbench/tests/`, `Tasks/clawBio/tests/`). Run the affected suite
-  before committing — commands are in the nested AGENTS.md files.
+- Shell entry points own environment and process orchestration. Put structured
+  parsing, file mutation, and delegated data workflows in focused Python
+  helpers, following the boundaries in `STRUCT.md`.
+- Shared benchmark settings use `HARBOR_*`; rollout-specific settings use
+  `RL_*`. Keep task inputs under `Tasks/` and agent integrations under `Agents/`.
+
+## Development Checks
+
+Run affected suites before committing. From the repo root, repository/setup/CI
+tests are:
+
+```bash
+PYTHONPATH=. python3 -m unittest discover -s tests -v
+PYTHONPATH=. python3 -m unittest discover -s scripts/tests -v
+PYTHONPATH=. python3 -m unittest discover -s .github/scripts/tests -v
+bash scripts/tests/test_prerequisites.sh
+bash scripts/tests/test_dind_cgroup_v2.sh
+bash scripts/tests/test_dind_run.sh
+```
+
+Agent and task suites are listed in the nested AGENTS.md files. The portable
+CI baseline, including Python and test dependencies, is
+[.github/workflows/pr-validation.yml](.github/workflows/pr-validation.yml).
+Validate changed shell files with `bash -n`. For Python changes, run
+`ruff check --config .github/ruff.toml` using the version required by that
+config. Setup installs an advisory Git hook; CI also runs Ruff.
 
 ## Pull Requests
 

--- a/Agents/AGENTS.md
+++ b/Agents/AGENTS.md
@@ -1,7 +1,8 @@
 # AGENTS.md — Agents/
 
-Two runnable subsystems live here: the shared **Harbor benchmark runner**
-(`utils/common/Harbor/`) and the **OpenClaw gateway fleet** (`Openclaw/`).
+Execution code lives here: the shared **Harbor benchmark runner**
+(`utils/common/Harbor/`), **remote rollout service** (`utils/rl/`),
+agent integrations, and the **OpenClaw gateway fleet** (`Openclaw/`).
 Repo-wide setup and config rules: [root AGENTS.md](../AGENTS.md).
 
 ## Harbor Benchmark Runner (`utils/common/Harbor/`)
@@ -9,14 +10,24 @@ Repo-wide setup and config rules: [root AGENTS.md](../AGENTS.md).
 Runs Claude Code, OpenCode, or Pi against Harbor datasets in parallel zellij
 workers.
 
-Prereq: model gateway values set in `config.local.env`. For traced runs only,
-also initialize the submodule and configure Opik values.
+Prereq: run `./scripts/setup.sh` from the repo root and set model gateway
+values in `config.local.env`. `OPIK_URL` enables tracing; initialize the
+submodule for traced runs. Authless Opik endpoints do not require an API key.
+
+Setup owns the pinned host runner environment; workload startup validates it
+and must not install or repair it. Dependency pins live in
+`utils/common/Harbor/runner-requirements.txt`. Keep setup, startup validation,
+and DinD aligned on `HARBOR_RUNNER_PYTHON_VERSION`.
 
 ### Run
 
+Use `./scripts/run_fleet.sh` for the unified launcher (see
+[scripts/README.md](../scripts/README.md)). For direct Harbor runs:
+
 ```bash
 cd Agents/utils/common/Harbor
-vim env.sh                 # set the run parameters below
+export AGENT=claude-code DATASET_NAME=terminalbench21
+export TOTAL_WORKERS=1 HARBOR_N_CONCURRENT=1
 bash start.sh --detach     # detached zellij session (prints session name)
 bash start.sh              # interactive zellij session
 zellij attach <session-name>
@@ -26,8 +37,8 @@ Main `env.sh` parameters:
 
 ```bash
 AGENT="claude-code"        # claude-code, opencode, or pi
-DATASET_NAME="seta"        # seta, smith, terminalbench21, or sweverify
-DATASET_PATH="/workspace/seta-env/Harbor-Dataset"
+DATASET_NAME="seta"        # registry alias, registry ID, or auto for local data
+DATASET_PATH="/workspace/seta-env/Harbor-Dataset"  # local runs only
 TOTAL_WORKERS="80"         # zellij worker panes
 HARBOR_N_CONCURRENT="80"       # Harbor concurrency, normally = TOTAL_WORKERS
 ```
@@ -45,8 +56,46 @@ restarting.
 | Terminal-Bench 2.1 | `terminalbench21` | `/workspace/terminal-bench-2-1/tasks` | 20 |
 | SWE-bench Verified | `sweverify` | `/workspace/swebench-verified` | 20 |
 
-`DATASET_NAME` selects a task list under `Tasks/` (for example
-`Tasks/SETA/harbor_tasks.txt`); `TASK_SOURCE_FILE=<path>` overrides it.
+`seta`, `terminalbench21`, and `sweverify` resolve to registry datasets by
+default; `smith` stays local. Registry IDs such as `tmax/TMax-15K-Harbor`
+also work. Registry runs bypass local task lists. Use `DATASET_NAME=auto`
+with `DATASET_PATH` for local data; `TASK_SOURCE_FILE=<path>` overrides the
+local task list under `Tasks/`. See [Tasks/AGENTS.md](../Tasks/AGENTS.md).
+
+### Sandbox Backends
+
+`RL_ENVIRONMENT_TYPE` selects `docker` (default), `e2b`, `qz`, or
+`opensandbox`; fixed runs derive `HARBOR_ENVIRONMENT_TYPE` from it unless
+explicitly overridden. Read the relevant backend contract before changing
+image preparation, runtime delivery, or provider configuration:
+
+- [E2B](utils/common/Harbor/E2B_README.md)
+- [qz](utils/common/Harbor/QZ_SANDBOX_README.md) and
+  [template management](utils/common/Harbor/QZ_TEMPLATE_MANAGER.md)
+- [OpenSandbox](utils/common/Harbor/OPENSANDBOX_README.md) and
+  [Bundle/image management](utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md)
+
+Reusable Python runtime construction belongs in `python_runtime.py`;
+dataset-specific verifier composition belongs in `verifier_runtime/`.
+
+### Monitor, Analyzer, and Fixer
+
+Fixed benchmark runs start the monitor and Pi-backed analyzer by default.
+`HARBOR_MONITOR_ENABLED=0` disables monitoring;
+`HARBOR_ANALYZER_ENABLED=0` disables only the analyzer. The analyzer uses
+model gateway defaults or `HARBOR_ANALYZER_*` overrides.
+
+Keep observation (`scripts/harbor_monitor/`), decisions/execution
+(`scripts/harbor_controller/`), analysis (`scripts/harbor_analyzer/`), and
+repair (`scripts/harbor_fixer/`) separate. Monitor observations do not
+automatically restart or stop runs. Controller decisions are submitted through
+`scripts/controller.py`; its Fixer workflow plans first, then binds approval
+to the exact plan before execution and smoke verification. Preserve these
+contracts when modifying automation.
+
+Artifacts live under `$OUTPUT_PATH/{monitor,analyzer,fixer}`. Workflow commands
+and artifact contracts: [Harbor README](utils/common/Harbor/README.md) and
+[Analyzer architecture](utils/common/Harbor/ANALYZER_ARCHITECTURE.md).
 
 ### Online Analysis (opt-in)
 
@@ -78,6 +127,21 @@ Full variable table: [utils/common/Harbor/STRUCT.md](utils/common/Harbor/STRUCT.
 Agent integration internals: [Harbor-claude-code/STRUCT.md](Harbor-claude-code/STRUCT.md),
 [Harbor-opencode/STRUCT.md](Harbor-opencode/STRUCT.md),
 [Harbor-pi/STRUCT.md](Harbor-pi/STRUCT.md).
+
+## Remote Rollout (`utils/rl/`)
+
+```bash
+ROLLOUT=1 bash Agents/utils/common/Harbor/start.sh --detach
+```
+
+The shared launcher loads `utils/rl/RL-env.sh` (or `RL_ENV_FILE`) and starts
+the listener instead of a fixed benchmark. `RL_DATASET_ROOTS` maps dataset
+names to local paths; `RL_AGENT` selects the worker agent. The listener serves
+`/health`, `/datasets`, and `/run_trial`, with per-submission queues and zellij
+workers. Keep rollout implementation and `RL_*` defaults in `utils/rl/`.
+Trusted host request configuration must not become caller-controlled through
+`/run_trial` payloads. Full configuration and lifecycle:
+[Harbor rollout docs](utils/common/Harbor/README.md#rl-rollout-mode).
 
 ## OpenClaw Fleet (`Openclaw/`)
 
@@ -131,12 +195,24 @@ Security policy: [Openclaw/SECURITY.md](Openclaw/SECURITY.md).
 
 ## Development
 
-Run from the repo root:
+Run the affected suites from the repo root with Python 3.12 and the test
+dependencies in `utils/common/Harbor/runner-requirements.txt`, as in portable
+CI. Set `PYTHONPATH=.` for repository imports:
 
 ```bash
+export PYTHONPATH=.
+python3 -m unittest discover -s Agents/utils/common/Harbor/tests
+python3 -m unittest discover -s Agents/utils/rl/tests
+python3 -m unittest discover -s Agents/Harbor-claude-code/tests
+python3 -m unittest discover -s Agents/Harbor-opencode/tests
+python3 -m unittest discover -s Agents/Harbor-pi/tests
 python3 -m unittest discover -s Agents/Openclaw/tests
 bash Agents/Openclaw/tests/test_build_openclaw_image.sh
 bash Agents/Openclaw/tests/test_session_layout.sh
 bash Agents/Openclaw/tests/test_start_session_tui.sh
 bash Agents/Openclaw/tests/test_stream_openclaw_session_sh.sh
 ```
+
+Harbor and rollout also have `tests/test_*.sh` regressions; run the scripts
+covering the changed behavior with `bash`. Backend smoke runs need their
+provider infrastructure; unit tests alone do not establish backend health.

--- a/Tasks/AGENTS.md
+++ b/Tasks/AGENTS.md
@@ -1,8 +1,9 @@
 # AGENTS.md — Tasks/
 
-Benchmark task inputs and OpenClaw benchmark runners. Harbor task lists are
-consumed by the shared runner in `Agents/utils/common/Harbor/`; PinchBench
-and ClawBio run against an OpenClaw fleet from `Agents/Openclaw/` (see
+Benchmark task inputs, Harbor task generators, and OpenClaw benchmark runners.
+Harbor task lists are consumed by the shared runner in
+`Agents/utils/common/Harbor/`; PinchBench and ClawBio run against an OpenClaw
+fleet from `Agents/Openclaw/` (see
 [Agents/AGENTS.md](../Agents/AGENTS.md)). Repo-wide config rules:
 [root AGENTS.md](../AGENTS.md).
 
@@ -11,6 +12,8 @@ and ClawBio run against an OpenClaw fleet from `Agents/Openclaw/` (see
 | Path | Role |
 | --- | --- |
 | `SETA/`, `SWE-smith/`, `SWE-verify/`, `Terminal-bench-2/` | Harbor task lists |
+| `SWE-rebench-v2/`, `TMax/` | Harbor registry dataset entrypoints and adaptation docs |
+| `WebResearchAdapter/` | BrowseComp and DeepSearchQA native Harbor task generator |
 | `Pinchbench/` | PinchBench runner for the OpenClaw fleet |
 | `clawBio/` | ClawBio bioinformatics benchmark for the OpenClaw fleet |
 
@@ -28,6 +31,34 @@ The `seta`, `sweverify`, and `terminalbench21` aliases resolve to Harbor
 registry datasets by default and skip these local files. `TASK_SOURCE_FILE=<path>`
 overrides the built-in selection for local runs. Task lists are owned here —
 don't duplicate them under `Agents/`.
+
+Other registry datasets use their full IDs, including
+`openthoughts/tasktrove-swe-rebench-v2-patched-oracle` and
+`tmax/TMax-15K-Harbor`. The unified launcher accepts these via
+`./scripts/run_fleet.sh --taskset <registry-id>`, or an explicit local dataset
+path. See [SWE-rebench-v2/README.md](SWE-rebench-v2/README.md) for qz
+final-image adaptation; task identity, repository, and revision must agree
+before an image can replace the task's setup instructions.
+
+## Web Research Adapter (`WebResearchAdapter/`)
+
+Generates Harbor tasks from official BrowseComp and DeepSearchQA CSV files:
+
+```bash
+cd Tasks/WebResearchAdapter
+uv run browsecomp-adapter --input /data/browse_comp_test_set.csv --output-dir /data/harbor/browsecomp
+uv run deepsearchqa-adapter --input /data/DSQA-full.csv --output-dir /data/harbor/deepsearchqa
+```
+
+Source count and SHA-256 validation happen before task filtering; keep each
+dataset's validation and reward semantics separate. Edit the generator and
+`src/web_research_adapter/task-template/` to change generated tasks.
+
+Register generated roots in `RL_DATASET_ROOTS` for rollout use. Search/fetch
+tools or an external MCP must be provisioned by the deployment. The verifier
+reuses the trial model gateway and returns rewards through the existing
+rollout path; do not configure `RL_RESULT_PROCESSOR`. Configuration and
+generation options: [WebResearchAdapter/README.md](WebResearchAdapter/README.md).
 
 ## PinchBench (`Pinchbench/`)
 
@@ -101,4 +132,9 @@ Run from the repo root:
 ```bash
 python3 -m unittest discover -s Tasks/Pinchbench/tests
 python3 -m unittest discover -s Tasks/clawBio/tests
+uv run --project Tasks/WebResearchAdapter python -m unittest discover -s Tasks/WebResearchAdapter/tests -v
 ```
+
+The web research adapter requires Python 3.11 or newer and its own project
+dependencies. Task-selection changes also affect the shared Harbor suite
+listed in [Agents/AGENTS.md](../Agents/AGENTS.md#development).


### PR DESCRIPTION
## 1. Why the change?

The AGENTS.md files omit several current subsystems and still describe an incomplete setup, dataset-selection, and testing workflow. Coding agents need guidance that matches the repository today.

## 2. Summary of the change

- Refresh the root map, unified setup/launcher instructions, configuration and tracing rules, and CI checks.
- Document Harbor sandbox backends, the rollout service, monitor/analyzer/fixer boundaries, and agent test suites, linking to detailed runbooks.
- Add registry dataset and web-research adapter guidance to Tasks/AGENTS.md, including its test command.

## 3. Other details

Documentation only; updates the root, Agents, and Tasks AGENTS.md files.

Validation:
- All 5 root tests pass (`PYTHONPATH=. python3 -m unittest discover -s tests -v`).
- Validated all 34 local Markdown links and code-fence balance across the three files.
- `git diff --check` passes.
