### PR TITLE
Display joint summary artifact in Harbor E2E nightly

### DIFF
--- a/.github/scripts/e2e_harbor_summary.py
+++ b/.github/scripts/e2e_harbor_summary.py
@@ -1,0 +1,40 @@
+"""Adapt the generated Fixer artifact link for display in an Actions summary."""
+
+import argparse
+import re
+from pathlib import Path
+
+FIXER_LINK = "[fix-report-latest.md](fixer/fix-report-latest.md)"
+
+
+def render_summary(report: str, artifact_url: str) -> str:
+    location = "`fixer/fix-report-latest.md`"
+    location += (
+        f" ([download run artifacts]({artifact_url}))"
+        if artifact_url else " (artifact upload unavailable)"
+    )
+    lines = []
+    fence = ""
+    for line in report.splitlines(keepends=True):
+        marker = re.match(r" {0,3}(`{3,}|~{3,})(.*)$", line)
+        if marker:
+            if not fence:
+                fence = marker[1]
+            elif marker[1][0] == fence[0] and len(marker[1]) >= len(fence) and not marker[2].strip():
+                fence = ""
+        elif not fence and line.rstrip("\r\n") == f"Full Fixer report: {FIXER_LINK}":
+            line = line.replace(FIXER_LINK, location)
+        lines.append(line)
+    return "".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("summary", type=Path)
+    parser.add_argument("--artifact-url", default="")
+    args = parser.parse_args()
+    print(render_summary(args.summary.read_text(encoding="utf-8"), args.artifact_url), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/fixtures/harbor-joint-summary.md
+++ b/.github/scripts/tests/fixtures/harbor-joint-summary.md
@@ -1,0 +1,77 @@
+# Benchmark Run Summary
+
+Run ID: `fixture-run`
+
+## Summary
+
+The automated narrative summary is unavailable; deterministic results are shown below.
+
+## Harbor
+
+| Metric | Value |
+| --- | --- |
+| status | complete |
+| RUN_ID | fixture-run |
+| AGENT | pi |
+| total | 2 |
+| completed | 2 |
+| mean_reward | 0.5 |
+
+Rewards describe model outcomes; completed trials can have zero reward.
+
+<details>
+<summary>Original Harbor report (summary.txt)</summary>
+
+```text
+status: complete
+RUN_ID: fixture-run
+AGENT: pi
+total: 2
+completed: 2
+mean_reward: 0.5
+```
+
+</details>
+
+### Run Overview
+
+| Metric | Value |
+| --- | ---: |
+| Runtime | 2m 0s |
+| Success rate | 50.00% (1/2) |
+| Failure rate | 50.00% (1/2) |
+
+## Analyzer
+
+### Analyzer Findings
+
+| Finding | Tasks |
+| --- | ---: |
+| Analysis complete | 1 |
+| Environment failure | 0 |
+| Infrastructure failure | 1 |
+| Model failure | 0 |
+| Unknown root cause | 0 |
+| Analysis failed | 0 |
+
+### Analysis Summary
+
+- **Infrastructure failure - `fixture-task`:** A required dependency was unavailable.
+
+### Recommended Actions
+
+No additional action was generated.
+
+## Fixer Results
+
+Smoke verification passed for one sampled task; a full rerun is pending.
+
+### What Fixer Changed
+
+Restored the missing dependency.
+
+### Remaining Issues
+
+Full benchmark verification remains pending.
+
+Full Fixer report: [fix-report-latest.md](fixer/fix-report-latest.md)

--- a/.github/scripts/tests/test_e2e_harbor_summary.py
+++ b/.github/scripts/tests/test_e2e_harbor_summary.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+
+class HarborSummaryDisplayTest(unittest.TestCase):
+    def setUp(self):
+        spec = importlib.util.spec_from_file_location("e2e_harbor_summary", SCRIPTS / "e2e_harbor_summary.py")
+        self.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.module)
+
+    def test_generated_fixer_link_becomes_downloadable_artifact_path(self):
+        report = (SCRIPTS / "tests/fixtures/harbor-joint-summary.md").read_text()
+        link = "[fix-report-latest.md](fixer/fix-report-latest.md)"
+        expected = "`fixer/fix-report-latest.md` ([download run artifacts](https://example.test/artifact))"
+        self.assertEqual(self.module.render_summary(report, "https://example.test/artifact"), report.replace(link, expected))
+
+    def test_missing_upload_has_path_without_download_link(self):
+        report = "Full Fixer report: [fix-report-latest.md](fixer/fix-report-latest.md)\n"
+        rendered = self.module.render_summary(report, "")
+        self.assertEqual(rendered, "Full Fixer report: `fixer/fix-report-latest.md` (artifact upload unavailable)\n")
+
+    def test_preserves_external_links_and_recorded_code_blocks(self):
+        line = "Full Fixer report: [fix-report-latest.md](fixer/fix-report-latest.md)\n"
+        for fence in ("```", "~~~~"):
+            report = fence + "text\n" + line + fence + "\n"
+            self.assertEqual(self.module.render_summary(report, "https://example.test/artifact"), report)
+        external = "Full Fixer report: [fix-report-latest.md](https://example.test/report.md)\n"
+        self.assertEqual(self.module.render_summary(external, "https://example.test/artifact"), external)
+
+    def test_report_without_fixer_is_unchanged(self):
+        report = (SCRIPTS / "tests/fixtures/harbor-joint-summary.md").read_text().split("\n## Fixer Results\n")[0] + "\n"
+        self.assertEqual(self.module.render_summary(report, "https://example.test/artifact"), report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -1,4 +1,8 @@
+import os
 import re
+import subprocess
+import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -153,6 +157,53 @@ class E2eValidationWorkflowTest(unittest.TestCase):
     def test_gates_on_pipeline_health(self):
         self.assertIn("e2e_harbor_gate.py", self.workflow)
         self.assertIn("--max-harness-failure-ratio 0.10", self.workflow)
+
+    def test_summary_runs_after_cleanup_even_when_checkout_fails(self):
+        self.assertIn("- name: Publish run summary\n        if: always()", self.workflow)
+        self.assertLess(self.workflow.index("- name: Clean up"),
+                        self.workflow.index("- name: Publish run summary"))
+        self.assertIn("--step-summary", self.workflow)
+        self.assertIn("steps.artifacts.outputs.artifact-url", self.workflow)
+
+    def test_publishes_redacted_joint_artifact_with_gate_fallback(self):
+        script = textwrap.dedent(self.workflow.split("- name: Publish run summary")[1]
+                                 .split("        run: |\n")[1])
+        joint = "# Harbor Run Summary\n\n## Harbor\n\nResults.\n\n## Analyzer\n\nDiagnosis.\n\n## Fixer\n\nVerification.\n"
+        for staging, report, gate_report in (
+            ("success", joint, "CI PASS"), ("success", joint, "CI FAIL"),
+            ("failure", joint, "CI FAIL"), ("skipped", joint, ""),
+            ("success", "", "CI PASS"), ("skipped", "", ""),
+        ):
+            with self.subTest(staging=staging, report=bool(report)), tempfile.TemporaryDirectory() as tmp:
+                staged = Path(tmp) / "staged"
+                staged.mkdir()
+                (staged / "summary.md").write_text(report)
+                gate = Path(tmp) / "gate.md"
+                gate.write_text(gate_report)
+                destination = Path(tmp) / "summary.md"
+                result = subprocess.run(
+                    ["bash", "-c", script], capture_output=True, text=True, check=False,
+                    cwd=tmp,
+                    env={**os.environ, "HEALTH_SUMMARY": str(gate),
+                         "GITHUB_STEP_SUMMARY": str(destination), "JOB_STATUS": "failure",
+                         "GATE_OUTCOME": "failure" if gate_report else "skipped",
+                         "STAGING_OUTCOME": staging, "STAGED_ARTIFACTS": str(staged),
+                         "ARTIFACT_URL": "https://example.com/artifact", "ARTIFACT_OUTCOME": "success",
+                         "RUN_URL": "https://example.com/run"},
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                rendered = destination.read_text()
+                self.assertIn("[Run logs](https://example.com/run)", rendered)
+                self.assertIn("[Download run artifacts](https://example.com/artifact)", rendered)
+                if staging == "success" and report:
+                    self.assertIn(joint, rendered)
+                else:
+                    self.assertNotIn("Diagnosis.", rendered)
+                    self.assertIn("Joint summary.md unavailable", rendered)
+                if gate_report:
+                    self.assertIn(gate_report, rendered)
+                else:
+                    self.assertIn("Pipeline validation report unavailable", rendered)
 
     def test_redacts_artifacts_before_upload(self):
         self.assertIn("Stage and redact artifacts", self.workflow)

--- a/.github/scripts/tests/test_e2e_validation_workflow.py
+++ b/.github/scripts/tests/test_e2e_validation_workflow.py
@@ -168,37 +168,56 @@ class E2eValidationWorkflowTest(unittest.TestCase):
     def test_publishes_redacted_joint_artifact_with_gate_fallback(self):
         script = textwrap.dedent(self.workflow.split("- name: Publish run summary")[1]
                                  .split("        run: |\n")[1])
-        joint = "# Harbor Run Summary\n\n## Harbor\n\nResults.\n\n## Analyzer\n\nDiagnosis.\n\n## Fixer\n\nVerification.\n"
-        for staging, report, gate_report in (
-            ("success", joint, "CI PASS"), ("success", joint, "CI FAIL"),
-            ("failure", joint, "CI FAIL"), ("skipped", joint, ""),
-            ("success", "", "CI PASS"), ("skipped", "", ""),
+        joint = (ROOT / ".github/scripts/tests/fixtures/harbor-joint-summary.md").read_text()
+        without_fixer = joint.split("\n## Fixer Results\n")[0] + "\n"
+        for staging, report, gate_report, upload in (
+            ("success", joint, "CI PASS", "success"),
+            ("success", without_fixer, "CI FAIL", "success"),
+            ("success", joint, "CI PASS", "failure"),
+            ("failure", joint, "CI FAIL", "skipped"),
+            ("skipped", joint, "", "skipped"),
+            ("success", "", "CI PASS", "success"),
+            ("skipped", "", "", "skipped"),
         ):
-            with self.subTest(staging=staging, report=bool(report)), tempfile.TemporaryDirectory() as tmp:
+            with self.subTest(staging=staging, report=bool(report), upload=upload), tempfile.TemporaryDirectory() as tmp:
                 staged = Path(tmp) / "staged"
                 staged.mkdir()
                 (staged / "summary.md").write_text(report)
                 gate = Path(tmp) / "gate.md"
                 gate.write_text(gate_report)
                 destination = Path(tmp) / "summary.md"
+                artifact_url = "https://example.com/artifact" if upload == "success" else ""
+                gate_outcome = {"CI PASS": "success", "CI FAIL": "failure", "": "skipped"}[gate_report]
                 result = subprocess.run(
                     ["bash", "-c", script], capture_output=True, text=True, check=False,
-                    cwd=tmp,
+                    cwd=ROOT if staging == "success" else tmp,
                     env={**os.environ, "HEALTH_SUMMARY": str(gate),
                          "GITHUB_STEP_SUMMARY": str(destination), "JOB_STATUS": "failure",
-                         "GATE_OUTCOME": "failure" if gate_report else "skipped",
+                         "GATE_OUTCOME": gate_outcome,
                          "STAGING_OUTCOME": staging, "STAGED_ARTIFACTS": str(staged),
-                         "ARTIFACT_URL": "https://example.com/artifact", "ARTIFACT_OUTCOME": "success",
+                         "ARTIFACT_URL": artifact_url, "ARTIFACT_OUTCOME": upload,
                          "RUN_URL": "https://example.com/run"},
                 )
                 self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual((staged / "summary.md").read_text(), report)
                 rendered = destination.read_text()
                 self.assertIn("[Run logs](https://example.com/run)", rendered)
-                self.assertIn("[Download run artifacts](https://example.com/artifact)", rendered)
-                if staging == "success" and report:
-                    self.assertIn(joint, rendered)
+                if upload == "success":
+                    self.assertIn("[Download run artifacts](https://example.com/artifact)", rendered)
                 else:
-                    self.assertNotIn("Diagnosis.", rendered)
+                    self.assertIn(f"Run artifacts: unavailable (upload step: {upload}).", rendered)
+                    self.assertNotIn("[Download run artifacts]", rendered)
+                if staging == "success" and report:
+                    if report == joint:
+                        location = "`fixer/fix-report-latest.md`"
+                        location += (f" ([download run artifacts]({artifact_url}))" if artifact_url
+                                     else " (artifact upload unavailable)")
+                        self.assertIn(joint.replace("[fix-report-latest.md](fixer/fix-report-latest.md)", location), rendered)
+                    else:
+                        self.assertIn(without_fixer, rendered)
+                        self.assertNotIn("## Fixer Results", rendered)
+                else:
+                    self.assertNotIn("A required dependency was unavailable.", rendered)
                     self.assertIn("Joint summary.md unavailable", rendered)
                 if gate_report:
                     self.assertIn(gate_report, rendered)

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -346,7 +346,8 @@ jobs:
 
             has_joint=0
             if [[ "$STAGING_OUTCOME" == "success" && -s "$STAGED_ARTIFACTS/summary.md" ]]; then
-              cat "$STAGED_ARTIFACTS/summary.md"
+              python3 .github/scripts/e2e_harbor_summary.py "$STAGED_ARTIFACTS/summary.md" \
+                --artifact-url "$ARTIFACT_URL"
               has_joint=1
               printf '\n\n<details>\n<summary>CI pipeline validation: %s</summary>\n\n' "$GATE_OUTCOME"
             else

--- a/.github/workflows/harbor-e2e-validation.yml
+++ b/.github/workflows/harbor-e2e-validation.yml
@@ -227,18 +227,22 @@ jobs:
           printf 'Harbor exit status: %s\n' "$status"
 
       - name: Evaluate pipeline health
+        id: health
         if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
         env:
           HARBOR_STATUS: ${{ steps.harbor.outputs.status }}
+          HEALTH_SUMMARY: ${{ runner.temp }}/harbor-health-${{ github.run_id }}-${{ github.run_attempt }}.md
         run: |
           set -euo pipefail
           python3 .github/scripts/e2e_harbor_gate.py \
+            --step-summary "$HEALTH_SUMMARY" \
             --output-path "${{ steps.params.outputs.output_path }}" \
             --harbor-status "${HARBOR_STATUS:-1}" \
             --expected-trials "${{ steps.params.outputs.expected_trials }}" \
             --max-harness-failure-ratio 0.10
 
       - name: Stage and redact artifacts
+        id: stage
         if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
         env:
           API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
@@ -290,6 +294,7 @@ jobs:
           printf 'staged=%s\n' "$staged" >> "$GITHUB_ENV"
 
       - name: Upload run artifacts
+        id: artifacts
         if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -316,3 +321,43 @@ jobs:
           # its own trial containers; leftovers are an operator concern, not
           # something this job should guess at on a shared host.
           docker ps -a --format '{{.Names}}\t{{.Status}}' 2>/dev/null | head -20 || true
+
+      - name: Publish run summary
+        if: always()
+        env:
+          HEALTH_SUMMARY: ${{ runner.temp }}/harbor-health-${{ github.run_id }}-${{ github.run_attempt }}.md
+          JOB_STATUS: ${{ job.status }}
+          GATE_OUTCOME: ${{ steps.health.outcome }}
+          STAGING_OUTCOME: ${{ steps.stage.outcome }}
+          STAGED_ARTIFACTS: ${{ env.staged }}
+          ARTIFACT_OUTCOME: ${{ steps.artifacts.outcome }}
+          ARTIFACT_URL: ${{ steps.artifacts.outputs.artifact-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf 'Workflow status: **%s**\n\n' "$JOB_STATUS"
+            printf '[Run logs](%s)\n\n' "$RUN_URL"
+            if [[ -n "$ARTIFACT_URL" ]]; then
+              printf '[Download run artifacts](%s) (retained for 14 days)\n\n' "$ARTIFACT_URL"
+            else
+              printf 'Run artifacts: unavailable (upload step: %s).\n\n' "$ARTIFACT_OUTCOME"
+            fi
+
+            has_joint=0
+            if [[ "$STAGING_OUTCOME" == "success" && -s "$STAGED_ARTIFACTS/summary.md" ]]; then
+              cat "$STAGED_ARTIFACTS/summary.md"
+              has_joint=1
+              printf '\n\n<details>\n<summary>CI pipeline validation: %s</summary>\n\n' "$GATE_OUTCOME"
+            else
+              printf 'Joint summary.md unavailable; showing pipeline validation below.\n\n'
+            fi
+            if [[ "$GATE_OUTCOME" != "skipped" && -s "$HEALTH_SUMMARY" ]]; then
+              cat "$HEALTH_SUMMARY"
+            else
+              printf 'Pipeline validation report unavailable. Check the failed or cancelled steps in the run logs.\n'
+            fi
+            if (( has_joint )); then
+              printf '\n</details>\n'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 1. Why the change?

[PR #184](https://github.com/sii-system/agent-fleet/pull/184) now produces a joint Harbor, Analyzer, and optional Fixer report at the run artifact root. Display that report in the Harbor E2E nightly's Actions summary so users can review results without downloading the archive first.

## 2. Summary of the change

- Display the successfully staged and redacted `summary.md` after cleanup, with run-log and artifact-download links.
- Adapt the generated Fixer report link for Actions: show `fixer/fix-report-latest.md` as a path inside the downloadable artifact. Show an unavailable note when upload fails. The archived report, recorded code blocks, and external links remain unchanged.
- Keep the existing CI gate report as supplemental validation details. Fall back to it when the joint report is absent or staging fails, and provide a log link when neither report is available.
- Exercise the publishing step with a fixture generated by the merged summary writer, with and without Fixer results, successful and failed uploads, and early failures where checkout is unavailable.

This PR only handles display. Summary generation, Pi invocation, gate pass/fail logic, credential redaction, and 14-day artifact retention stay with their existing owners.

## 3. Other details

Validation:
- 330 CI-helper tests passed with Python 3.12, including direct execution of the workflow publishing step and verification that the staged report is not modified.
- Ruff 0.16.0, diff checks, and Actionlint passed; Actionlint allows the existing custom `bare-metal` runner label.
- Replayed the supplied archived nightly report without Fixer: Harbor and Analyzer content and failed-gate evidence were preserved in the Actions output.

No live nightly was dispatched.
