### PR TITLE
fix(opensandbox): detect parenthesized apt commands

### DIFF
--- a/Agents/utils/common/Harbor/opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/opensandbox_image_manager.py
@@ -159,7 +159,7 @@ SHELL_WRAPPED_COMMAND = re.compile(
     r"(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S+|command|exec|sudo|env)\s+)*"
     r"(?:[^\s;&|]+/)?(?:sh|bash)\s+"
     r"-[A-Za-z]*c[A-Za-z]*\s+"
-    r"(?P<command>'[^']*'|\"[^\"]*\")",
+    r"(?P<command>'[^']*'|\"(?:\\.|[^\"\\])*\")",
     re.IGNORECASE | re.DOTALL,
 )
 APT_SOURCE_FILE_REFERENCE = re.compile(
@@ -217,9 +217,9 @@ APT_COMMAND = re.compile(
     r"(?:"
     r"(?:^|[;&|])\s*(?:RUN\s+)?"
     r"(?:(?:--mount=\S+|[A-Za-z_][A-Za-z0-9_]*=\S+|"
-    r"if|then|do|command|exec|sudo|env)\s+)*"
-    r"(?:[^\s;&|]+/)?apt(?:-get)?(?=\s|$)"
-    r'|^\s*RUN\s+\[\s*"(?:[^"]*/)?apt(?:-get)?"\s*[,\]]'
+    r"if|then|do|command|exec|sudo|env)\s+|\((?!\()\s*)*"
+    r"(?P<shell_apt>(?:[^\s;&|]+/)?apt(?:-get)?)(?=\s|$)"
+    r'|^\s*RUN\s+\[\s*"(?P<exec_apt>(?:[^"]*/)?apt(?:-get)?)"\s*[,\]]'
     r")",
     re.IGNORECASE,
 )
@@ -409,10 +409,112 @@ def run_heredoc_specs(
     return specs
 
 
+def shell_offset_is_executable(source: str, offset: int) -> bool:
+    """Return whether an offset is executable shell text, not data or a comment."""
+    quote: str | None = None
+    substitutions: list[tuple[str, str | None, int]] = []
+    comment = False
+    at_word_start = True
+    index = 0
+    while index < offset:
+        character = source[index]
+        if comment:
+            if character == "\n":
+                comment = False
+                at_word_start = True
+            index += 1
+            continue
+        if quote == "'":
+            if character == "'":
+                quote = None
+            index += 1
+            continue
+        if quote == '"':
+            if source.startswith("$(", index):
+                substitutions.append(("paren", quote, 1))
+                quote = None
+                at_word_start = True
+                index += 2
+                continue
+            if character == "`":
+                substitutions.append(("backtick", quote, 0))
+                quote = None
+                at_word_start = True
+                index += 1
+                continue
+            if character == "\\" and index + 1 < offset:
+                index += 2
+                continue
+            if character == '"':
+                quote = None
+            index += 1
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            at_word_start = False
+            index += 1
+            continue
+        if source.startswith("$(", index):
+            substitutions.append(("paren", quote, 1))
+            at_word_start = True
+            index += 2
+            continue
+        if character == "\\":
+            if index + 1 >= offset:
+                return False
+            at_word_start = False
+            index += 2
+            continue
+        if character == "`":
+            if substitutions and substitutions[-1][0] == "backtick":
+                _kind, resume_quote, _depth = substitutions.pop()
+                quote = resume_quote
+                at_word_start = False
+            else:
+                substitutions.append(("backtick", quote, 0))
+                at_word_start = True
+            index += 1
+            continue
+        if character == "#" and at_word_start:
+            comment = True
+            index += 1
+            continue
+        if substitutions and substitutions[-1][0] == "paren" and character == "(":
+            kind, resume_quote, depth = substitutions[-1]
+            substitutions[-1] = (kind, resume_quote, depth + 1)
+            at_word_start = True
+            index += 1
+            continue
+        if substitutions and substitutions[-1][0] == "paren" and character == ")":
+            kind, resume_quote, depth = substitutions[-1]
+            if depth == 1:
+                substitutions.pop()
+                quote = resume_quote
+                at_word_start = False
+            else:
+                substitutions[-1] = (kind, resume_quote, depth - 1)
+                at_word_start = True
+            index += 1
+            continue
+        at_word_start = character.isspace() or character in ";&|()<>"
+        index += 1
+    return not comment and quote is None
+
+
+def apt_command_search(source: str) -> bool:
+    """Return whether source contains an unquoted shell or exec-form APT call."""
+    for match in APT_COMMAND.finditer(source):
+        if match.group("exec_apt") is not None:
+            return True
+        if shell_offset_is_executable(source, match.start("shell_apt")):
+            return True
+    return False
+
+
 def run_invokes_apt(source: str) -> bool:
     """Recognize direct and statically visible shell-wrapped APT commands."""
     source = re.sub(r"\\\r?\n", " ", source)
-    if APT_COMMAND.search(source):
+    if apt_command_search(source):
         return True
 
     exec_form = RUN_EXEC_FORM.match(source)
@@ -433,10 +535,11 @@ def run_invokes_apt(source: str) -> bool:
                     and "c" in argument[1:]
                     and index + 1 < len(argv)
                 ):
-                    return APT_COMMAND.search(argv[index + 1]) is not None
+                    return apt_command_search(argv[index + 1])
 
     return any(
-        APT_COMMAND.search(match.group("command")[1:-1]) is not None
+        shell_offset_is_executable(source, match.start())
+        and apt_command_search(match.group("command")[1:-1])
         for match in SHELL_WRAPPED_COMMAND.finditer(source)
     )
 

--- a/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
@@ -783,6 +783,95 @@ networks:
             rendered.index(injected[1][0]), rendered.index("apt-get update")
         )
 
+    def test_render_detects_parenthesized_apt_run(self) -> None:
+        task_run = "RUN ( apt-get update -qq ) || true"
+        rendered = render_build_dockerfile(
+            f"FROM ubuntu:24.04\n{task_run}\n",
+            dockerhub_mirror_prefix="registry.internal/public-mirror",
+            apt_mirror="http://apt-mirror.internal/repos",
+        )
+
+        injected = injected_shell_runs(rendered)
+        self.assertEqual(len(injected), 2)
+        task_run_offset = rendered.index(task_run)
+        self.assertLess(rendered.index(injected[0][0]), task_run_offset)
+        self.assertGreater(rendered.index(injected[1][0]), task_run_offset)
+
+    def test_render_detects_parenthesized_apt_after_control_keywords(self) -> None:
+        for task_run in (
+            "RUN if test -f /marker; then ( apt-get update ); fi",
+            "RUN while test -f /marker; do ( apt-get update ); done",
+        ):
+            with self.subTest(task_run=task_run):
+                rendered = render_build_dockerfile(
+                    f"FROM ubuntu:24.04\n{task_run}\n",
+                    dockerhub_mirror_prefix="registry.internal/public-mirror",
+                    apt_mirror="http://apt-mirror.internal/repos",
+                )
+
+                injected = injected_shell_runs(rendered)
+                self.assertEqual(len(injected), 2)
+                task_run_offset = rendered.index(task_run)
+                self.assertLess(rendered.index(injected[0][0]), task_run_offset)
+                self.assertGreater(
+                    rendered.index(injected[1][0]), task_run_offset
+                )
+
+    def test_render_ignores_bash_arithmetic_containing_apt_text(self) -> None:
+        rendered = render_build_dockerfile(
+            (
+                "FROM ubuntu:24.04\n"
+                'SHELL ["/bin/bash", "-c"]\n'
+                "RUN (( apt-get ))\n"
+            ),
+            dockerhub_mirror_prefix="registry.internal/public-mirror",
+            apt_mirror="http://apt-mirror.internal/repos",
+        )
+
+        self.assertEqual(injected_shell_runs(rendered), [])
+
+    def test_render_ignores_parenthesized_apt_text_inside_quotes(self) -> None:
+        for task_run in (
+            "RUN printf '%s\\n' '; ( apt-get update' > /tmp/example",
+            "RUN EXAMPLE='( apt-get update' printf ok",
+        ):
+            with self.subTest(task_run=task_run):
+                rendered = render_build_dockerfile(
+                    f"FROM ubuntu:24.04\n{task_run}\n",
+                    dockerhub_mirror_prefix="registry.internal/public-mirror",
+                    apt_mirror="http://apt-mirror.internal/repos",
+                )
+
+                self.assertEqual(injected_shell_runs(rendered), [])
+
+    def test_render_ignores_parenthesized_apt_text_inside_comments(self) -> None:
+        for task_run in (
+            "RUN echo ok; # disabled: ( apt-get update )",
+            "RUN echo ok # disabled; ( apt-get update )",
+        ):
+            with self.subTest(task_run=task_run):
+                rendered = render_build_dockerfile(
+                    f"FROM ubuntu:24.04\n{task_run}\n",
+                    dockerhub_mirror_prefix="registry.internal/public-mirror",
+                    apt_mirror="http://apt-mirror.internal/repos",
+                )
+
+                self.assertEqual(injected_shell_runs(rendered), [])
+
+    def test_render_detects_apt_after_escaped_whitespace_before_hash(self) -> None:
+        task_run = r"RUN echo foo\ #literal; apt-get update"
+        rendered = render_build_dockerfile(
+            f"FROM ubuntu:24.04\n{task_run}\n",
+            dockerhub_mirror_prefix="registry.internal/public-mirror",
+            apt_mirror="http://apt-mirror.internal/repos",
+        )
+
+        injected = injected_shell_runs(rendered)
+        self.assertEqual(len(injected), 2)
+        task_run_offset = rendered.index(task_run)
+        self.assertLess(rendered.index(injected[0][0]), task_run_offset)
+        self.assertGreater(rendered.index(injected[1][0]), task_run_offset)
+
     def test_render_detects_exec_form_apt_run(self) -> None:
         rendered = render_build_dockerfile(
             'FROM ubuntu:24.04\nRUN ["apt-get", "update"]\n',
@@ -799,6 +888,7 @@ networks:
     def test_render_detects_shell_wrapped_apt_runs(self) -> None:
         for task_run in (
             "RUN sh -c 'apt-get update'",
+            'RUN sh -c "echo \\"starting\\"; apt-get update"',
             'RUN ["/bin/bash", "-lc", "apt-get update"]',
         ):
             with self.subTest(task_run=task_run):
@@ -813,6 +903,34 @@ networks:
                 task_run_offset = rendered.index(task_run)
                 self.assertLess(rendered.index(injected[0][0]), task_run_offset)
                 self.assertGreater(rendered.index(injected[1][0]), task_run_offset)
+
+    def test_render_detects_apt_inside_quoted_command_substitution(self) -> None:
+        task_run = 'RUN output="$(echo starting; apt-get update)"'
+        rendered = render_build_dockerfile(
+            f"FROM ubuntu:24.04\n{task_run}\n",
+            dockerhub_mirror_prefix="registry.internal/public-mirror",
+            apt_mirror="http://apt-mirror.internal/repos",
+        )
+
+        injected = injected_shell_runs(rendered)
+        self.assertEqual(len(injected), 2)
+        task_run_offset = rendered.index(task_run)
+        self.assertLess(rendered.index(injected[0][0]), task_run_offset)
+        self.assertGreater(rendered.index(injected[1][0]), task_run_offset)
+
+    def test_render_detects_apt_inside_quoted_backtick_substitution(self) -> None:
+        task_run = 'RUN output="`echo starting; apt-get update`"'
+        rendered = render_build_dockerfile(
+            f"FROM ubuntu:24.04\n{task_run}\n",
+            dockerhub_mirror_prefix="registry.internal/public-mirror",
+            apt_mirror="http://apt-mirror.internal/repos",
+        )
+
+        injected = injected_shell_runs(rendered)
+        self.assertEqual(len(injected), 2)
+        task_run_offset = rendered.index(task_run)
+        self.assertLess(rendered.index(injected[0][0]), task_run_offset)
+        self.assertGreater(rendered.index(injected[1][0]), task_run_offset)
 
     def test_render_refreshes_apt_sources_copied_after_stage_setup(self) -> None:
         rendered = render_build_dockerfile(


### PR DESCRIPTION
## 1. Why the change?

Parenthesized APT commands such as `RUN ( apt-get update ... )` were not detected, so OpenSandbox builds skipped APT mirror setup and could time out.

## 2. Summary of the change

- Detect parenthesized APT commands.
- Add a regression test covering setup and cleanup injection.

## 3. Other details

All 74 related unit tests and Ruff checks pass.