### PR TITLE
Add joint summaries and artifact downloads to self-hosted nightly

### DIFF
--- a/.github/scripts/e2e_harbor_summary.py
+++ b/.github/scripts/e2e_harbor_summary.py
@@ -1,0 +1,40 @@
+"""Adapt the generated Fixer artifact link for display in an Actions summary."""
+
+import argparse
+import re
+from pathlib import Path
+
+FIXER_LINK = "[fix-report-latest.md](fixer/fix-report-latest.md)"
+
+
+def render_summary(report: str, artifact_url: str) -> str:
+    location = "`fixer/fix-report-latest.md`"
+    location += (
+        f" ([download run artifacts]({artifact_url}))"
+        if artifact_url else " (artifact upload unavailable)"
+    )
+    lines = []
+    fence = ""
+    for line in report.splitlines(keepends=True):
+        marker = re.match(r" {0,3}(`{3,}|~{3,})(.*)$", line)
+        if marker:
+            if not fence:
+                fence = marker[1]
+            elif marker[1][0] == fence[0] and len(marker[1]) >= len(fence) and not marker[2].strip():
+                fence = ""
+        elif not fence and line.rstrip("\r\n") == f"Full Fixer report: {FIXER_LINK}":
+            line = line.replace(FIXER_LINK, location)
+        lines.append(line)
+    return "".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("summary", type=Path)
+    parser.add_argument("--artifact-url", default="")
+    args = parser.parse_args()
+    print(render_summary(args.summary.read_text(encoding="utf-8"), args.artifact_url), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/harbor_nightly_cleanup.py
+++ b/.github/scripts/harbor_nightly_cleanup.py
@@ -1,0 +1,119 @@
+"""Stop this nightly run's detached processes before reading its artifacts."""
+
+import argparse
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+
+def process_state(pid):
+    try:
+        fields = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
+        if fields[0] == "Z":
+            return None
+        return int(fields[1]), int(fields[19])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def run_processes(run_dir, run_id):
+    processes = {}
+    selected = set()
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdecimal():
+            continue
+        pid = int(entry.name)
+        state = process_state(pid)
+        if state is None:
+            continue
+        processes[pid] = state
+        try:
+            environment = dict(
+                item.split(b"=", 1)
+                for item in (entry / "environ").read_bytes().split(b"\0")
+                if b"=" in item
+            )
+        except (OSError, ValueError):
+            continue
+        if environment.get(b"RUN_ID") == run_id.encode() and environment.get(
+            b"OUTPUT_PATH"
+        ) == os.fsencode(run_dir):
+            selected.add(pid)
+        # Pi intentionally drops RUN_ID/OUTPUT_PATH from its minimal environment.
+        pi_home = environment.get(b"PI_CODING_AGENT_DIR")
+        if pi_home:
+            home = Path(os.fsdecode(pi_home)).resolve()
+            if home.is_relative_to(
+                run_dir / "analyzer/.pi-analyzer-home"
+            ) or home.is_relative_to(run_dir / "benchmark-summary/.pi-home"):
+                selected.add(pid)
+    previous = set()
+    while previous != selected:
+        previous = selected.copy()
+        selected.update(
+            pid for pid, (parent, _) in processes.items() if parent in selected
+        )
+    # A cleanup step can inherit the same run environment. Never signal itself
+    # or the Actions runner/step shell that invoked it.
+    ancestor = os.getpid()
+    while ancestor in processes:
+        selected.discard(ancestor)
+        ancestor = processes[ancestor][0]
+    return {pid: processes[pid] for pid in selected}
+
+
+def stop_run(run_dir, run_id, grace_seconds):
+    deadline = time.monotonic() + grace_seconds
+    tracked = {}
+    while True:
+        tracked.update(
+            {
+                pid: state[1]
+                for pid, state in run_processes(run_dir, run_id).items()
+            }
+        )
+        tracked = {
+            pid: start
+            for pid, start in tracked.items()
+            if (state := process_state(pid)) and state[1] == start
+        }
+        if not tracked:
+            return
+        now = time.monotonic()
+        if now > deadline + 5:
+            raise RuntimeError(
+                "Nightly processes did not stop; refusing to stage artifacts"
+            )
+        sig = signal.SIGTERM if now < deadline else signal.SIGKILL
+        for pid, start in tracked.items():
+            if (state := process_state(pid)) and state[1] == start:
+                try:
+                    os.kill(pid, sig)
+                except ProcessLookupError:
+                    pass
+        time.sleep(0.1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True, type=Path)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--grace-seconds", default=10, type=float)
+    args = parser.parse_args()
+    if (
+        not sys.platform.startswith("linux")
+        or not args.run_id
+        or not args.run_dir.is_absolute()
+    ):
+        parser.error("requires Linux, an absolute run directory, and a nonempty run ID")
+    stop_run(
+        args.run_dir,
+        args.run_id,
+        args.grace_seconds,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/redact_harbor_artifacts.py
+++ b/.github/scripts/redact_harbor_artifacts.py
@@ -1,0 +1,95 @@
+"""Redact credentials from a staged nightly artifact tree before uploading it."""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+SECRET_NAME = re.compile(r"(?:key|token|secret|password|credentials?)$", re.IGNORECASE)
+JSON_CONFIGS = (
+    "HARBOR_LLM_KWARGS",
+    "OPENCODE_CONFIG_CONTENT",
+    "OPENCODE_RUNTIME_SECRETS_JSON",
+)
+
+
+def credential_values(environment):
+    values = set()
+
+    def collect(value, sensitive=False):
+        if isinstance(value, dict):
+            for key, child in value.items():
+                collect(
+                    child,
+                    sensitive
+                    or bool(SECRET_NAME.search(key))
+                    or key.lower().endswith("headers"),
+                )
+        elif isinstance(value, list):
+            for child in value:
+                collect(child, sensitive)
+        elif sensitive and isinstance(value, str) and value:
+            values.add(value)
+
+    for name, value in environment.items():
+        if not value:
+            continue
+        if SECRET_NAME.search(name):
+            values.add(value)
+        if name in JSON_CONFIGS:
+            collect(json.loads(value), name == "OPENCODE_RUNTIME_SECRETS_JSON")
+        if name in ("ANTHROPIC_CUSTOM_HEADERS", "HARBOR_ANTHROPIC_CUSTOM_HEADERS"):
+            for line in value.splitlines():
+                _, separator, header = line.partition(":")
+                if separator and header.strip():
+                    values.add(header.strip())
+        if "://" in value and "@" in value:
+            try:
+                password = urlsplit(value).password
+            except ValueError:
+                continue
+            if password:
+                values.add(password)
+    return sorted((value.encode() for value in values), key=len, reverse=True)
+
+
+def redact(directory, values):
+    pattern = (
+        re.compile(b"|".join(re.escape(value) for value in values)) if values else None
+    )
+    files = []
+    for path in directory.rglob("*"):
+        if path.is_symlink():
+            raise ValueError("symlink in staged artifacts")
+        if any(value in os.fsencode(path.relative_to(directory)) for value in values):
+            raise ValueError("credential in artifact filename")
+        if path.is_file():
+            files.append(path)
+            data = path.read_bytes()
+            replaced = pattern.sub(b"***", data) if pattern else data
+            if replaced != data:
+                path.write_bytes(replaced)
+    for path in files:
+        data = path.read_bytes()
+        if any(value in data for value in values):
+            raise ValueError("credential remains in staged artifacts")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path)
+    args = parser.parse_args()
+    try:
+        redact(args.directory, credential_values(os.environ))
+    except (OSError, ValueError):
+        # Parser errors and paths may contain credentials; do not print them.
+        print("::error::Artifact redaction failed; refusing to upload", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/fixtures/harbor-joint-summary.md
+++ b/.github/scripts/tests/fixtures/harbor-joint-summary.md
@@ -1,0 +1,77 @@
+# Benchmark Run Summary
+
+Run ID: `fixture-run`
+
+## Summary
+
+The automated narrative summary is unavailable; deterministic results are shown below.
+
+## Harbor
+
+| Metric | Value |
+| --- | --- |
+| status | complete |
+| RUN_ID | fixture-run |
+| AGENT | pi |
+| total | 2 |
+| completed | 2 |
+| mean_reward | 0.5 |
+
+Rewards describe model outcomes; completed trials can have zero reward.
+
+<details>
+<summary>Original Harbor report (summary.txt)</summary>
+
+```text
+status: complete
+RUN_ID: fixture-run
+AGENT: pi
+total: 2
+completed: 2
+mean_reward: 0.5
+```
+
+</details>
+
+### Run Overview
+
+| Metric | Value |
+| --- | ---: |
+| Runtime | 2m 0s |
+| Success rate | 50.00% (1/2) |
+| Failure rate | 50.00% (1/2) |
+
+## Analyzer
+
+### Analyzer Findings
+
+| Finding | Tasks |
+| --- | ---: |
+| Analysis complete | 1 |
+| Environment failure | 0 |
+| Infrastructure failure | 1 |
+| Model failure | 0 |
+| Unknown root cause | 0 |
+| Analysis failed | 0 |
+
+### Analysis Summary
+
+- **Infrastructure failure - `fixture-task`:** A required dependency was unavailable.
+
+### Recommended Actions
+
+No additional action was generated.
+
+## Fixer Results
+
+Smoke verification passed for one sampled task; a full rerun is pending.
+
+### What Fixer Changed
+
+Restored the missing dependency.
+
+### Remaining Issues
+
+Full benchmark verification remains pending.
+
+Full Fixer report: [fix-report-latest.md](fixer/fix-report-latest.md)

--- a/.github/scripts/tests/test_e2e_harbor_summary.py
+++ b/.github/scripts/tests/test_e2e_harbor_summary.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+
+class HarborSummaryDisplayTest(unittest.TestCase):
+    def setUp(self):
+        spec = importlib.util.spec_from_file_location("e2e_harbor_summary", SCRIPTS / "e2e_harbor_summary.py")
+        self.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.module)
+
+    def test_generated_fixer_link_becomes_downloadable_artifact_path(self):
+        report = (SCRIPTS / "tests/fixtures/harbor-joint-summary.md").read_text()
+        link = "[fix-report-latest.md](fixer/fix-report-latest.md)"
+        expected = "`fixer/fix-report-latest.md` ([download run artifacts](https://example.test/artifact))"
+        self.assertEqual(self.module.render_summary(report, "https://example.test/artifact"), report.replace(link, expected))
+
+    def test_missing_upload_has_path_without_download_link(self):
+        report = "Full Fixer report: [fix-report-latest.md](fixer/fix-report-latest.md)\n"
+        rendered = self.module.render_summary(report, "")
+        self.assertEqual(rendered, "Full Fixer report: `fixer/fix-report-latest.md` (artifact upload unavailable)\n")
+
+    def test_preserves_external_links_and_recorded_code_blocks(self):
+        line = "Full Fixer report: [fix-report-latest.md](fixer/fix-report-latest.md)\n"
+        for fence in ("```", "~~~~"):
+            report = fence + "text\n" + line + fence + "\n"
+            self.assertEqual(self.module.render_summary(report, "https://example.test/artifact"), report)
+        external = "Full Fixer report: [fix-report-latest.md](https://example.test/report.md)\n"
+        self.assertEqual(self.module.render_summary(external, "https://example.test/artifact"), external)
+
+    def test_report_without_fixer_is_unchanged(self):
+        report = (SCRIPTS / "tests/fixtures/harbor-joint-summary.md").read_text().split("\n## Fixer Results\n")[0] + "\n"
+        self.assertEqual(self.module.render_summary(report, "https://example.test/artifact"), report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_harbor_nightly_cleanup.py
+++ b/.github/scripts/tests/test_harbor_nightly_cleanup.py
@@ -1,0 +1,109 @@
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+CLEANUP = Path(__file__).resolve().parents[1] / "harbor_nightly_cleanup.py"
+
+
+@unittest.skipUnless(sys.platform == "linux", "requires Linux process identities")
+class CleanupTest(unittest.TestCase):
+    def test_stops_run_processes_and_orphan_pi_but_preserves_other_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            processes = []
+            child_record = root / "child.pid"
+            try:
+                for name, env in (
+                    ("monitor", {"RUN_ID": "nightly-test", "OUTPUT_PATH": str(root)}),
+                    ("analyzer", {"RUN_ID": "nightly-test", "OUTPUT_PATH": str(root)}),
+                    (
+                        "pi",
+                        {
+                            "PI_CODING_AGENT_DIR": str(
+                                root / "analyzer/.pi-analyzer-home/task"
+                            )
+                        },
+                    ),
+                    (
+                        "other",
+                        {"RUN_ID": "another-run", "OUTPUT_PATH": str(root / "other")},
+                    ),
+                ):
+                    ready = root / name
+                    code = (
+                        "import signal,time; from pathlib import Path; "
+                        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                        f"Path({str(ready)!r}).touch(); time.sleep(60)"
+                    )
+                    if name == "analyzer":
+                        child_code = (
+                            "import os,signal,time; from pathlib import Path; "
+                            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                            f"Path({str(child_record)!r}).write_text(str(os.getpid())); time.sleep(60)"
+                        )
+                        code = (
+                            "import subprocess; "
+                            f"subprocess.Popen({[sys.executable, '-c', child_code]!r}, env={{}}, start_new_session=True); "
+                        ) + code
+                    processes.append(
+                        subprocess.Popen(
+                            [sys.executable, "-c", code],
+                            env={**os.environ, **env},
+                            start_new_session=True,
+                        )
+                    )
+                deadline = time.monotonic() + 5
+                while not all(
+                    (root / name).exists()
+                    for name in ("monitor", "analyzer", "pi", "other")
+                ):
+                    self.assertLess(time.monotonic(), deadline)
+                    time.sleep(0.02)
+                while not child_record.exists():
+                    self.assertLess(time.monotonic(), deadline)
+                    time.sleep(0.02)
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(CLEANUP),
+                        "--run-dir",
+                        str(root),
+                        "--run-id",
+                        "nightly-test",
+                        "--grace-seconds",
+                        "0.1",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env={**os.environ, "RUN_ID": "nightly-test", "OUTPUT_PATH": str(root)},
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                for process in processes[:3]:
+                    process.wait(timeout=3)
+                self.assertIsNone(processes[3].poll())
+                child_stat = Path(f"/proc/{child_record.read_text()}/stat")
+                if child_stat.exists():
+                    self.assertEqual(
+                        child_stat.read_text().rsplit(")", 1)[1].split()[0], "Z"
+                    )
+            finally:
+                for process in processes:
+                    if process.poll() is None:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    process.wait()
+                if child_record.exists():
+                    try:
+                        os.kill(int(child_record.read_text()), signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_redact_harbor_artifacts.py
+++ b/.github/scripts/tests/test_redact_harbor_artifacts.py
@@ -1,0 +1,63 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "redact_harbor_artifacts",
+    Path(__file__).resolve().parents[1] / "redact_harbor_artifacts.py",
+)
+redactor = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(redactor)
+
+
+class RedactionTest(unittest.TestCase):
+    def test_collects_credentials_without_treating_token_limits_as_secrets(self):
+        values = redactor.credential_values(
+            {
+                "EXA_API_KEY": "fake-exa",
+                "HARBOR_MAX_TOKENS": "8192",
+                "HARBOR_ANALYZER_ENABLED": "1",
+                "API_KEY": "",
+                "HARBOR_LLM_KWARGS": '{"api_key":"fake-llm","max_tokens":8192,"extra_headers":{"x-auth":"fake-header"}}',
+                "OPENCODE_CONFIG_CONTENT": '{"provider":{"custom":{"options":{"apiKey":"fake-opencode"}}}}',
+                "OPENCODE_RUNTIME_SECRETS_JSON": '{"CUSTOM_AUTH":"fake-runtime"}',
+                "HARBOR_ANTHROPIC_CUSTOM_HEADERS": "Authorization: Bearer fake-bearer",
+                "HTTPS_PROXY": "https://user:fake-password@proxy.example.test",
+            }
+        )
+        self.assertEqual(
+            set(values),
+            {
+                b"fake-exa",
+                b"fake-llm",
+                b"fake-header",
+                b"fake-opencode",
+                b"fake-runtime",
+                b"Bearer fake-bearer",
+                b"fake-password",
+            },
+        )
+
+    def test_redacts_overlapping_values_in_binary_and_hidden_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / ".transcript"
+            path.write_bytes(b"\xff fake-long-key fake-long 8192")
+            redactor.redact(root, [b"fake-long-key", b"fake-long"])
+            self.assertEqual(path.read_bytes(), b"\xff *** *** 8192")
+
+    def test_rejects_secret_filenames_and_symlinks(self):
+        for kind in ("filename", "symlink"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                if kind == "filename":
+                    (root / "fake-secret.log").touch()
+                else:
+                    (root / "link").symlink_to(root / "missing")
+                with self.assertRaises(ValueError):
+                    redactor.redact(root, [b"fake-secret"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_self_hosted_nightly_workflow.py
+++ b/.github/scripts/tests/test_self_hosted_nightly_workflow.py
@@ -1,5 +1,8 @@
 import importlib.util
+import os
+import subprocess
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -43,7 +46,9 @@ class SelectorTest(unittest.TestCase):
             root = Path(temp_dir)
             task_list = root / selector.LOCAL_TASK_LISTS["seta"]
             task_list.parent.mkdir(parents=True)
-            task_list.write_text("# comment\ntask-a\ntask-b\ntask-a\n", encoding="utf-8")
+            task_list.write_text(
+                "# comment\ntask-a\ntask-b\ntask-a\n", encoding="utf-8"
+            )
             self.assertEqual(selector.task_names(root, "seta"), ["task-a", "task-b"])
 
     def test_reads_harbor_machine_metadata(self):
@@ -86,7 +91,9 @@ class WorkflowTest(unittest.TestCase):
         self.assertNotIn("pull_request", self.workflow)
 
     def test_catalog_excludes_terminal_bench_and_adds_harbor_hub(self):
-        self.assertFalse(any("terminal-bench" in item.lower() for item in self.benchmarks))
+        self.assertFalse(
+            any("terminal-bench" in item.lower() for item in self.benchmarks)
+        )
         self.assertGreaterEqual(sum("/" in item for item in self.benchmarks), 10)
         self.assertIn("tmax/TMax-15K-Harbor", self.benchmarks)
 
@@ -96,7 +103,9 @@ class WorkflowTest(unittest.TestCase):
         self.assertIn("harbor_nightly_select.py", self.workflow)
 
     def test_passes_the_sample_to_harbor(self):
-        self.assertIn("HARBOR_INCLUDE_TASKS: ${{ steps.params.outputs.tasks }}", self.workflow)
+        self.assertIn(
+            "HARBOR_INCLUDE_TASKS: ${{ steps.params.outputs.tasks }}", self.workflow
+        )
         self.assertIn('scripts/run_fleet.sh --taskset "$BENCHMARK"', self.workflow)
         self.assertIn("Verify sampled tasks completed", self.workflow)
         self.assertIn("--expected-trials", self.workflow)
@@ -113,8 +122,10 @@ class WorkflowTest(unittest.TestCase):
         self.assertIn('MIN_TEST: "0"', self.workflow)
 
     def test_smith_rejects_excess_harness_failures(self):
-        self.assertIn('failed_count="$(grep -c . "$queue_dir/failed.txt"', self.workflow)
-        self.assertIn("$4 != \"\" { count++ }", self.workflow)
+        self.assertIn(
+            'failed_count="$(grep -c . "$queue_dir/failed.txt"', self.workflow
+        )
+        self.assertIn('$4 != "" { count++ }', self.workflow)
         self.assertIn("errors * 100 > EXPECTED_TASKS * 10", self.workflow)
 
     def test_uses_least_privilege_and_pinned_checkout(self):
@@ -126,6 +137,147 @@ class WorkflowTest(unittest.TestCase):
         self.assertIn("zellij kill-session", self.workflow)
         self.assertNotIn("docker system prune", self.workflow)
         self.assertNotIn("docker image prune", self.workflow)
+
+    def step_script(self, name):
+        self.assertIn(f"- name: {name}", self.workflow)
+        step = self.workflow.split(f"- name: {name}\n", 1)[1].split(
+            "\n      - name:", 1
+        )[0]
+        return textwrap.dedent(step.split("        run: |\n", 1)[1])
+
+    def test_health_reports_registry_and_smith_failures(self):
+        script = self.step_script("Verify sampled tasks completed")
+        for benchmark, done, failed, shell_status, expected_status in (
+            ("registry", 20, 0, 0, 0),
+            ("registry", 20, 0, 1, 1),
+            ("smith", 20, 0, 0, 0),
+            ("smith", 17, 3, 0, 1),
+            ("smith", 19, 0, 0, 1),
+            ("smith", 20, 0, 1, 1),
+            ("smith", 0, 0, 0, 1),
+        ):
+            with (
+                self.subTest(
+                    benchmark=benchmark,
+                    done=done,
+                    failed=failed,
+                    shell_status=shell_status,
+                ),
+                tempfile.TemporaryDirectory() as tmp,
+            ):
+                output = Path(tmp) / "run"
+                output.mkdir()
+                (output / "summary.txt").write_text(
+                    "status: complete\nharbor_exit_code: 0\ntotal: 20\ncompleted: 20\nerrored: 0\n"
+                )
+                if done or failed:
+                    queue = output / "queue" / "worker"
+                    queue.mkdir(parents=True)
+                    (queue / "done.txt").write_text("task\t0\tresult\t\n" * done)
+                    (queue / "failed.txt").write_text("task\n" * failed)
+                report = Path(tmp) / "health.md"
+                result = subprocess.run(
+                    ["bash", "-c", script],
+                    cwd=ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env={
+                        **os.environ,
+                        "BENCHMARK": benchmark,
+                        "EXPECTED_TASKS": "20",
+                        "OUTPUT_PATH": str(output),
+                        "HEALTH_SUMMARY": str(report),
+                        "HARBOR_STATUS": str(shell_status),
+                    },
+                )
+                self.assertEqual(result.returncode, expected_status, result.stderr)
+                self.assertTrue(report.exists(), result.stderr)
+                self.assertIn(
+                    "PASS" if expected_status == 0 else "FAIL", report.read_text()
+                )
+
+    def test_stages_redacted_downloads_without_modifying_originals(self):
+        script = self.step_script("Stage and redact artifacts")
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "run"
+            output.mkdir()
+            original = "fake-api-credential fake-opik-credential\n"
+            (output / "summary.txt").write_text(original)
+            env_file = Path(tmp) / "env"
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                env={
+                    **os.environ,
+                    "RUNNER_TEMP": tmp,
+                    "OUTPUT_PATH": str(output),
+                    "GITHUB_ENV": str(env_file),
+                    "API_KEY": "fake-api-credential",
+                    "OPIK_API_KEY": "fake-opik-credential",
+                },
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            staged = Path(env_file.read_text().strip().split("=", 1)[1])
+            self.assertEqual((staged / "summary.txt").read_text(), "*** ***\n")
+            self.assertEqual((output / "summary.txt").read_text(), original)
+        upload = self.workflow.split("- name: Upload run artifacts\n", 1)[1].split(
+            "\n      - name:", 1
+        )[0]
+        self.assertIn("steps.stage.outcome == 'success'", upload)
+        self.assertRegex(upload, r"actions/upload-artifact@[0-9a-f]{40}")
+        self.assertIn("retention-days: 14", upload)
+
+    def test_publishes_joint_summary_and_download_link_after_failures(self):
+        script = self.step_script("Publish run summary")
+        fixture = (ROOT / ".github/scripts/tests/fixtures/harbor-joint-summary.md").read_text()
+        for checkout, staging in ((True, "success"), (True, "failure"), (False, "skipped")):
+            with self.subTest(checkout=checkout, staging=staging), tempfile.TemporaryDirectory() as tmp:
+                report = Path(tmp) / "health.md"
+                report.write_text("## Validation: FAIL\n\nHarness failure.\n")
+                staged = Path(tmp) / "staged"
+                staged.mkdir()
+                (staged / "summary.md").write_text(fixture)
+                summary = Path(tmp) / "summary.md"
+                result = subprocess.run(
+                    ["bash", "-c", script],
+                    cwd=ROOT if checkout else tmp,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env={
+                        **os.environ,
+                        "HEALTH_SUMMARY": str(report),
+                        "JOB_STATUS": "failure",
+                        "GATE_OUTCOME": "failure" if checkout else "skipped",
+                        "STAGING_OUTCOME": staging,
+                        "STAGED_ARTIFACTS": str(staged),
+                        "ARTIFACT_OUTCOME": "success",
+                        "ARTIFACT_URL": "https://example.com/artifact",
+                        "RUN_URL": "https://example.com/run",
+                        "GITHUB_STEP_SUMMARY": str(summary),
+                    },
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                rendered = summary.read_text()
+                if staging == "success":
+                    self.assertIn("## Harbor\n", rendered)
+                    self.assertIn("## Analyzer\n", rendered)
+                    self.assertIn("## Fixer Results\n", rendered)
+                    self.assertIn("CI pipeline validation: failure", rendered)
+                    self.assertEqual((staged / "summary.md").read_text(), fixture)
+                else:
+                    self.assertIn("Joint summary.md unavailable", rendered)
+                    self.assertNotIn("## Harbor\n", rendered)
+                self.assertIn("Workflow status: **failure**", rendered)
+                self.assertIn(
+                    "[Download run artifacts](https://example.com/artifact)", rendered
+                )
+                if checkout:
+                    self.assertIn("Harness failure.", rendered)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_self_hosted_nightly_workflow.py
+++ b/.github/scripts/tests/test_self_hosted_nightly_workflow.py
@@ -120,6 +120,7 @@ class WorkflowTest(unittest.TestCase):
         )
         self.assertIn('HARBOR_LIMIT: ""', self.workflow)
         self.assertIn('MIN_TEST: "0"', self.workflow)
+        self.assertIn('export HARBOR_ANALYZER_OUTPUT_DIR="$OUTPUT_PATH/analyzer"', self.workflow)
 
     def test_smith_rejects_excess_harness_failures(self):
         self.assertIn(
@@ -137,6 +138,16 @@ class WorkflowTest(unittest.TestCase):
         self.assertIn("zellij kill-session", self.workflow)
         self.assertNotIn("docker system prune", self.workflow)
         self.assertNotIn("docker image prune", self.workflow)
+        self.assertLess(
+            self.workflow.index("- name: Clean up"),
+            self.workflow.index("- name: Verify sampled tasks completed"),
+        )
+        self.assertLess(
+            self.workflow.index("- name: Clean up"),
+            self.workflow.index("- name: Stage and redact artifacts"),
+        )
+        self.assertEqual(self.workflow.count("steps.cleanup.outcome == 'success'"), 2)
+        self.assertIn("harbor_nightly_cleanup.py", self.workflow)
 
     def step_script(self, name):
         self.assertIn(f"- name: {name}", self.workflow)
@@ -216,6 +227,7 @@ class WorkflowTest(unittest.TestCase):
                     "RUNNER_TEMP": tmp,
                     "OUTPUT_PATH": str(output),
                     "GITHUB_ENV": str(env_file),
+                    "GITHUB_WORKSPACE": str(ROOT),
                     "API_KEY": "fake-api-credential",
                     "OPIK_API_KEY": "fake-opik-credential",
                 },
@@ -231,11 +243,90 @@ class WorkflowTest(unittest.TestCase):
         self.assertRegex(upload, r"actions/upload-artifact@[0-9a-f]{40}")
         self.assertIn("retention-days: 14", upload)
 
+    def test_staging_redacts_saved_credentials_and_structured_overrides(self):
+        script = self.step_script("Stage and redact artifacts")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.local.env").write_text(
+                "EXA_API_KEY=fake-exa-key\n"
+                "HARBOR_ANALYZER_API_KEY=fake-analyzer-key\n"
+                "HARBOR_FIXER_API_KEY=fake-fixer-key\n"
+                'HARBOR_LLM_KWARGS=\'{"api_key":"fake-llm-key"}\'\n'
+                'OPENCODE_RUNTIME_SECRETS_JSON=\'{"custom_header":"fake-header-key"}\'\n'
+            )
+            original = b"fake-exa-key fake-analyzer-key fake-fixer-key fake-llm-key fake-header-key"
+            output = root / "run"
+            output.mkdir()
+            (output / "agent.log").write_bytes(original)
+            env_file = root / "env"
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                env={
+                    **os.environ,
+                    "GITHUB_WORKSPACE": tmp,
+                    "RUNNER_TEMP": tmp,
+                    "OUTPUT_PATH": str(output),
+                    "GITHUB_ENV": str(env_file),
+                    "API_KEY": "fake-primary-key",
+                    "OPIK_API_KEY": "",
+                },
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            staged = Path(env_file.read_text().strip().split("=", 1)[1])
+            self.assertEqual(
+                (staged / "agent.log").read_bytes(), b"*** *** *** *** ***"
+            )
+            self.assertEqual((output / "agent.log").read_bytes(), original)
+
+    def test_summary_renderer_failure_falls_back_to_health(self):
+        script = self.step_script("Publish run summary")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "summary.md").write_bytes(b"invalid utf8: \xff")
+            health = root / "health.md"
+            health.write_text("Validation: PASS\n")
+            summary = root / "published.md"
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                env={
+                    **os.environ,
+                    "HEALTH_SUMMARY": str(health),
+                    "JOB_STATUS": "success",
+                    "GATE_OUTCOME": "success",
+                    "STAGING_OUTCOME": "success",
+                    "STAGED_ARTIFACTS": tmp,
+                    "ARTIFACT_OUTCOME": "success",
+                    "ARTIFACT_URL": "https://example.com/artifact",
+                    "RUN_URL": "https://example.com/run",
+                    "GITHUB_STEP_SUMMARY": str(summary),
+                },
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Validation: PASS", summary.read_text())
+            self.assertNotIn("<details>", summary.read_text())
+
     def test_publishes_joint_summary_and_download_link_after_failures(self):
         script = self.step_script("Publish run summary")
-        fixture = (ROOT / ".github/scripts/tests/fixtures/harbor-joint-summary.md").read_text()
-        for checkout, staging in ((True, "success"), (True, "failure"), (False, "skipped")):
-            with self.subTest(checkout=checkout, staging=staging), tempfile.TemporaryDirectory() as tmp:
+        fixture = (
+            ROOT / ".github/scripts/tests/fixtures/harbor-joint-summary.md"
+        ).read_text()
+        for checkout, staging in (
+            (True, "success"),
+            (True, "failure"),
+            (False, "skipped"),
+        ):
+            with (
+                self.subTest(checkout=checkout, staging=staging),
+                tempfile.TemporaryDirectory() as tmp,
+            ):
                 report = Path(tmp) / "health.md"
                 report.write_text("## Validation: FAIL\n\nHarness failure.\n")
                 staged = Path(tmp) / "staged"

--- a/.github/workflows/harbor-self-hosted-nightly.yml
+++ b/.github/workflows/harbor-self-hosted-nightly.yml
@@ -100,6 +100,7 @@ jobs:
           printf 'Selected %s tasks from %s: %s\n' "$task_count" "$benchmark" "$tasks"
 
       - name: Run Harbor benchmark
+        id: harbor
         env:
           BASE_URL_RAW: ${{ vars.LLM_REVIEW_BASE_URL }}
           API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
@@ -143,11 +144,17 @@ jobs:
               /dev/null || status=$?
           if (( status == 124 || status == 137 )); then
             echo "::error::Harbor exceeded its 450-minute budget" >&2
+            zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
           fi
+          printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
           exit "$status"
 
       - name: Verify sampled tasks completed
+        id: health
+        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
         env:
+          HARBOR_STATUS: ${{ steps.harbor.outputs.status }}
+          HEALTH_SUMMARY: ${{ runner.temp }}/harbor-self-hosted-health-${{ github.run_id }}-${{ github.run_attempt }}.md
           BENCHMARK: ${{ steps.params.outputs.benchmark }}
           EXPECTED_TASKS: ${{ steps.params.outputs.task_count }}
           OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
@@ -155,17 +162,20 @@ jobs:
           set -euo pipefail
           if [[ "$BENCHMARK" != "smith" ]]; then
             python3 .github/scripts/e2e_harbor_gate.py \
+              --step-summary "$HEALTH_SUMMARY" \
               --output-path "$OUTPUT_PATH" \
-              --harbor-status 0 \
+              --harbor-status "${HARBOR_STATUS:-1}" \
               --expected-trials "$EXPECTED_TASKS" \
               --max-harness-failure-ratio 0.10
             exit 0
           fi
 
+          printf '### Smith sampled task validation\n\n' > "$HEALTH_SUMMARY"
           shopt -s nullglob
           done_files=("$OUTPUT_PATH"/queue/*/done.txt)
           if (( ${#done_files[@]} != 1 )); then
             echo "::error::expected one Smith completion queue" >&2
+            printf 'FAIL: expected one Smith completion queue.\n' >> "$HEALTH_SUMMARY"
             exit 1
           fi
           queue_dir="${done_files[0]%/done.txt}"
@@ -174,14 +184,89 @@ jobs:
           exception_count="$(awk -F '\t' '$4 != "" { count++ } END { print count + 0 }' "${done_files[0]}")"
           accounted=$((done_count + failed_count))
           errors=$((exception_count + failed_count))
+          {
+            printf '| Metric | Value |\n| --- | --- |\n'
+            printf '| Expected tasks | %s |\n' "$EXPECTED_TASKS"
+            printf '| Completed queue entries | %s |\n' "$done_count"
+            printf '| Failed queue entries | %s |\n' "$failed_count"
+            printf '| Harness failures | %s |\n' "$errors"
+            printf '| Benchmark shell exit status | %s |\n\n' "${HARBOR_STATUS:-1}"
+          } >> "$HEALTH_SUMMARY"
           if (( accounted != EXPECTED_TASKS )); then
             echo "::error::Smith accounted for $accounted of $EXPECTED_TASKS sampled tasks" >&2
+            printf 'FAIL: Smith accounted for %s of %s sampled tasks.\n' "$accounted" "$EXPECTED_TASKS" >> "$HEALTH_SUMMARY"
             exit 1
           fi
           if (( errors * 100 > EXPECTED_TASKS * 10 )); then
             echo "::error::Smith had $errors harness failures across $EXPECTED_TASKS tasks" >&2
+            printf 'FAIL: Smith had %s harness failures across %s tasks.\n' "$errors" "$EXPECTED_TASKS" >> "$HEALTH_SUMMARY"
             exit 1
           fi
+          if (( ${HARBOR_STATUS:-1} != 0 )); then
+            printf 'FAIL: benchmark shell exited with status %s.\n' "${HARBOR_STATUS:-1}" >> "$HEALTH_SUMMARY"
+            exit 1
+          fi
+          printf 'PASS: sampled tasks completed within the harness failure allowance.\n' >> "$HEALTH_SUMMARY"
+
+      - name: Stage and redact artifacts
+        id: stage
+        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
+        env:
+          API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
+          OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
+          OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$API_KEY" ]]; then
+            # An empty needle would make replace() and grep -F match everything.
+            echo "::error::API_KEY is empty; refusing to stage artifacts unredacted" >&2
+            exit 1
+          fi
+          staged="$(mktemp -d "${RUNNER_TEMP}/harbor-self-hosted-artifacts.XXXXXX")"
+          cp -R "$OUTPUT_PATH/." "$staged/"
+          while IFS= read -r -d '' file; do
+            python3 - "$file" <<'PY'
+          import os
+          import sys
+
+          path = sys.argv[1]
+          # Redact every credential this job puts in the benchmark environment.
+          # Skip empties: an empty needle inserts the marker between every byte.
+          keys = [
+              value
+              for name in ("API_KEY", "OPIK_API_KEY")
+              for value in (os.environ.get(name, ""),)
+              if value
+          ]
+          with open(path, "rb") as handle:
+              data = handle.read()
+          replaced = data
+          for key in keys:
+              replaced = replaced.replace(key.encode(), b"***")
+          if replaced != data:
+              with open(path, "wb") as handle:
+                  handle.write(replaced)
+          PY
+          done < <(find "$staged" -type f -print0)
+          if grep -rqF -- "$API_KEY" "$staged"; then
+            echo "::error::API key still present in staged artifacts after redaction" >&2
+            exit 1
+          fi
+          if [[ -n "${OPIK_API_KEY:-}" ]] && grep -rqF -- "$OPIK_API_KEY" "$staged"; then
+            echo "::error::Opik key still present in staged artifacts after redaction" >&2
+            exit 1
+          fi
+          printf 'staged=%s\n' "$staged" >> "$GITHUB_ENV"
+
+      - name: Upload run artifacts
+        id: artifacts
+        if: ${{ !cancelled() && steps.stage.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.params.outputs.run_id }}
+          path: ${{ env.staged }}
+          retention-days: 14
+          if-no-files-found: warn
 
       - name: Clean up
         if: always()
@@ -191,3 +276,44 @@ jobs:
           set -euo pipefail
           zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
           zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+
+      - name: Publish run summary
+        if: always()
+        env:
+          HEALTH_SUMMARY: ${{ runner.temp }}/harbor-self-hosted-health-${{ github.run_id }}-${{ github.run_attempt }}.md
+          JOB_STATUS: ${{ job.status }}
+          GATE_OUTCOME: ${{ steps.health.outcome }}
+          STAGING_OUTCOME: ${{ steps.stage.outcome }}
+          STAGED_ARTIFACTS: ${{ env.staged }}
+          ARTIFACT_OUTCOME: ${{ steps.artifacts.outcome }}
+          ARTIFACT_URL: ${{ steps.artifacts.outputs.artifact-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            printf 'Workflow status: **%s**\n\n' "$JOB_STATUS"
+            printf '[Run logs](%s)\n\n' "$RUN_URL"
+            if [[ -n "$ARTIFACT_URL" ]]; then
+              printf '[Download run artifacts](%s) (retained for 14 days)\n\n' "$ARTIFACT_URL"
+            else
+              printf 'Run artifacts: unavailable (upload step: %s).\n\n' "$ARTIFACT_OUTCOME"
+            fi
+
+            has_joint=0
+            if [[ "$STAGING_OUTCOME" == "success" && -s "$STAGED_ARTIFACTS/summary.md" ]]; then
+              python3 .github/scripts/e2e_harbor_summary.py "$STAGED_ARTIFACTS/summary.md" \
+                --artifact-url "$ARTIFACT_URL"
+              has_joint=1
+              printf '\n\n<details>\n<summary>CI pipeline validation: %s</summary>\n\n' "$GATE_OUTCOME"
+            else
+              printf 'Joint summary.md unavailable; showing pipeline validation below.\n\n'
+            fi
+            if [[ "$GATE_OUTCOME" != "skipped" && -s "$HEALTH_SUMMARY" ]]; then
+              cat "$HEALTH_SUMMARY"
+            else
+              printf 'Pipeline validation report unavailable. Check the failed or cancelled steps in the run logs.\n'
+            fi
+            if (( has_joint )); then
+              printf '\n</details>\n'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/harbor-self-hosted-nightly.yml
+++ b/.github/workflows/harbor-self-hosted-nightly.yml
@@ -136,6 +136,8 @@ jobs:
           export BASE_URL="${BASE_URL_RAW%/chat/completions}"
           export OPIK_PROJECT_NAME="$(date -u +'%Y-%m-%d-%H')-harbor-self-hosted-nightly"
           export HARBOR_OPENSANDBOX_BENCHMARK="$BENCHMARK"
+          # Keep Analyzer artifacts and detached Pi homes inside this run.
+          export HARBOR_ANALYZER_OUTPUT_DIR="$OUTPUT_PATH/analyzer"
 
           status=0
           timeout --signal=TERM --kill-after=5m 450m \
@@ -149,9 +151,23 @@ jobs:
           printf 'status=%s\n' "$status" >> "$GITHUB_OUTPUT"
           exit "$status"
 
+      - name: Clean up
+        id: cleanup
+        if: ${{ always() && steps.params.outputs.run_id != '' }}
+        env:
+          ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
+          RUN_ID: ${{ steps.params.outputs.run_id }}
+          OUTPUT_PATH: ${{ steps.params.outputs.output_path }}
+        run: |
+          set -euo pipefail
+          zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+          zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
+          python3 .github/scripts/harbor_nightly_cleanup.py \
+            --run-dir "$OUTPUT_PATH" --run-id "$RUN_ID"
+
       - name: Verify sampled tasks completed
         id: health
-        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
+        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' && steps.cleanup.outcome == 'success' }}
         env:
           HARBOR_STATUS: ${{ steps.harbor.outputs.status }}
           HEALTH_SUMMARY: ${{ runner.temp }}/harbor-self-hosted-health-${{ github.run_id }}-${{ github.run_attempt }}.md
@@ -210,7 +226,7 @@ jobs:
 
       - name: Stage and redact artifacts
         id: stage
-        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' }}
+        if: ${{ !cancelled() && steps.harbor.outcome != 'skipped' && steps.cleanup.outcome == 'success' }}
         env:
           API_KEY: ${{ secrets.LLM_REVIEW_API_KEY }}
           OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
@@ -222,40 +238,11 @@ jobs:
             echo "::error::API_KEY is empty; refusing to stage artifacts unredacted" >&2
             exit 1
           fi
+          source scripts/config_loader.sh
+          agent_fleet_load_config "$GITHUB_WORKSPACE"
           staged="$(mktemp -d "${RUNNER_TEMP}/harbor-self-hosted-artifacts.XXXXXX")"
           cp -R "$OUTPUT_PATH/." "$staged/"
-          while IFS= read -r -d '' file; do
-            python3 - "$file" <<'PY'
-          import os
-          import sys
-
-          path = sys.argv[1]
-          # Redact every credential this job puts in the benchmark environment.
-          # Skip empties: an empty needle inserts the marker between every byte.
-          keys = [
-              value
-              for name in ("API_KEY", "OPIK_API_KEY")
-              for value in (os.environ.get(name, ""),)
-              if value
-          ]
-          with open(path, "rb") as handle:
-              data = handle.read()
-          replaced = data
-          for key in keys:
-              replaced = replaced.replace(key.encode(), b"***")
-          if replaced != data:
-              with open(path, "wb") as handle:
-                  handle.write(replaced)
-          PY
-          done < <(find "$staged" -type f -print0)
-          if grep -rqF -- "$API_KEY" "$staged"; then
-            echo "::error::API key still present in staged artifacts after redaction" >&2
-            exit 1
-          fi
-          if [[ -n "${OPIK_API_KEY:-}" ]] && grep -rqF -- "$OPIK_API_KEY" "$staged"; then
-            echo "::error::Opik key still present in staged artifacts after redaction" >&2
-            exit 1
-          fi
+          python3 .github/scripts/redact_harbor_artifacts.py "$staged"
           printf 'staged=%s\n' "$staged" >> "$GITHUB_ENV"
 
       - name: Upload run artifacts
@@ -267,15 +254,6 @@ jobs:
           path: ${{ env.staged }}
           retention-days: 14
           if-no-files-found: warn
-
-      - name: Clean up
-        if: always()
-        env:
-          ZELLIJ_SESSION_NAME: ${{ steps.params.outputs.run_id }}
-        run: |
-          set -euo pipefail
-          zellij kill-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
-          zellij delete-session "$ZELLIJ_SESSION_NAME" >/dev/null 2>&1 || true
 
       - name: Publish run summary
         if: always()
@@ -301,10 +279,13 @@ jobs:
 
             has_joint=0
             if [[ "$STAGING_OUTCOME" == "success" && -s "$STAGED_ARTIFACTS/summary.md" ]]; then
-              python3 .github/scripts/e2e_harbor_summary.py "$STAGED_ARTIFACTS/summary.md" \
-                --artifact-url "$ARTIFACT_URL"
-              has_joint=1
-              printf '\n\n<details>\n<summary>CI pipeline validation: %s</summary>\n\n' "$GATE_OUTCOME"
+              if python3 .github/scripts/e2e_harbor_summary.py "$STAGED_ARTIFACTS/summary.md" \
+                --artifact-url "$ARTIFACT_URL"; then
+                has_joint=1
+                printf '\n\n<details>\n<summary>CI pipeline validation: %s</summary>\n\n' "$GATE_OUTCOME"
+              else
+                printf 'Joint summary.md could not be rendered; showing pipeline validation below.\n\n'
+              fi
             else
               printf 'Joint summary.md unavailable; showing pipeline validation below.\n\n'
             fi


### PR DESCRIPTION
## 1. Why the change?

Harbor Self-Hosted Nightly currently has no downloadable run artifacts, and its validation step is skipped when the benchmark shell fails. Apply the E2E nightly's current summary display so users can inspect results and download diagnostic artifacts directly from the Actions run.

## 2. Summary of the change

- Display the successfully staged and redacted root `summary.md`, including Harbor, Analyzer, and available Fixer results, with workflow status and run-log/download links. Keep CI validation as supplemental detail and fall back to it when the joint report is unavailable or the display renderer fails.
- Stage artifacts with repository configuration loaded at the same precedence as the launcher. Redact configured credentials (including Exa, Analyzer/Fixer overrides, and structured OpenCode/LLM credentials), verify redaction, and upload only after successful staging with 14-day retention.
- Evaluate registry and Smith results after benchmark failures, record the actual shell status, and include Smith completion counts and failure reasons in the summary. Stop the benchmark session and run-scoped detached Monitor/Analyzer/Pi processes before validation and staging. Refuse staging if cleanup fails, and keep Analyzer output under the run directory so orphaned Pi processes can be identified safely.
- Reuse the exact display helper, fixture, and helper tests from [PR #185](https://github.com/sii-system/agent-fleet/pull/185). This PR targets current `main` independently and does not modify the E2E workflow.

## 3. Other details

Validation:
- 337 CI-helper tests passed in Linux with Python 3.12: `PYTHONPATH=. python3 -m unittest discover -s .github/scripts/tests`.
- Ruff 0.16.0 passed on all changed Python files.
- Actionlint passed with the existing custom runner label and pre-existing SC2155 warning excluded; the same warning was confirmed on the prior head. Workflow shell syntax and `git diff --check` passed.
- Directly exercised report publishing (including invalid UTF-8 fallback), registry/Smith success and failure cases, and saved/structured credential redaction without modifying source artifacts.
- Linux process tests cover TERM-resistant run processes, detached children, orphaned Pi, preservation of unrelated runs, and exclusion of the cleanup process itself.
- Verified the pinned upload action declares the `artifact-url` output used for download links.

No live nightly was dispatched. Artifact collection adds a temporary copy of the run output and a GitHub upload. This nightly now pins Analyzer output to its run directory; externally configured Analyzer output paths are overridden for this workflow. Benchmark selection, analysis enablement, and the existing 10% harness-failure allowance remain unchanged.

