### PR TITLE
docs: refresh repository skills for current benchmark workflows

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -17,7 +17,7 @@ description: Use when ...
 | --- | --- |
 | `openclaw-fleet-operations` | Generating, scaling, operating, or debugging the Dockerized OpenClaw gateway fleet. |
 | `openclaw-benchmark-runners` | Running PinchBench or ClawBio benchmarks against an OpenClaw gateway fleet. |
-| `harbor-benchmark-runner` | Configuring, launching, monitoring, or debugging Harbor benchmark runs for Claude Code or OpenCode. |
+| `harbor-benchmark-runner` | Configuring, launching, monitoring, or debugging Harbor benchmark runs for Claude Code, OpenCode, or Pi. |
 
 ## Usage Examples
 
@@ -35,8 +35,8 @@ current OpenClaw fleet and summarize pass/fail counts.
 ```
 
 ```text
-Use harbor-benchmark-runner to run 3 SETA Harbor tasks with AGENT=claude-code,
-TOTAL_WORKERS=3, HARBOR_N_CONCURRENT=3, and inspect online-analysis results.
+Use harbor-benchmark-runner to run the terminalbench21 fix-git task with Pi,
+one worker and one attempt, then inspect the run summary and trial results.
 ```
 
 You can also combine skills for end-to-end validation:
@@ -51,6 +51,10 @@ Use openclaw-fleet-operations and openclaw-benchmark-runners to regenerate a
 Run these commands from the repository root. Symlinks keep the installed skills
 updated as the checkout changes; use `cp -a` instead of `ln -sfn` when the
 runtime needs a standalone copy.
+
+`./scripts/setup.sh` already installs all three skills into
+`~/.pi/agent/skills/` as symlinks to this checkout. Use the manual installation
+sections below for other runtimes or a separate installation.
 
 ### Codex
 

--- a/skills/e2e-harbor-benchmark.txt
+++ b/skills/e2e-harbor-benchmark.txt
@@ -11,12 +11,22 @@ Before doing anything:
 Requirements:
 1. Verify the LLM endpoint before benchmark use when BASE_URL,
    API_KEY, and MODEL are available.
-2. Prefer the configured mounted Claude Code tgz/cache over public
+2. For Claude Code runs, prefer the configured mounted tgz/cache over public
    download/install paths. If CLAUDE_CODE_VERSION, CLAUDE_CODE_TGZ_BASENAME, or
    HARBOR_CC_* cache variables are set, use them deliberately.
-3. Run 3 SETA tasks and 3 Terminal-Bench-2 tasks with TOTAL_WORKERS=3 and
-   HARBOR_N_CONCURRENT=3.
+3. Run exactly 3 SETA tasks and 3 Terminal-Bench 2.1 tasks with TOTAL_WORKERS=3,
+   HARBOR_N_CONCURRENT=3, N_ATTEMPTS=1, and HARBOR_RUNS=1. Preserve the requested
+   agent (claude-code, opencode, or pi) and backend. Select three exact task IDs
+   with scripts/run_fleet.sh --task, or bound a registry run with HARBOR_LIMIT=3.
+   Worker count alone does not limit tasks. For local runs, use a three-task
+   selection; HARBOR_LIMIT does not limit the local worker queue.
 4. Use isolated RUN_ID and OUTPUT_PATH values for each dataset.
-5. If a dataset path or task selection is unavailable, prepare dataset from Harbor hub.
-6. Record result directories, task rewards, exceptions, online-analysis output,
-   and whether failures are operator/setup failures or task/verifier outcomes.
+5. The seta and terminalbench21 aliases resolve to Harbor registry datasets
+   through the normal start.sh launcher, including --detach. A supplied local
+   dataset uses DATASET_NAME=auto and DATASET_PATH; validate its selected IDs.
+   Do not silently replace a requested local dataset revision with registry data.
+6. Check the host runner before launching; scripts/setup.sh owns dependency
+   installation. OPIK_URL controls tracing; an explicit empty value disables it.
+7. Record result directories, task rewards, exceptions, monitor/analyzer output,
+   optional online-analysis output, and whether failures are operator/setup
+   failures or task/verifier outcomes.

--- a/skills/e2e-openclaw-benchmark.txt
+++ b/skills/e2e-openclaw-benchmark.txt
@@ -16,8 +16,15 @@ Requirements:
 2. Create or verify an OpenClaw fleet with 10 instances unless config.local.env
    or the caller requests another count.
 3. Use isolated names, prefixes, workspaces, and result directories for the run.
-4. Run 3 PinchBench sanity tasks through the OpenClaw fleet.
-5. Run 3 ClawBio tasks through the OpenClaw fleet.
+4. Select exactly 3 available PinchBench sanity task IDs and run them once
+   against the healthy fleet. Use scripts/run_fleet.sh --taskset pinchbench
+   --task <id1,id2,id3>, or the direct runner's --suite with exact IDs. If fewer
+   than 3 sanity tasks exist, report the available subset; do not broaden to
+   the full suite. Instance count does not limit the number of tasks.
+5. Run exactly 3 ClawBio task IDs once, using the unified launcher with --tasks
+   <id1,id2,id3> and ITERATIONS=1. It prepares the ClawBio fleet and applies its
+   dedicated execution profile. Finish PinchBench first; after ClawBio, stop or
+   regenerate that fleet before using it for another purpose.
 6. Capture exact commands, result paths, success counts, failed tasks, and
    whether failures are operator/setup failures or task/agent outcomes.
 7. Do not run long full benchmarks unless explicitly requested.

--- a/skills/harbor-benchmark-runner/SKILL.md
+++ b/skills/harbor-benchmark-runner/SKILL.md
@@ -1,123 +1,141 @@
 ---
 name: harbor-benchmark-runner
-description: Use when configuring, launching, monitoring, or debugging Harbor benchmark runs for Claude Code or OpenCode in this repository.
+description: Use when configuring, launching, monitoring, or debugging Harbor benchmark runs for Claude Code, OpenCode, or Pi in this repository.
 ---
 
 # Harbor Benchmark Runner
 
 ## Overview
 
-Use this skill for Harbor benchmark runs from `Agents/utils/common/Harbor/`.
-The main path is `Agents/utils/common/Harbor/start.sh` -> `env.sh` ->
-zellij layout -> worker panes -> `run_harbor_worker.sh` -> `harboropik.sh`.
+Use this skill for fixed Harbor benchmark runs. The unified launcher is
+`scripts/run_fleet.sh`; direct runs enter through
+`Agents/utils/common/Harbor/start.sh` and `Agents/utils/common/Harbor/env.sh`.
+Local datasets use worker queues; registry datasets use `run_harbor_registry.sh`
+through the same zellij launcher. Both use `harboropik.sh`.
 
-Keep task ownership in `Tasks/`, agent integration ownership in
-`Agents/Harbor-claude-code/` or `Agents/Harbor-opencode/`, and shared
-orchestration ownership in `Agents/utils/common/Harbor/`.
+Task inputs belong in `Tasks/`, agent integrations in `Agents/Harbor-*/`, and
+shared orchestration in `Agents/utils/common/Harbor/`. For a remote rollout
+request, follow the rollout section of the
+[Harbor README](../../Agents/utils/common/Harbor/README.md#rl-rollout-mode):
+`ROLLOUT=1` starts the service under `Agents/utils/rl/`, not a fixed benchmark.
 
 ## Workflow
 
-1. Read the active run config before changing anything:
-   `Agents/utils/common/Harbor/env.sh`, root `config.env`, optional
-   `config.local.env`, and the relevant task list under `Tasks/`.
-2. Confirm the Opik plugin submodule exists when tracing is enabled:
-   `git submodule update --init --recursive`.
-3. Choose the dataset path deliberately:
-   `DATASET_NAME=seta|smith|terminalbench21|sweverify` maps to the built-in
-   `Tasks/` lists, while `TASK_SOURCE_FILE=<path>` overrides them.
-4. Validate that `DATASET_PATH` contains the selected task IDs before launch.
-   A Harbor error like `No tasks matched ... There are 0 tasks available` is a
-   dataset/task-resolution failure, not an agent or model failure.
-5. Keep `TOTAL_WORKERS` and `HARBOR_N_CONCURRENT` aligned unless there is a
-   specific reason to decouple zellij panes from Harbor concurrency.
-6. Launch from `Agents/utils/common/Harbor/` with `bash start.sh --detach` for
-   detached operation or `bash start.sh` for an interactive zellij session.
-7. For Harbor registry datasets such as `owner/name` or `owner/name@version`,
-   use the non-interactive entrypoint shown by `start.sh`; zellij worker mode
-   requires a materialized task file.
-8. If `HARBOR_ONLINE_ANALYSIS=1`, inspect
-   `<OUTPUT_PATH>/online-analysis/environment-events.jsonl` and
-   `environment-summary.json` before attributing failures to the agent.
+1. Read [Agents/AGENTS.md](../../Agents/AGENTS.md), the active runner defaults,
+   and the requested configuration. Preserve precedence: caller environment
+   (including explicitly empty values), `config.local.env`, then `config.env`.
+   Inspect private configuration without printing credentials.
+2. Check the configured host runner. `scripts/setup.sh` prepares the pinned
+   environment; benchmark startup only validates it. Use explicit setup to
+   address missing tools or dependency mismatches, preserving existing config.
+3. Choose registry or local task resolution:
+   - `seta`, `terminalbench21`, and `sweverify` resolve to registry datasets;
+     full IDs such as `owner/name` or `owner/name@version` also work. They do
+     not require a local `DATASET_PATH` or materialized worker task file.
+   - `smith` stays local. For another local checkout, use an explicit path with
+     `--taskset`, or `DATASET_NAME=auto` plus `DATASET_PATH` directly.
+     `TASK_SOURCE_FILE` overrides the local list. Validate selected task IDs
+     against that dataset before launching.
+4. Preserve the requested agent and backend. The unified launcher accepts
+   `claude-code`, `opencode`, and `pi`; direct Harbor also accepts `oracle`
+   for reference solutions. `RL_ENVIRONMENT_TYPE` selects the backend, and
+   fixed runs derive `HARBOR_ENVIRONMENT_TYPE` unless explicitly overridden.
+   Read the relevant backend runbook below before preparing remote resources.
+5. Bound a smoke run by task selection and attempt count. Worker count controls
+   concurrency, not total tasks. `--task` selects exact names for built-in
+   aliases and local paths; it is unsupported for arbitrary registry IDs and
+   rollout mode. For a registry run, `HARBOR_LIMIT` bounds tasks; local runs
+   require a selected task list. Set `N_ATTEMPTS=1` and `HARBOR_RUNS=1` when
+   only one attempt is intended. Keep worker and concurrency counts aligned.
+6. Launch with `scripts/run_fleet.sh --taskset ... --agent ... --workers ...`
+   or `bash Agents/utils/common/Harbor/start.sh`. Both local and registry runs
+   support `--detach`. Use `--dry-run` on the unified launcher to preview routing;
+   it does not validate provider health or execute the benchmark. FleetSpec,
+   prompt mode, and DinD usage are in [scripts/README.md](../../scripts/README.md).
+7. Record the run receipt and inspect results under `OUTPUT_PATH` (default
+   `<repo>/runs/<RUN_ID>`). Successful fixed sessions close by default and
+   foreground runs print `summary.txt`; detached or interactive failed runs
+   retain the final pane for inspection.
 
-## Configuration Rules
+Example one-task canary from the repository root:
 
-- Put real `API_KEY`, `OPIK_API_KEY`, gateway credentials, and private endpoint
-  overrides only in `config.local.env` or the caller environment.
-- Treat `config.env` as the public-safe template.
-- Do not duplicate Harbor task lists under `Agents/`; built-in task lists live
-  under `Tasks/`.
-- Use `RESET_RUN=1` only when intentionally clearing run state for the selected
-  `RUN_ID` and zellij session.
-- `OUTPUT_PATH` defaults under `OUTPUT_ROOT` and contains console logs, task
-  state, and optional online-analysis artifacts.
+```bash
+N_ATTEMPTS=1 HARBOR_RUNS=1 ./scripts/run_fleet.sh \
+  --taskset terminalbench21 --task fix-git --agent pi --workers 1
+```
 
-## E2E Run Notes
+## Configuration and Runtime
 
-- For Claude Code in restricted-network environments, prefer a mounted
-  `claude-code-<version>.tgz` plus npm cache over downloading from the public
-  Claude installer during each task.
-- Harbor mounts the Claude Code tgz and wheel/cache independently of the Opik
-  hook. Point `HARBOR_CC_CLAUDE_TGZ_SOURCE` at the local tgz and
-  `HARBOR_CC_PY_WHEEL_DIR_SOURCE` at the cache directory that contains
-  `npm-cache/`; enable `HARBOR_CC_OPIK_ENABLE_HOOK=1` only for traced runs.
-- After a mounted-tgz run starts, confirm task `config.json`, `lock.json`, or
-  `trial.log` includes `/opt/tb-opik/claude-code.tgz` and
-  `/opt/tb-opik/python-wheels/npm-cache`. If the task still attempts
-  `downloads.claude.ai`, report that as an install-rewrite/setup issue rather
-  than an agent failure.
-- Known working local dataset paths from E2E verification:
-  - SETA numeric tasks: `/workspace/seta-env-camel/Harbor-Dataset`
-  - TerminalBench21 verified tasks: `/workspace/terminal-bench-2-verified`
-- SWE-smith and SWE-verify need extra dataset validation before judging agent
-  quality. Ensure the dataset is materialized and that the selected task names
-  appear in Harbor's available task list; otherwise failures before agent setup
-  are operator/setup failures.
+- `OPIK_URL` is the only tracing switch; empty disables upload, including when
+  overriding a saved endpoint. `OPIK_API_KEY` is optional for authless Opik.
+  Initialize `third_party/agent-opik-plugin` for traced runs with
+  `git submodule update --init --recursive`. The Claude hook default follows
+  the URL; it is not a separate tracing opt-in.
+- `config.env` is public-safe. Real credentials and private endpoints belong in
+  `config.local.env`, the caller environment, or the backend's ignored credential
+  files. Do not include them in commands reported back to the user.
+- Host dependency pins live in `runner-requirements.txt`. For task-container
+  caches, inspect `prepare_local_deps.py`, `LOCAL_WHEEL_DIR`, and
+  `HARBOR_REMOTE_WHEEL_SERVER_URLS`. For mounted Claude packages, inspect
+  `HARBOR_CC_CLAUDE_TGZ_SOURCE`, `HARBOR_CC_PY_WHEEL_DIR_SOURCE`, and the
+  configured mount paths. Check trial logs before diagnosing an installer fault.
+- Pi uses a prepared runtime archive. `PI_THINKING_LEVEL` configures reasoning;
+  local TypeScript extensions use `PI_EXTENSION_SOURCE` and require Docker or
+  OpenSandbox. See [Harbor Pi](../../Agents/Harbor-pi/README.md).
+- `HARBOR_TEMPERATURE` and `HARBOR_TOP_P` require OpenCode;
+  `HARBOR_MAX_TOKENS` also applies to Claude Code and Pi. Rollout sampling has
+  its own `RL_*` settings.
+- Use a fresh `RUN_ID` for an independent run. `RESET_RUN=1` clears existing
+  run state and is refused while an active Fixer workflow prevents reset.
 
-## Debugging
+Backend-specific setup and limitations:
 
-- Validate `AGENT` first: only `claude-code` and `opencode` are supported.
-- For task selection issues, read `Agents/utils/common/Harbor/STRUCT.md` and
-  compare `DATASET_NAME`, `DATASET_PATH`, and `TASK_SOURCE_FILE`.
-- For worker failures, inspect the worker console log and the corresponding
-  Harbor job log before changing scripts.
-- For dependency-cache problems, inspect `prepare_local_deps.sh`,
-  `prepare_local_deps.py`,
-  `LOCAL_WHEEL_DIR`, `LOCAL_WHEEL_PORT`, and
-  `HARBOR_REMOTE_WHEEL_SERVER_URLS`.
-- For mounted Claude Code tgz problems, inspect `HARBOR_CC_CLAUDE_TGZ_SOURCE`,
-  `HARBOR_CC_PY_WHEEL_DIR_SOURCE`, `HARBOR_CC_CLAUDE_TGZ_MOUNT_PATH`, and
-  `HARBOR_CC_NPM_CACHE_MOUNT_PATH`, then grep task logs for public installer URLs.
-- For tracing problems, verify `third_party/agent-opik-plugin` and the agent
-  integration file listed in `Agents/utils/common/Harbor/STRUCT.md`.
+- [E2B](../../Agents/utils/common/Harbor/E2B_README.md)
+- [qz](../../Agents/utils/common/Harbor/QZ_SANDBOX_README.md)
+- [OpenSandbox](../../Agents/utils/common/Harbor/OPENSANDBOX_README.md) and
+  [Bundle/image preparation](../../Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md)
+
+## Monitoring and Debugging
+
+- Monitor and Pi-backed analyzer start by default for fixed runs. The analyzer
+  uses the model gateway or `HARBOR_ANALYZER_*` overrides; set
+  `HARBOR_ANALYZER_ENABLED=0` when analysis is not wanted. Inspect `summary.txt`,
+  `monitor/monitor-latest.json`, `monitor/user-notify-latest.json`, and
+  `analyzer/` alongside worker/trial logs. `HARBOR_MONITOR_ENABLED=0` disables
+  the monitor and its dependent analyzer.
+- Monitor observations do not automatically stop or restart runs. Use the
+  run-local `scripts/controller.py` decision workflow when requested. Fixer
+  planning precedes approval of the exact plan, execution, and smoke verification;
+  analyzer findings alone do not authorize repairs. Commands and artifact
+  contracts are in the [Harbor README](../../Agents/utils/common/Harbor/README.md).
+- `HARBOR_ONLINE_ANALYSIS=1` enables separate console diagnostics under
+  `online-analysis/`; these are distinct from the Pi-backed analyzer.
+- Treat missing tasks, image preparation, runner validation, and dependency
+  delivery failures as setup failures. Inspect the worker console and Harbor
+  job/trial logs before attributing a failure to the model or verifier.
 
 ## Output Contract
 
-When reporting a Harbor run or fix, include:
-
-- selected `AGENT`, `DATASET_NAME`, `DATASET_PATH` or `TASK_SOURCE_FILE`
-- `RUN_ID`, `OUTPUT_PATH`, `TOTAL_WORKERS`, and `HARBOR_N_CONCURRENT`
-- exact launch command and whether it was detached
-- strongest failure signal or current run state
-- whether Claude Code was installed from mounted tgz/cache or from network
-- files changed, if any
-- validation command, usually an affected Harbor/OpenClaw test or a dry run of
-  the edited script path
+Report the selected agent, backend, dataset ID or local path, exact task
+selection and attempts, worker count, sanitized launch command, detached state,
+`RUN_ID`, and `OUTPUT_PATH`. Include completion status, rewards, result paths,
+and the strongest failure evidence. Describe cache/runtime delivery when relevant
+to a failure, and list any files changed and checks run. A successful launcher
+or dry run is not evidence that benchmark tasks passed.
 
 ## Validation
 
-Run only the affected checks unless the change spans subsystems:
+For edits, run affected suites with the Python/dependencies used by portable
+CI, from the repository root:
 
 ```bash
-python3 -m unittest discover -s Agents/utils/common/Harbor/tests
-bash -n Agents/utils/common/Harbor/env.sh \
-  Agents/utils/common/Harbor/start.sh \
-  Agents/utils/common/Harbor/run_harbor_worker.sh \
-  Agents/utils/common/Harbor/harboropik.sh \
-  Agents/utils/common/Harbor/prepare_local_deps.sh
+PYTHONPATH=. python3 -m unittest discover -s Agents/utils/common/Harbor/tests
 ```
 
-For Claude Code integration changes, also run:
-
-```bash
-python3 -m py_compile Agents/Harbor-claude-code/sitecustomize.py
-```
+Also run the corresponding `Agents/Harbor-claude-code/tests`,
+`Agents/Harbor-opencode/tests`, or `Agents/Harbor-pi/tests` suite for integration
+changes, `scripts/tests` for launcher changes, and `Agents/utils/rl/tests` for
+rollout changes. Run relevant shell regressions listed in
+[Agents/AGENTS.md](../../Agents/AGENTS.md#development). Check each changed shell
+file individually with `bash -n "$script"`; one `bash -n` invocation with several
+filenames only parses the first file.

--- a/skills/openclaw-benchmark-runners/SKILL.md
+++ b/skills/openclaw-benchmark-runners/SKILL.md
@@ -17,16 +17,24 @@ starts the fleet, and then runs skill tasks in parallel.
 
 ## Workflow
 
-1. Confirm the OpenClaw fleet exists and is healthy:
-   `./Agents/Openclaw/scripts/openclaw-fleet.sh status all`.
-2. Match benchmark instance count to fleet count unless intentionally running a
-   subset.
-3. Keep shared model gateway values in root `config.env`, private values in
-   `config.local.env`, and benchmark-specific defaults in the benchmark config.
-4. Run PinchBench with
-   `Tasks/Pinchbench/scripts/run-parallel-workers.py`.
-5. Run ClawBio with
-   `Tasks/clawBio/scripts/run-openclaw-clawbio.sh` for the normal unified flow.
+1. Read [Tasks/AGENTS.md](../../Tasks/AGENTS.md). For PinchBench, confirm the
+   existing fleet is healthy with `openclaw-fleet.sh status all` and `probe all`.
+   ClawBio's unified launcher prepares and starts its own benchmark fleet;
+   account for the existing fleet before regenerating its Compose configuration.
+2. Match PinchBench instances to available gateways, or choose an explicit
+   subset. For ClawBio, `COUNT` controls fleet generation. Instance count is
+   concurrency, not a task limit: select tasks explicitly for smoke runs.
+3. Keep `config.env` public-safe, private model gateway values in
+   `config.local.env` or the caller environment, and benchmark defaults in
+   their config files. `OPIK_URL` alone enables tracing; empty disables it.
+4. Use `scripts/run_fleet.sh --taskset <benchmark> --agent openclaw
+   --workers <count> --task <id1,id2>`, with `pinchbench` or `clawbio` as the
+   benchmark, for exact task selection. The direct runners are below.
+   `--dry-run` previews routing. `--detach` is ignored for OpenClaw tasksets;
+   both runners remain in the foreground.
+5. PinchBench calls `Tasks/Pinchbench/scripts/run-parallel-workers.py` against
+   existing gateways. ClawBio calls
+   `Tasks/clawBio/scripts/run-openclaw-clawbio.sh` for setup and execution.
 6. Inspect benchmark result summaries before rerunning. Repeated runs can spend
    substantial tokens and compute.
 
@@ -73,26 +81,25 @@ COUNT=20 ITERATIONS=3 \
   ./Tasks/clawBio/scripts/run-openclaw-clawbio.sh
 ```
 
-Manual flow, when debugging phases:
-
-```bash
-./Tasks/clawBio/scripts/prewarm-cache.sh
-set -a
-. ./Tasks/clawBio/config/benchmark.env
-set +a
-PLUGIN_CACHE_DIR=$(pwd)/Tasks/clawBio/cache \
-  ./Agents/Openclaw/scripts/setup.sh 4
-./Tasks/clawBio/scripts/patch-plugin-config.sh
-docker compose -f Agents/Openclaw/docker-compose.yml up -d
-./Tasks/clawBio/scripts/run-benchmark.py --instances 4
-```
+For a subset, pass `--tasks id1,id2` to the unified launcher. It validates
+exact IDs before changing the fleet. The phase-by-phase flow for debugging
+is in [Tasks/clawBio/README.md](../../Tasks/clawBio/README.md#quick-start);
+preserve `CONFIG_BASE` and `PLUGIN_CACHE_DIR` consistently across those phases.
 
 `patch-plugin-config.sh` must run after `setup.sh` and before Compose starts
 the fleet. Do not run `run-benchmark.py` immediately after the unified
 launcher unless an additional benchmark run is intentional. The profile is
 permissive: the launcher loads it with a warning, and the manual flow sources
-it directly. Use it only for a dedicated ClawBio fleet, then stop or regenerate
+it directly. Conflicting caller overrides are rejected before setup; the
+required values are `SANDBOX_MODE=off`, `EXEC_SECURITY=full`, `EXEC_ASK=off`,
+and `WORKSPACE_ONLY=false`. The root filesystem remains read-only by default.
+Use the profile only for a dedicated ClawBio fleet, then stop or regenerate
 that fleet before using OpenClaw for another purpose.
+
+PinchBench summaries live under
+`Tasks/Pinchbench/.pinchbench-results-docker/<timestamp>/`; ClawBio summaries
+are under `Tasks/clawBio/results/latest/`. Capture the concrete run directory
+as well as any `latest` link. Both provide `iterations-summary.{json,md}`.
 
 ## Debugging
 

--- a/skills/openclaw-fleet-operations/SKILL.md
+++ b/skills/openclaw-fleet-operations/SKILL.md
@@ -16,13 +16,16 @@ per-instance `$CONFIG_BASE/<N>/openclaw.json`, followed by Docker Compose and
 ## Workflow
 
 1. Read `Agents/AGENTS.md`, `Agents/Openclaw/GUIDE.md`, and
-   `Agents/Openclaw/SECURITY.md` before changing fleet behavior.
+   `Agents/Openclaw/SECURITY.md` before changing fleet behavior. For host
+   bootstrap and managed zellij/tool paths, use `scripts/setup.sh` and
+   [scripts/README.md](../../scripts/README.md).
 2. Load configuration in the same precedence as `setup.sh`: CLI flags and
    positional `COUNT`, caller environment, `Agents/Openclaw/config/fleet.env`,
    root `config.local.env`, then root `config.env`.
 3. Build the image when needed:
-   `./Agents/Openclaw/scripts/build-openclaw-image.sh`. Use
-   `OPIK_URL` only when Opik tracing should be built into the image.
+   `./Agents/Openclaw/scripts/build-openclaw-image.sh`. A configured `OPIK_URL`
+   also builds the Opik image; `OPIK_URL=` overrides a saved endpoint to disable
+   tracing. The API key is optional for authless Opik endpoints.
 4. Generate the fleet with `Agents/Openclaw/scripts/setup.sh`. Required model
    gateway values are `BASE_URL` and `API_KEY`; `MODEL` selects the model.
 5. Start with
@@ -32,6 +35,9 @@ per-instance `$CONFIG_BASE/<N>/openclaw.json`, followed by Docker Compose and
    `2-5`.
 7. Use `Agents/Openclaw/scripts/start-session-tui.sh` when the operator needs a
    zellij view of active sessions.
+
+`scale` stops the current Compose fleet, regenerates it, and starts the new
+count. Account for that interruption when operating an active benchmark.
 
 ## Hard Rules
 
@@ -69,7 +75,8 @@ per-instance `$CONFIG_BASE/<N>/openclaw.json`, followed by Docker Compose and
 - If a benchmark cannot access files outside the workspace, rerun setup with
   `WORKSPACE_ONLY=false` only for that benchmark path.
 - If plugin tracing is missing, verify both the image build and setup used
-  `OPIK_URL` plus `OPIK_PROJECT_NAME` were set.
+  `OPIK_URL`, setup has the required `OPIK_PROJECT_NAME`, and the selected
+  image contains the plugin.
 - If generated config paths look wrong, inspect `CONFIG_BASE`,
   `WORKSPACE_BASE`, UID/GID, and host permissions before patching code.
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -5,7 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_SKILLS = {
     "harbor-benchmark-runner": {
-        "description": "Use when configuring, launching, monitoring, or debugging Harbor benchmark runs for Claude Code or OpenCode in this repository.",
+        "description": "Use when configuring, launching, monitoring, or debugging Harbor benchmark runs for Claude Code, OpenCode, or Pi in this repository.",
         "paths": [
             "Agents/utils/common/Harbor/start.sh",
             "Agents/utils/common/Harbor/env.sh",


### PR DESCRIPTION
## 1. Why the change?

Repository skills still exclude Pi, describe registry aliases as local datasets, and incorrectly require a separate entrypoint for registry runs. Smoke-test prompts also leave task limits ambiguous: worker count controls concurrency, not the number of benchmark tasks.

## 2. Summary of the change

- Refresh the Harbor skill for Pi, unified launch/setup, registry and local task selection, sandbox backends, tracing, and monitor/analyzer/fixer workflows.
- Update OpenClaw skills for the unified launcher, explicit task selection, tracing, fleet scaling, and ClawBio lifecycle requirements.
- Make smoke prompts specify task and attempt limits, and refresh the skills README and existing metadata test expectation.

## 3. Other details

This is a separate PR based on upstream main. It includes seven skill/documentation/test files and does not include the AGENTS.md changes from #173. No benchmark implementation changes.

Validation:
- All three skills pass the skill-creator validator.
- All 5 root tests pass, including after moving these changes onto upstream main.
- Validated 13 local Markdown links, code-fence balance, and Bash example syntax across the three skills.
- Ruff 0.16.0 passes for repository-tracked Python files.
- `git diff --check` passes.

A whole-worktree Ruff run also found an import-order issue in an unrelated, untracked qz workflow test; that file is excluded from this PR and was left untouched. No live benchmarks were launched.
