### PR TITLE
refactor(opensandbox): intercept apt through runtime PATH

### DIFF
--- a/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
+++ b/Agents/utils/common/Harbor/OPENSANDBOX_IMAGE_MANAGER.md
@@ -85,10 +85,14 @@ fallback that could silently diverge after a Harbor runner upgrade.
 Task-declared Compose build arguments and Dockerfile defaults are already part
 of the static environment content. Runtime build-argument overrides, package
 mirrors, APT mirrors, base-image transport mirrors, proxies, fallback choices,
-build-network settings, and target platform do not participate in image
-identity. The implementation uses the Harbor benchmark framework's complete
-SHA-256 result rather than
-a provider-specific display truncation.
+build-network settings, target platform, renderer version, and APT runtime asset
+digest do not participate in image identity. The implementation uses the Harbor
+benchmark framework's complete SHA-256 result rather than a provider-specific
+display truncation.
+
+**P0 invariant:** image identity must come only from the original static task
+environment. Treat any dependency on rendering, rewriting, mounts, mirrors,
+runtime assets, resolved artifacts, or other build-time mutation as a P0 bug.
 
 For an `image:` service, the original image reference declared by the task is
 used only as the Harbor benchmark framework's empty-environment fallback seed.
@@ -178,6 +182,79 @@ for Dockerfile `RUN` commands. They apply to ordinary clone/fetch and recursive
 GitHub submodules, including HTTPS, SCP-like SSH, `ssh://`, and `git://` URLs.
 The mount exists only while each `RUN` executes, so it is not written into an
 image layer, image environment, or global `.gitconfig`.
+
+## APT build-runtime interception
+
+APT routing is runtime interception, not Dockerfile APT analysis. The renderer
+mechanically gives each shell-form `RUN` instruction the same BuildKit-only
+environment:
+
+```text
+/run/opensandbox-apt/bin/apt
+/run/opensandbox-apt/bin/apt-get
+PATH=/run/opensandbox-apt/bin:$PATH
+```
+
+The wrappers, source rewriter, and source map are mounted as BuildKit secrets;
+the invocation workspace is a tmpfs mount. Shell-form `RUN` instructions prepend
+the temporary directory to `PATH`. Shell heredocs use a small build-only launcher
+when needed. Ordinary JSON exec-form `RUN` instructions remain unchanged and do
+not receive APT runtime mounts or an added shell dependency. The renderer does
+not inspect shell command content, predict APT use, or track source mutations.
+None of the mounted files or the temporary `PATH` value is persisted in the
+resulting image.
+
+Existing `RUN --<option>=<value>` options, including `--mount`, `--network`,
+`--security`, and `--device`, remain in the instruction-options region. Runtime
+mounts are added there, while the `PATH` setup is added only to a shell-form
+command body. The independent Git `/etc/gitconfig` secret mount also coexists
+with these options and remains available to JSON exec-form RUNs.
+
+The runtime helper files are hashed as a stable set solely for their BuildKit
+secret IDs, while the source map keeps its own content-addressed secret ID.
+Changing a wrapper or rewriter therefore invalidates affected RUN cache entries
+when a build occurs, but does not change the task's static image identity.
+
+Each time `apt` or `apt-get` is found through `PATH`, the wrapper reads the
+current rootfs copies of `/etc/apt/sources.list`, `*.list`, and `*.sources`. It
+copies them into an invocation-local shadow tree, rewrites active source URIs,
+and invokes the current rootfs binary at `/usr/bin/apt` or `/usr/bin/apt-get`
+with `Dir::Etc::SourceList` and `Dir::Etc::SourceParts` pointing at that shadow.
+The real `/etc/apt` files are never changed. Updating the `apt` package during a
+build therefore naturally changes the real binary used by later invocations.
+
+After a successful `apt update` or `apt-get update`, the same invocation asks
+APT for rewritten-source and original-source index targets with `apt-get
+indextargets`. It joins targets by their stable source-entry and target metadata,
+then copies the downloaded target and any compressed variants to the filename
+APT derives from the original URI. Corresponding `InRelease`, `Release`, and
+`Release.gpg` files are reconciled as well. The gateway-named files remain in
+place for later intercepted commands in the same build. If target discovery or
+copying fails, the wrapper emits `event=index-reconciliation-failed` and fails
+the invocation instead of silently leaving an identity-mismatched image. This
+runs only after a successful update and needs no stage analysis or final cleanup
+RUN.
+
+The mapping combines the configured distro mirror with
+`HARBOR_OPENSANDBOX_APT_SOURCE_OVERRIDES_JSON`. Repository matches use the
+longest prefix, retain the suffix, and require an exact match or `/` boundary.
+An unmatched active HTTP(S) URI remains unchanged, but the wrapper emits a
+structured warning before real APT starts:
+
+```text
+[opensandbox apt] WARNING event=unmapped-source source=<uri> file=<source-file>
+```
+
+Non-HTTP(S) sources such as `file:` and `cdrom:` remain unchanged without a
+warning. Interception covers ordinary `apt` and `apt-get` lookup from shell-form
+RUNs, including nested `sh`/`bash`, dynamically downloaded scripts, and
+subprocesses that inherit the build `PATH`. It intentionally does not intercept
+JSON exec-form APT invocations, `/usr/bin/apt`, `/usr/bin/apt-get`, other
+explicit paths, or custom libapt frontends. `APT_CONFIG` and explicit custom APT
+source or config-root options are passed directly to the real binary with a
+warning.
+There is no `/usr/bin` overlay, apt-binary copy, base-stage snapshot, bind mount,
+or stage-level restore/virtualization fallback.
 
 `SkopeoPublisher` removes ambient HTTP(S) proxy variables for login, copy, and
 inspect. TLS verification is controlled by `YICLOUD_HARBOR_TLS_VERIFY`; the

--- a/Agents/utils/common/Harbor/OPENSANDBOX_README.md
+++ b/Agents/utils/common/Harbor/OPENSANDBOX_README.md
@@ -171,10 +171,10 @@ configured package-source health probes, so a batch made entirely of local
 hits performs no per-task network request. If a real miss later fails while
 building, the existing health check and trusted-source fallback still run.
 
-APT mirror rewriting is build-stage scoped. `--apt-mirror` provides the
-Ubuntu and Debian mirror root. Third-party repositories, signing keys, and
-bootstrap downloads use an explicit provider-neutral prefix map; Agent Fleet
-does not guess mirror paths:
+APT source routing is build-runtime scoped. `--apt-mirror` provides the Ubuntu
+and Debian mirror root. Third-party repositories, signing keys, and bootstrap
+downloads use an explicit provider-neutral prefix map; Agent Fleet does not
+guess mirror paths:
 
 ```bash
 export HARBOR_OPENSANDBOX_APT_SOURCE_OVERRIDES_JSON='{
@@ -183,35 +183,52 @@ export HARBOR_OPENSANDBOX_APT_SOURCE_OVERRIDES_JSON='{
 }'
 ```
 
-The generated Dockerfile applies the longest matching configured prefix only
-where the URL is unambiguously build transport: direct shell- or exec-form
-`curl` or `wget` commands, APT source writes in a stage that statically invokes
-`apt` or `apt-get`, and existing APT source files in that stage. Static
-`sh -c`/`bash -c` wrappers are inspected, but downloaded or generated scripts
-are not. Other `RUN` data, including URLs written to non-APT runtime
-configuration, remains task-authored. The same rule applies to statically
-visible Dockerfile heredoc bodies: command heredocs are rewritten, while data
-heredocs persisted outside the APT source tree and `COPY <<EOF` data remain
-unchanged.
+The generated Dockerfile gives every shell-form `RUN` the same ephemeral wrapper
+directory at the front of `PATH`. Ordinary `apt` and `apt-get` calls therefore
+read the source files that exist at invocation time, create an invocation-local
+shadow tree, and apply the longest exact-or-`/`-boundary source mapping there.
+The wrapper passes the shadow paths to the current `/usr/bin/apt*` binary through
+APT's `Dir::Etc::SourceList` and `Dir::Etc::SourceParts` options. Unmatched
+active HTTP(S) sources remain usable and produce a warning containing both URI
+and source-file path; `file:`, `cdrom:`, and other non-HTTP(S) sources remain
+quiet. Real `/etc/apt` content is never changed. Runtime helper contents
+participate in content-addressed BuildKit secret IDs, so helper changes invalidate
+cached RUNs when a build occurs. They do not participate in the task's static
+image identity.
 
-At the start of a stage that statically invokes APT, Agent Fleet snapshots the
-task-visible `sources.list` and `sources.list.d`. Before the stage ends, it
-restores unchanged source files exactly and removes configured build transport
-rewrites from task-added or task-modified source files. Cached package and
-signed release indexes are renamed to match the restored source URLs, so a
-later agent-side `apt install` does not require an extra update solely because
-the build used a mirror. APT sources introduced later by `COPY`, `ADD`, or a
-statically visible `RUN` source-tree update are restored, checkpointed, and
-mirrored after that instruction, then restored by the same final cleanup. An
-explicit task `USER` is also restored after cleanup.
-Stages that only download a configured signing key or bootstrap object do not
-run the root-only APT snapshot. This is a runtime-behavior guarantee, not a
-claim that historical OCI layers are byte-for-byte free of build mirror
-strings. Unconfigured third-party URLs remain task-authored and are not
-rewritten.
+Following a successful `apt update` or `apt-get update`, the wrapper uses
+`apt-get indextargets` against the rewritten and original source views to copy
+the downloaded package and release metadata to the filenames associated with
+the original URIs. Final images can therefore consume their existing package
+lists with the unchanged `/etc/apt` sources; reconciliation failure is reported
+as `event=index-reconciliation-failed` and fails that invocation. This remains
+invocation-local and does not add static stage detection or a cleanup RUN.
+
+This includes nested shells, dynamically downloaded scripts, and subprocesses
+that use normal `PATH` lookup. The implementation intentionally permits JSON
+exec-form APT invocations, `/usr/bin/apt`, `/usr/bin/apt-get`, other explicit
+binary paths, and custom libapt frontends to bypass interception. `APT_CONFIG`
+and explicit custom source/config layouts also warn and bypass instead of being
+parsed. The wrapper assets, source map, shadow tree, and `PATH` change are
+BuildKit-only mounts or shell-local state and do not enter the final image.
+There is no static APT detection, source mutation tracking, snapshot, restore,
+`/usr/bin` overlay, or apt-binary mount.
+
+Dockerfile `RUN --<option>=<value>` prefixes, including `--device`, are preserved
+as RUN options when shell runtime mounts are added. Git `/etc/gitconfig` mounts
+remain independent and continue to work on both shell-form and JSON exec-form
+RUN instructions.
+
+The same explicit map remains available for direct shell- or exec-form `curl`
+and `wget` build-transport URLs, including signing keys and bootstrap objects.
+Other `RUN` data, APT source-file writes, persisted data heredocs, and
+`COPY <<EOF` data remain task-authored; command heredocs only rewrite configured
+URLs used by direct `curl` or `wget` commands. Unconfigured third-party URLs are
+never guessed or silently rewritten.
 
 Other package sources such as pip, npm, Go, Cargo, Rustup, Dart Pub, and Julia
-retain their Docker build-argument behavior and are not part of the APT cleanup.
+retain their Docker build-argument behavior and are not part of APT runtime
+interception.
 `HARBOR_OPENSANDBOX_PUB_HOSTED_URL` and
 `HARBOR_OPENSANDBOX_JULIA_PKG_SERVER` are optional provider-neutral URLs. When
 configured, the manager passes them to Dockerfile `RUN` instructions as

--- a/Agents/utils/common/Harbor/STRUCT.md
+++ b/Agents/utils/common/Harbor/STRUCT.md
@@ -34,6 +34,10 @@ Agents/utils/common/Harbor/
 │   └── router_cli_utils.py     # Shared Router build/config/launcher helpers
 ├── compose_bundle.py            # Dockerfile/Compose to provider-neutral BundleSpec
 ├── opensandbox_image_manager.py # Per-service image build/cache/publish and Bundle output
+├── opensandbox_apt_runtime/      # Build-only PATH wrappers and shadow-source rewriter
+│   ├── apt-wrapper.sh            # Runtime apt/apt-get adapter to current /usr/bin binary
+│   ├── run-with-apt-path.sh      # Shell-heredoc launcher with ephemeral PATH
+│   └── source-rewriter.awk       # Boundary-safe list and Deb822 URI mapping/warnings
 ├── OPENSANDBOX_IMAGE_MANAGER.md # OpenSandbox Bundle and image management contract
 ├── prebuild_opensandbox_dataset.sh # Batch prebuild/publish dataset Bundles
 └── scripts/

--- a/Agents/utils/common/Harbor/opensandbox_apt_runtime/apt-wrapper.sh
+++ b/Agents/utils/common/Harbor/opensandbox_apt_runtime/apt-wrapper.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+set -u
+
+runtime=/run/opensandbox-apt
+command_name=${0##*/}
+real=/usr/bin/$command_name
+if [ ! -x "$real" ]; then
+    echo "[opensandbox apt] ERROR event=real-binary-unavailable" \
+        "command=$command_name path=$real" >&2
+    exit 127
+fi
+
+if [ -n "${APT_CONFIG:-}" ]; then
+    echo "[opensandbox apt] WARNING event=custom-source-config" \
+        "action=bypass environment=APT_CONFIG" >&2
+    exec "$real" "$@"
+fi
+
+for argument in "$@"; do
+    case "$argument" in
+        -c|--config-file|-c*|--config-file=*|*Dir::Etc=*|*Dir::Etc::SourceList*|*Dir::Etc::SourceParts*|*RootDir*)
+            echo "[opensandbox apt] WARNING event=custom-source-config" \
+                "action=bypass argument=$argument" >&2
+            exec "$real" "$@"
+            ;;
+    esac
+done
+
+shadow=$(mktemp -d "$runtime/shadow/invocation.XXXXXX") || {
+    echo "[opensandbox apt] ERROR event=shadow-create-failed root=$runtime/shadow" >&2
+    exit 125
+}
+original_sources=$shadow/original
+source_view=$shadow/view
+mkdir -p "$original_sources/sources.list.d" "$source_view/sources.list.d" || exit 125
+: > "$original_sources/sources.list"
+: > "$source_view/sources.list"
+: > "$shadow/seen"
+
+capture_source() {
+    original=$1
+    saved=$2
+    destination=$3
+    source_kind=$4
+    display_file=$5
+    if ! cat "$original" > "$saved"; then
+        echo "[opensandbox apt] ERROR event=source-copy-failed file=$display_file" >&2
+        exit 125
+    fi
+    if ! awk -v map_file="$runtime/source-map" -v seen_file="$shadow/seen" \
+        -v source_kind="$source_kind" -v display_file="$display_file" \
+        -f "$runtime/source-rewriter.awk" "$saved" > "$destination"; then
+        echo "[opensandbox apt] ERROR event=source-rewrite-failed file=$display_file" >&2
+        exit 125
+    fi
+}
+
+if [ -f /etc/apt/sources.list ]; then
+    capture_source \
+        /etc/apt/sources.list \
+        "$original_sources/sources.list" "$source_view/sources.list" \
+        list /etc/apt/sources.list
+fi
+for original in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+    [ -f "$original" ] || continue
+    name=${original##*/}
+    case "$name" in
+        *.list) source_kind=list ;;
+        *.sources) source_kind=sources ;;
+        *) continue ;;
+    esac
+    capture_source \
+        "$original" \
+        "$original_sources/sources.list.d/$name" \
+        "$source_view/sources.list.d/$name" "$source_kind" \
+        "/etc/apt/sources.list.d/$name"
+done
+
+run_with_source_view() {
+    "$real" \
+        -o "Dir::Etc::SourceList=$source_view/sources.list" \
+        -o "Dir::Etc::SourceParts=$source_view/sources.list.d" \
+        "$@"
+}
+
+is_update=0
+skip_option_value=0
+for argument in "$@"; do
+    if [ "$skip_option_value" -eq 1 ]; then
+        skip_option_value=0
+        continue
+    fi
+    case "$argument" in
+        -o|--option|-t|--target-release|--host-architecture)
+            skip_option_value=1
+            ;;
+        update)
+            is_update=1
+            break
+            ;;
+        -*) ;;
+        *) break ;;
+    esac
+done
+
+if [ "$is_update" -ne 1 ]; then
+    exec "$real" \
+        -o "Dir::Etc::SourceList=$source_view/sources.list" \
+        -o "Dir::Etc::SourceParts=$source_view/sources.list.d" \
+        "$@"
+fi
+
+run_with_source_view "$@"
+apt_status=$?
+if [ "$apt_status" -ne 0 ]; then
+    exit "$apt_status"
+fi
+
+reconciliation_error() {
+    echo "[opensandbox apt] ERROR event=index-reconciliation-failed phase=$1" >&2
+    return 1
+}
+
+restore_original_view() {
+    if ! cat "$original_sources/sources.list" > "$source_view/sources.list"; then
+        reconciliation_error restore-source-list
+        return 1
+    fi
+    rm -f "$source_view/sources.list.d/"*.list \
+        "$source_view/sources.list.d/"*.sources || {
+        reconciliation_error clear-source-parts
+        return 1
+    }
+    for saved in \
+        "$original_sources/sources.list.d/"*.list \
+        "$original_sources/sources.list.d/"*.sources; do
+        [ -f "$saved" ] || continue
+        if ! cp -a "$saved" "$source_view/sources.list.d/${saved##*/}"; then
+            reconciliation_error restore-source-parts
+            return 1
+        fi
+    done
+}
+
+reconcile_indexes() {
+    for utility in /usr/bin/apt-get sort join cp; do
+        if ! command -v "$utility" >/dev/null 2>&1; then
+            reconciliation_error missing-utility
+            return 1
+        fi
+    done
+
+    target_format='$(SOURCESENTRY)~$(IDENTIFIER)~$(RELEASE)~$(COMPONENT)~$(ARCHITECTURE)~$(CREATED_BY)~$(METAKEY)|$(COMPONENT)|$(FILENAME)'
+    if ! /usr/bin/apt-get \
+        -o "Dir::Etc::SourceList=$source_view/sources.list" \
+        -o "Dir::Etc::SourceParts=$source_view/sources.list.d" \
+        indextargets --no-release-info --format "$target_format" \
+        > "$shadow/rewritten-targets"; then
+        reconciliation_error rewritten-targets
+        return 1
+    fi
+    restore_original_view || return 1
+    if ! /usr/bin/apt-get \
+        -o "Dir::Etc::SourceList=$source_view/sources.list" \
+        -o "Dir::Etc::SourceParts=$source_view/sources.list.d" \
+        indextargets --no-release-info --format "$target_format" \
+        > "$shadow/original-targets"; then
+        reconciliation_error original-targets
+        return 1
+    fi
+    if ! sort "$shadow/rewritten-targets" -o "$shadow/rewritten-targets" \
+        || ! sort "$shadow/original-targets" -o "$shadow/original-targets"; then
+        reconciliation_error sort-targets
+        return 1
+    fi
+    if ! join -t '|' "$shadow/rewritten-targets" "$shadow/original-targets" \
+        > "$shadow/target-copies"; then
+        reconciliation_error join-targets
+        return 1
+    fi
+
+    while IFS='|' read -r key source_component source_path \
+        target_component target_path; do
+        [ -n "$key" ] || continue
+        [ -n "$source_path" ] && [ -n "$target_path" ] || continue
+        [ "$source_path" = "$target_path" ] && continue
+        for candidate in "$source_path" "$source_path".*; do
+            [ -f "$candidate" ] || continue
+            suffix=${candidate#"$source_path"}
+            if ! cp -a "$candidate" "$target_path$suffix"; then
+                reconciliation_error copy-index-target
+                return 1
+            fi
+        done
+
+        [ -n "$source_component" ] || continue
+        source_marker=_${source_component}_
+        target_marker=_${target_component}_
+        case "$source_path" in
+            *"$source_marker"*) ;;
+            *) continue ;;
+        esac
+        source_dist=${source_path%%"$source_marker"*}
+        target_dist=${target_path%%"$target_marker"*}
+        for release_file in InRelease Release Release.gpg; do
+            [ -f "${source_dist}_${release_file}" ] || continue
+            if ! cp -a "${source_dist}_${release_file}" \
+                "${target_dist}_${release_file}"; then
+                reconciliation_error copy-release-target
+                return 1
+            fi
+        done
+    done < "$shadow/target-copies"
+}
+
+if ! reconcile_indexes; then
+    exit 125
+fi
+exit 0

--- a/Agents/utils/common/Harbor/opensandbox_apt_runtime/run-with-apt-path.sh
+++ b/Agents/utils/common/Harbor/opensandbox_apt_runtime/run-with-apt-path.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -u
+
+PATH=/run/opensandbox-apt/bin:$PATH
+export PATH
+
+if [ "$#" -eq 0 ]; then
+    exec /bin/sh
+fi
+exec "$@"

--- a/Agents/utils/common/Harbor/opensandbox_apt_runtime/source-rewriter.awk
+++ b/Agents/utils/common/Harbor/opensandbox_apt_runtime/source-rewriter.awk
@@ -1,0 +1,107 @@
+BEGIN {
+    while ((getline mapping < map_file) > 0) {
+        separator = index(mapping, "\t")
+        if (!separator) continue
+        origins[++mapping_count] = substr(mapping, 1, separator - 1)
+        replacements[mapping_count] = substr(mapping, separator + 1)
+    }
+    close(map_file)
+    while ((getline seen_uri < seen_file) > 0) seen[seen_uri] = 1
+    close(seen_file)
+}
+
+function prefix_matches(prefix, uri, suffix) {
+    if (substr(uri, 1, length(prefix)) != prefix) return 0
+    suffix = substr(uri, length(prefix) + 1)
+    if (suffix == "") return 1
+    return substr(suffix, 1, 1) == "/"
+}
+
+function rewrite_uri(uri, best, best_length, i) {
+    if (uri !~ /^https?:\/\//) return uri
+    for (i = 1; i <= mapping_count; i++) {
+        if (prefix_matches(replacements[i], uri)) return uri
+    }
+    best = 0
+    best_length = -1
+    for (i = 1; i <= mapping_count; i++) {
+        if (length(origins[i]) > best_length && prefix_matches(origins[i], uri)) {
+            best = i
+            best_length = length(origins[i])
+        }
+    }
+    if (best) {
+        return replacements[best] substr(uri, length(origins[best]) + 1)
+    }
+    if (!seen[uri]) {
+        printf "[opensandbox apt] WARNING event=unmapped-source " \
+            "source=%s file=%s\n", uri, display_file > "/dev/stderr"
+        seen[uri] = 1
+        print uri >> seen_file
+        close(seen_file)
+    }
+    return uri
+}
+
+function rewrite_uri_fields(text, output, rest, token) {
+    output = ""
+    rest = text
+    while (match(rest, /[^[:space:]]+/)) {
+        output = output substr(rest, 1, RSTART - 1)
+        token = substr(rest, RSTART, RLENGTH)
+        output = output rewrite_uri(token)
+        rest = substr(rest, RSTART + RLENGTH)
+    }
+    return output rest
+}
+
+function rewrite_list_line(line, probe, close_bracket, uri, position) {
+    probe = line
+    sub(/^[[:space:]]*/, "", probe)
+    if (probe ~ /^#/ || probe !~ /^(deb|deb-src)[[:space:]]+/) return line
+    sub(/^(deb|deb-src)[[:space:]]+/, "", probe)
+    if (substr(probe, 1, 1) == "[") {
+        close_bracket = index(probe, "]")
+        if (!close_bracket) return line
+        probe = substr(probe, close_bracket + 1)
+        sub(/^[[:space:]]+/, "", probe)
+    }
+    uri = probe
+    sub(/[[:space:]].*$/, "", uri)
+    if (uri == "") return line
+    position = index(line, uri)
+    if (!position) return line
+    return substr(line, 1, position - 1) rewrite_uri(uri) \
+        substr(line, position + length(uri))
+}
+
+function flush_stanza(disabled, i, lower, colon, uri_continuation) {
+    if (!stanza_count) return
+    disabled = 0
+    for (i = 1; i <= stanza_count; i++) {
+        lower = tolower(stanza[i])
+        if (lower ~ /^enabled:[[:space:]]*no([[:space:]]|$)/) disabled = 1
+    }
+    uri_continuation = 0
+    for (i = 1; i <= stanza_count; i++) {
+        lower = tolower(stanza[i])
+        if (!disabled && lower ~ /^uris:[[:space:]]*/) {
+            colon = index(stanza[i], ":")
+            stanza[i] = substr(stanza[i], 1, colon) \
+                rewrite_uri_fields(substr(stanza[i], colon + 1))
+            uri_continuation = 1
+        } else if (!disabled && uri_continuation && stanza[i] ~ /^[[:space:]]+/) {
+            stanza[i] = rewrite_uri_fields(stanza[i])
+        } else {
+            uri_continuation = 0
+        }
+        print stanza[i]
+        delete stanza[i]
+    }
+    stanza_count = 0
+}
+
+source_kind == "list" { print rewrite_list_line($0); next }
+/^[[:space:]]*$/ { flush_stanza(); print; next }
+{ stanza[++stanza_count] = $0 }
+END { if (source_kind != "list") flush_stanza() }

--- a/Agents/utils/common/Harbor/opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/opensandbox_image_manager.py
@@ -23,7 +23,7 @@ Flow:
               +--------+--------+
               | yes             | no
               v                 v
-       Reuse manifest    Rewrite source mirrors
+       Reuse manifest    Attach build-only source adapters
                               |
                               v
                          Build OCI archive
@@ -63,7 +63,7 @@ import sys
 import tarfile
 import tempfile
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -125,8 +125,14 @@ GITHUB_GIT_URL_PREFIXES = (
     "git://github.com/",
 )
 GITHUB_MIRROR_CONFIG_MOUNT_ID = "opensandbox-github-mirror-gitconfig"
-APT_MIRROR_STATE_DIR = "/var/lib/.opensandbox-apt-source-state"
-BUILD_RENDERER_VERSION = "apt-source-isolation-v4"
+APT_RUNTIME_ROOT = "/run/opensandbox-apt"
+APT_RUNTIME_ASSET_NAMES = (
+    "apt-wrapper.sh",
+    "source-rewriter.awk",
+    "run-with-apt-path.sh",
+)
+APT_SOURCE_MAP_SECRET_PREFIX = "opensandbox-apt-source-map"
+APT_RUNTIME_ASSET_DIR = Path(__file__).with_name("opensandbox_apt_runtime")
 SOURCE_OVERRIDE_FETCH_COMMAND = re.compile(
     r"(?:^|\|)\s*(?:RUN\s+)?"
     r"(?:(?:--mount=\S+|[A-Za-z_][A-Za-z0-9_]*=\S+|"
@@ -134,13 +140,14 @@ SOURCE_OVERRIDE_FETCH_COMMAND = re.compile(
     r"(?:[^\s;&|]+/)?(?:curl|wget)(?=\s|$)",
     re.IGNORECASE,
 )
+RUN_OPTION = r"--[A-Za-z][A-Za-z0-9-]*=\S+"
 RUN_EXEC_FORM = re.compile(
-    r"^(?P<prefix>\s*RUN\s+(?:(?:--mount|--network|--security)=\S+\s+)*)"
+    rf"^(?P<prefix>\s*RUN\s+(?:(?:{RUN_OPTION})\s+)*)"
     r"(?P<argv>\[.*\])(?P<suffix>\s*)$",
     re.DOTALL | re.IGNORECASE,
 )
 RUN_SHELL_PREFIX = re.compile(
-    r"^\s*RUN\s+(?:(?:--mount|--network|--security)=\S+\s+)*",
+    rf"^\s*RUN\s+(?:(?:{RUN_OPTION})\s+)*",
     re.IGNORECASE,
 )
 SHELL_HEREDOC_EXECUTOR = re.compile(
@@ -152,54 +159,6 @@ PIPE_TO_SHELL = re.compile(
     r"\|\s*(?:(?:command|exec|sudo|env)\s+)*"
     r"(?:[^\s;&|]+/)?(?:sh|bash)(?:\s|$)",
     re.IGNORECASE,
-)
-SHELL_WRAPPED_COMMAND = re.compile(
-    r"(?:^|[;&|])\s*(?:RUN\s+"
-    r"(?:(?:--mount|--network|--security)=\S+\s+)*)?"
-    r"(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S+|command|exec|sudo|env)\s+)*"
-    r"(?:[^\s;&|]+/)?(?:sh|bash)\s+"
-    r"-[A-Za-z]*c[A-Za-z]*\s+"
-    r"(?P<command>'[^']*'|\"[^\"]*\")",
-    re.IGNORECASE | re.DOTALL,
-)
-APT_SOURCE_FILE_REFERENCE = re.compile(
-    r"/etc/apt/(?:sources\.list\.d(?:/|(?=$|[\s;&|\"']))|"
-    r"sources\.list(?=$|[\s;&|\"']))"
-)
-APT_SOURCE_RESTORE_AWK = (
-    "function replace_literal(text, needle, replacement, position) { "
-    "position = index(text, needle); "
-    "if (!position) return text; "
-    "return substr(text, 1, position - 1) replacement "
-    "substr(text, position + length(needle)) "
-    "} "
-    "FILENAME == ARGV[1] { original[FNR] = $0; next } "
-    "FILENAME == ARGV[2] { "
-    "adapted[FNR] = $0; "
-    "adapted_seen[$0]++; "
-    "restore[$0 SUBSEP adapted_seen[$0]] = original[FNR]; "
-    "next "
-    "} "
-    "{ "
-    "line = $0; "
-    "replaced = 0; "
-    "original_count = split(original[FNR], original_fields); "
-    "adapted_count = split(adapted[FNR], adapted_fields); "
-    "if (original_count == adapted_count) { "
-    "for (field = 1; field <= adapted_count; field++) { "
-    "if (original_fields[field] != adapted_fields[field] "
-    "&& index(line, adapted_fields[field])) { "
-    "line = replace_literal(line, adapted_fields[field], "
-    "original_fields[field]); "
-    "replaced = 1 "
-    "} "
-    "} "
-    "} "
-    "if (replaced) { print line; next } "
-    "current_seen[$0]++; "
-    "key = $0 SUBSEP current_seen[$0]; "
-    "if (key in restore) print restore[key]; else print "
-    "}"
 )
 BUILD_ARG_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 FROM_LINE = re.compile(
@@ -213,17 +172,6 @@ HEREDOC_MARKER = re.compile(
     r"<<(?P<strip>-)?\s*(?P<quote>['\"]?)"
     r"(?P<delimiter>[A-Za-z0-9_.-]+)(?P=quote)"
 )
-APT_COMMAND = re.compile(
-    r"(?:"
-    r"(?:^|[;&|])\s*(?:RUN\s+)?"
-    r"(?:(?:--mount=\S+|[A-Za-z_][A-Za-z0-9_]*=\S+|"
-    r"if|then|do|command|exec|sudo|env)\s+)*"
-    r"(?:[^\s;&|]+/)?apt(?:-get)?(?=\s|$)"
-    r'|^\s*RUN\s+\[\s*"(?:[^"]*/)?apt(?:-get)?"\s*[,\]]'
-    r")",
-    re.IGNORECASE,
-)
-
 # This is deliberately a small, version-controlled adapter contract rather
 # than an inference based on service names or installed software.  It covers
 # the real Compose task whose SSH sidecar has OCI evidence for port 22 but no
@@ -331,40 +279,20 @@ def mirror_image_ref(image: str, mirror_prefix: str, aliases: set[str]) -> str:
     return image
 
 
-def sed_replacement(value: str) -> str:
-    """Escape a literal value for a ``#``-delimited sed replacement."""
-    return re.sub(r"([\\&#])", r"\\\1", value)
-
-
-def sed_pattern(value: str) -> str:
-    """Escape a literal value for a ``#``-delimited POSIX ERE pattern."""
-    return re.sub(r"([\\.^$*+?()\[\]{}|#])", r"\\\1", value)
-
-
 def ordered_source_overrides(
-    source_overrides: dict[str, str], *, reverse: bool = False
+    source_overrides: dict[str, str],
 ) -> tuple[tuple[str, str], ...]:
-    pairs = (
-        ((target, source) for source, target in source_overrides.items())
-        if reverse
-        else source_overrides.items()
+    return tuple(
+        sorted(source_overrides.items(), key=lambda item: len(item[0]), reverse=True)
     )
-    return tuple(sorted(pairs, key=lambda item: len(item[0]), reverse=True))
-
-
-def source_prefix_matches(prefix: str, value: str) -> bool:
-    """Return whether ``prefix`` covers ``value`` as the same URL token."""
-    return bool(re.match(re.escape(prefix) + r"(?=$|[^A-Za-z0-9._~-])", value))
 
 
 def rewrite_source_overrides(
-    source: str, source_overrides: dict[str, str], *, reverse: bool = False
+    source: str, source_overrides: dict[str, str]
 ) -> str:
     """Rewrite configured URL prefixes without matching a longer URL token."""
     rewritten = source
-    for original, replacement in ordered_source_overrides(
-        source_overrides, reverse=reverse
-    ):
+    for original, replacement in ordered_source_overrides(source_overrides):
         pattern = re.compile(
             re.escape(original) + r"(?=$|[^A-Za-z0-9._~-])"
         )
@@ -372,10 +300,8 @@ def rewrite_source_overrides(
     return rewritten
 
 
-def run_heredoc_specs(
-    source: str, *, rewrite_apt_sources: bool
-) -> list[tuple[str, bool, str]]:
-    """Return Dockerfile heredocs and whether their payload is build commands."""
+def run_heredoc_specs(source: str) -> list[tuple[str, bool, str]]:
+    """Return Dockerfile heredocs and whether payloads run build commands."""
     specs: list[tuple[str, bool, str]] = []
     for marker in HEREDOC_MARKER.finditer(source):
         prefix = re.sub(r"\\\r?\n", " ", source[: marker.start()])
@@ -393,59 +319,16 @@ def run_heredoc_specs(
             or PIPE_TO_SHELL.search(declaration[marker.end() - line_start :])
             is not None
         )
-        payload_is_apt_source = (
-            rewrite_apt_sources
-            and APT_SOURCE_FILE_REFERENCE.search(declaration) is not None
-        )
-        if payload_is_apt_source:
-            rewrite_mode = "all"
-        elif payload_is_command:
-            rewrite_mode = "safe"
-        else:
-            rewrite_mode = "none"
+        rewrite_mode = "safe" if payload_is_command else "none"
         specs.append(
             (marker.group("delimiter"), bool(marker.group("strip")), rewrite_mode)
         )
     return specs
 
 
-def run_invokes_apt(source: str) -> bool:
-    """Recognize direct and statically visible shell-wrapped APT commands."""
-    source = re.sub(r"\\\r?\n", " ", source)
-    if APT_COMMAND.search(source):
-        return True
-
-    exec_form = RUN_EXEC_FORM.match(source)
-    if exec_form:
-        try:
-            argv = json.loads(exec_form.group("argv"))
-        except ValueError:
-            argv = None
-        if (
-            isinstance(argv, list)
-            and argv
-            and all(isinstance(argument, str) for argument in argv)
-            and argv[0].rsplit("/", 1)[-1].lower() in {"sh", "bash"}
-        ):
-            for index, argument in enumerate(argv[1:], start=1):
-                if (
-                    argument.startswith("-")
-                    and "c" in argument[1:]
-                    and index + 1 < len(argv)
-                ):
-                    return APT_COMMAND.search(argv[index + 1]) is not None
-
-    return any(
-        APT_COMMAND.search(match.group("command")[1:-1]) is not None
-        for match in SHELL_WRAPPED_COMMAND.finditer(source)
-    )
-
-
 def rewrite_run_source_overrides(
     source: str,
     source_overrides: dict[str, str],
-    *,
-    rewrite_apt_sources: bool,
 ) -> str:
     """Rewrite only unambiguously build-transport URL occurrences in a RUN."""
     if not source_overrides:
@@ -454,7 +337,7 @@ def rewrite_run_source_overrides(
     exec_form = RUN_EXEC_FORM.match(source)
     if exec_form:
         try:
-            argv = json.loads(exec_form.group("argv"))
+            argv = json.loads(re.sub(r"\\\r?\n\s*", "", exec_form.group("argv")))
         except ValueError:
             argv = None
         if (
@@ -485,13 +368,9 @@ def rewrite_run_source_overrides(
         segment = source[segment_start:end]
         probe = re.sub(r"\\\r?\n", " ", segment)
         is_fetch = SOURCE_OVERRIDE_FETCH_COMMAND.search(probe) is not None
-        is_apt_source_write = (
-            rewrite_apt_sources
-            and APT_SOURCE_FILE_REFERENCE.search(probe) is not None
-        )
         output.append(
             rewrite_source_overrides(segment, source_overrides)
-            if is_fetch or is_apt_source_write
+            if is_fetch
             else segment
         )
 
@@ -539,45 +418,38 @@ def rewrite_run_source_overrides(
 def rewrite_dockerfile_run_source_overrides(
     source: str,
     source_overrides: dict[str, str],
-    apt_stages: tuple[bool, ...],
+    *,
+    run_transform: Callable[[str], str] | None = None,
 ) -> str:
     """Apply source overrides to safe contexts in complete RUN instructions."""
-    # TODO: Support configured APT URLs that appear only inside scripts
-    # downloaded or generated while a RUN executes.
-    if not source_overrides:
+    if not source_overrides and run_transform is None:
         return source
 
     output: list[str] = []
     run_lines: list[str] = []
     run_rewrite_modes: list[str] = []
     heredocs: list[tuple[str, bool, str]] = []
-    stage_index = -1
 
     def rewrite_chunk_content(lines: list[str], mode: str) -> str:
         content = "".join(lines)
-        if mode == "all":
-            return rewrite_source_overrides(content, source_overrides)
-        if mode == "safe":
-            return rewrite_run_source_overrides(
-                content,
-                source_overrides,
-                rewrite_apt_sources=(
-                    stage_index < len(apt_stages) and apt_stages[stage_index]
-                ),
-            )
+        if mode == "safe" and source_overrides:
+            return rewrite_run_source_overrides(content, source_overrides)
         return content
 
     def flush_run() -> None:
+        rewritten: list[str] = []
         chunk: list[str] = []
         rewrite_chunk: str | None = None
         for line, rewrite_line in zip(run_lines, run_rewrite_modes, strict=True):
             if rewrite_chunk is not None and rewrite_line != rewrite_chunk:
-                output.append(rewrite_chunk_content(chunk, rewrite_chunk))
+                rewritten.append(rewrite_chunk_content(chunk, rewrite_chunk))
                 chunk.clear()
             rewrite_chunk = rewrite_line
             chunk.append(line)
         if chunk:
-            output.append(rewrite_chunk_content(chunk, rewrite_chunk or "none"))
+            rewritten.append(rewrite_chunk_content(chunk, rewrite_chunk or "none"))
+        content = "".join(rewritten)
+        output.append(run_transform(content) if run_transform else content)
         run_lines.clear()
         run_rewrite_modes.clear()
 
@@ -588,21 +460,12 @@ def rewrite_dockerfile_run_source_overrides(
                 output.append(source_line)
                 continue
             instruction_name = instruction.group("name").upper()
-            if instruction_name == "FROM":
-                stage_index += 1
             if instruction_name != "RUN":
                 output.append(source_line)
                 continue
             run_lines.append(source_line)
             run_rewrite_modes.append("safe")
-            heredocs.extend(
-                run_heredoc_specs(
-                    "".join(run_lines),
-                    rewrite_apt_sources=(
-                        stage_index < len(apt_stages) and apt_stages[stage_index]
-                    ),
-                )
-            )
+            heredocs.extend(run_heredoc_specs("".join(run_lines)))
         else:
             if heredocs:
                 delimiter, strip_tabs, rewrite_mode = heredocs[0]
@@ -618,15 +481,7 @@ def rewrite_dockerfile_run_source_overrides(
             else:
                 run_lines.append(source_line)
                 run_rewrite_modes.append("safe")
-                heredocs.extend(
-                    run_heredoc_specs(
-                        "".join(run_lines),
-                        rewrite_apt_sources=(
-                            stage_index < len(apt_stages)
-                            and apt_stages[stage_index]
-                        ),
-                    )
-                )
+                heredocs.extend(run_heredoc_specs("".join(run_lines)))
 
         if not heredocs and not source_line.rstrip().endswith("\\"):
             flush_run()
@@ -634,270 +489,6 @@ def rewrite_dockerfile_run_source_overrides(
     if run_lines:
         flush_run()
     return "".join(output)
-
-
-def source_override_sed(
-    source_overrides: dict[str, str], *, reverse: bool = False
-) -> str:
-    expressions = []
-    for original, replacement in ordered_source_overrides(
-        source_overrides, reverse=reverse
-    ):
-        expressions.append(
-            f"s#{sed_pattern(original)}([^A-Za-z0-9._~-]|$)#"
-            f"{sed_replacement(replacement)}\\1#g"
-        )
-    return ";".join(expressions)
-
-
-def apt_mirror_command(
-    apt_mirror: str,
-    *,
-    stage_uses_apt: bool = False,
-    source_overrides: dict[str, str] | None = None,
-) -> str | None:
-    if not apt_mirror or not stage_uses_apt:
-        return None
-    mirror = sed_replacement(apt_mirror.rstrip("/"))
-    source_overrides = source_overrides or {}
-    # Keep an exact copy of the stage's authored source files. The matching
-    # cleanup instruction restores untouched files byte-for-byte and removes
-    # only this adapter's transport rewrite from files the task changed.
-    replacements = (
-        f"s#https?://(archive|security|ports)\\.ubuntu\\.com/ubuntu/?#"
-        f"{mirror}/ubuntu/#g;"
-        f"s#https?://(deb|security)\\.debian\\.org/debian-security/?#"
-        f"{mirror}/debian-security/#g;"
-        f"s#https?://deb\\.debian\\.org/debian/?#{mirror}/debian/#g"
-    )
-    override_replacements = source_override_sed(source_overrides)
-    if override_replacements:
-        replacements = f"{replacements};{override_replacements}"
-    command = (
-        "set -eu; "
-        f"state={shlex.quote(APT_MIRROR_STATE_DIR)}; "
-        'rm -rf "$state"; '
-        'mkdir -p "$state/original" "$state/adapted"; '
-        "for path in sources.list sources.list.d; do "
-        'source_path="/etc/apt/$path"; '
-        'if [ -e "$source_path" ] || [ -L "$source_path" ]; then '
-        'cp -a "$source_path" "$state/original/$path"; '
-        "fi; "
-        "done; "
-        "for file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list "
-        "/etc/apt/sources.list.d/*.sources; do "
-        '[ -f "$file" ] || continue; '
-        f"sed -E -i {shlex.quote(replacements)} \"$file\"; "
-        "done; "
-        "for path in sources.list sources.list.d; do "
-        'source_path="/etc/apt/$path"; '
-        'if [ -e "$source_path" ] || [ -L "$source_path" ]; then '
-        'cp -a "$source_path" "$state/adapted/$path"; '
-        "fi; "
-        "done"
-    )
-    return f"RUN {json.dumps(['/bin/sh', '-c', command])}"
-
-
-def apt_mirror_cleanup_command(
-    apt_mirror: str, source_overrides: dict[str, str] | None = None
-) -> str:
-    """Restore task-visible APT sources after a mirrored build stage."""
-    mirror = apt_mirror.rstrip("/")
-    mirror_pattern = sed_pattern(mirror)
-    source_overrides = source_overrides or {}
-    target_format = (
-        "$(SOURCESENTRY)~$(IDENTIFIER)~$(RELEASE)~$(COMPONENT)~"
-        "$(ARCHITECTURE)~$(CREATED_BY)~$(METAKEY)|$(COMPONENT)|$(FILENAME)"
-    )
-    replacements = (
-        f"s#{mirror_pattern}/ubuntu/?#http://archive.ubuntu.com/ubuntu/#g;"
-        f"s#{mirror_pattern}/debian-security/?#"
-        "http://security.debian.org/debian-security/#g;"
-        f"s#{mirror_pattern}/debian/?#http://deb.debian.org/debian/#g"
-    )
-    override_replacements = source_override_sed(source_overrides, reverse=True)
-    if override_replacements:
-        replacements = f"{replacements};{override_replacements}"
-    command = (
-        "set -eu; "
-        f"state={shlex.quote(APT_MIRROR_STATE_DIR)}; "
-        '[ -d "$state" ] || exit 0; '
-        f"target_format={shlex.quote(target_format)}; "
-        "if command -v apt-get >/dev/null 2>&1; then "
-        'apt-get indextargets --no-release-info --format "$target_format" '
-        '> "$state/adapted-targets" 2>/dev/null || :; '
-        "fi; "
-        "for file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list "
-        "/etc/apt/sources.list.d/*.sources; do "
-        '[ -f "$file" ] || continue; '
-        'relative="${file#/etc/apt/}"; '
-        'adapted="$state/adapted/$relative"; '
-        'original="$state/original/$relative"; '
-        'if [ -f "$adapted" ] && [ -e "$original" ] '
-        '&& cmp -s "$file" "$adapted"; then '
-        'rm -f "$file"; cp -a "$original" "$file"; '
-        "else "
-        'if [ -f "$adapted" ] && [ -e "$original" ] '
-        "&& command -v awk >/dev/null 2>&1; then "
-        f"awk {shlex.quote(APT_SOURCE_RESTORE_AWK)} "
-        '"$original" "$adapted" "$file" > "$state/merged-source"; '
-        'cat "$state/merged-source" > "$file"; '
-        "fi; "
-        f"sed -E -i {shlex.quote(replacements)} \"$file\"; "
-        "fi; "
-        "done; "
-        'if [ -s "$state/adapted-targets" ] '
-        "&& command -v apt-get >/dev/null 2>&1 "
-        "&& command -v sort >/dev/null 2>&1 "
-        "&& command -v join >/dev/null 2>&1; then "
-        'apt-get indextargets --no-release-info --format "$target_format" '
-        '> "$state/restored-targets" 2>/dev/null || :; '
-        'sort "$state/adapted-targets" -o "$state/adapted-targets"; '
-        'sort "$state/restored-targets" -o "$state/restored-targets"; '
-        'join -t "|" "$state/adapted-targets" "$state/restored-targets" '
-        '> "$state/target-moves" || :; '
-        'while IFS="|" read -r key source_component source_path '
-        "target_component target_path; do "
-        '[ "$source_path" = "$target_path" ] && continue; '
-        'for candidate in "$source_path" "$source_path".*; do '
-        '[ -f "$candidate" ] || continue; '
-        'suffix=${candidate#"$source_path"}; '
-        'cp -a "$candidate" "$target_path$suffix"; '
-        "done; "
-        'source_marker=_${source_component}_; '
-        'target_marker=_${target_component}_; '
-        'source_dist=${source_path%%"$source_marker"*}; '
-        'target_dist=${target_path%%"$target_marker"*}; '
-        "for release_file in InRelease Release Release.gpg; do "
-        '[ -f "${source_dist}_${release_file}" ] '
-        '&& cp -a "${source_dist}_${release_file}" '
-        '"${target_dist}_${release_file}"; '
-        "done; "
-        'done < "$state/target-moves"; '
-        'while IFS="|" read -r key source_component source_path '
-        "target_component target_path; do "
-        '[ "$source_path" = "$target_path" ] && continue; '
-        'rm -f "$source_path" "$source_path".*; '
-        'source_marker=_${source_component}_; '
-        'source_dist=${source_path%%"$source_marker"*}; '
-        'rm -f "${source_dist}_InRelease" "${source_dist}_Release" '
-        '"${source_dist}_Release.gpg"; '
-        'done < "$state/target-moves"; '
-        "fi; "
-        'rm -rf "$state"'
-    )
-    return f"RUN {json.dumps(['/bin/sh', '-c', command])}"
-
-
-def append_apt_mirror_cleanup(
-    output: list[str],
-    apt_mirror: str,
-    current_user_instruction: str | None,
-    source_overrides: dict[str, str],
-) -> None:
-    """Append cleanup under root, then restore an explicit task USER."""
-    restore_user = current_user_instruction
-    if restore_user is not None:
-        user_value = restore_user.split(None, 1)[1].split(":", 1)[0].lower()
-        if user_value not in {"root", "0"}:
-            output.append("USER root")
-        else:
-            restore_user = None
-    output.append(apt_mirror_cleanup_command(apt_mirror, source_overrides))
-    if restore_user is not None:
-        output.append(restore_user)
-
-
-def append_apt_mirror_refresh(
-    output: list[str],
-    apt_mirror: str,
-    current_user_instruction: str | None,
-    source_overrides: dict[str, str],
-) -> None:
-    """Restore task sources, snapshot them again, and reapply build mirrors."""
-    restore_user = current_user_instruction
-    if restore_user is not None:
-        user_value = restore_user.split(None, 1)[1].split(":", 1)[0].lower()
-        if user_value not in {"root", "0"}:
-            output.append("USER root")
-        else:
-            restore_user = None
-    output.append(apt_mirror_cleanup_command(apt_mirror, source_overrides))
-    setup = apt_mirror_command(
-        apt_mirror,
-        stage_uses_apt=True,
-        source_overrides=source_overrides,
-    )
-    if setup is None:
-        raise AssertionError("APT mirror refresh requires a configured mirror")
-    output.append(setup)
-    if restore_user is not None:
-        output.append(restore_user)
-
-
-def dockerfile_apt_stages(source: str) -> tuple[bool, ...]:
-    """Identify Dockerfile stages that actually invoke apt or apt-get."""
-    stages: list[bool] = []
-    active_instruction: str | None = None
-    instruction_lines: list[str] = []
-    heredocs: list[tuple[str, bool, str]] = []
-    for source_line in source.splitlines():
-        if heredocs:
-            if (
-                stages
-                and active_instruction == "RUN"
-                and heredocs[0][2] == "safe"
-                and run_invokes_apt(source_line)
-            ):
-                stages[-1] = True
-            delimiter, strip_tabs, _rewrite_mode = heredocs[0]
-            candidate = source_line.lstrip("\t") if strip_tabs else source_line
-            if candidate == delimiter:
-                heredocs.pop(0)
-                if not heredocs:
-                    active_instruction = None
-                    instruction_lines.clear()
-            continue
-
-        instruction = None
-        if active_instruction is None:
-            instruction = DOCKERFILE_INSTRUCTION.match(source_line)
-            if instruction:
-                active_instruction = instruction.group("name").upper()
-                instruction_lines = [source_line]
-            if active_instruction == "FROM":
-                stages.append(False)
-        else:
-            instruction_lines.append(source_line)
-        if (
-            stages
-            and active_instruction == "RUN"
-            and run_invokes_apt("\n".join(instruction_lines))
-        ):
-            stages[-1] = True
-
-        if active_instruction in {"RUN", "COPY", "ADD"}:
-            if active_instruction == "RUN":
-                heredocs.extend(
-                    run_heredoc_specs(
-                        "\n".join(instruction_lines),
-                        rewrite_apt_sources=False,
-                    )
-                )
-            else:
-                heredocs.extend(
-                    (
-                        item.group("delimiter"),
-                        bool(item.group("strip")),
-                        "none",
-                    )
-                    for item in HEREDOC_MARKER.finditer(source_line)
-                )
-        if not heredocs and not source_line.rstrip().endswith("\\"):
-            active_instruction = None
-            instruction_lines.clear()
-    return tuple(stages)
 
 
 def _validate_source_url(
@@ -953,7 +544,6 @@ def parse_apt_source_overrides(
     if not isinstance(loaded, dict):
         raise TypeError("APT source overrides must be a JSON object")
     overrides: dict[str, str] = {}
-    reverse_targets: dict[str, str] = {}
     for original, replacement in loaded.items():
         if not isinstance(original, str) or not isinstance(replacement, str):
             raise TypeError("APT source override keys and values must be strings")
@@ -969,40 +559,131 @@ def parse_apt_source_overrides(
             raise ValueError(
                 f"duplicate normalized APT source override: {normalized_original}"
             )
-        previous_origin = reverse_targets.get(normalized_replacement)
-        if previous_origin is not None:
-            raise ValueError(
-                "APT source override replacements must be unique for cleanup: "
-                f"{normalized_replacement} maps both {previous_origin} and "
-                f"{normalized_original}"
-            )
         overrides[normalized_original] = normalized_replacement
-        reverse_targets[normalized_replacement] = normalized_original
-    overlap = set(overrides).intersection(reverse_targets)
-    if overlap:
-        raise ValueError(
-            "APT source override origins and replacements must be disjoint: "
-            + ", ".join(sorted(overlap))
-        )
-    cross_prefixes = sorted(
-        {
-            (origin, replacement)
-            for origin in overrides
-            for replacement in reverse_targets
-            if source_prefix_matches(origin, replacement)
-            or source_prefix_matches(replacement, origin)
-        }
-    )
-    if cross_prefixes:
-        rendered = ", ".join(
-            f"{origin} <> {replacement}"
-            for origin, replacement in cross_prefixes
-        )
-        raise ValueError(
-            "APT source override origins and replacements must not overlap "
-            f"by URL prefix: {rendered}"
-        )
     return overrides
+
+
+def apt_runtime_source_overrides(
+    apt_mirror: str, source_overrides: dict[str, str]
+) -> dict[str, str]:
+    """Combine the existing distro mirror routes with explicit URL overrides."""
+    mirror = apt_mirror.rstrip("/")
+    combined = {
+        "http://archive.ubuntu.com/ubuntu": f"{mirror}/ubuntu",
+        "https://archive.ubuntu.com/ubuntu": f"{mirror}/ubuntu",
+        "http://security.ubuntu.com/ubuntu": f"{mirror}/ubuntu",
+        "https://security.ubuntu.com/ubuntu": f"{mirror}/ubuntu",
+        "http://ports.ubuntu.com/ubuntu": f"{mirror}/ubuntu",
+        "https://ports.ubuntu.com/ubuntu": f"{mirror}/ubuntu",
+        "http://deb.debian.org/debian": f"{mirror}/debian",
+        "https://deb.debian.org/debian": f"{mirror}/debian",
+        "http://deb.debian.org/debian-security": f"{mirror}/debian-security",
+        "https://deb.debian.org/debian-security": f"{mirror}/debian-security",
+        "http://security.debian.org/debian-security": (
+            f"{mirror}/debian-security"
+        ),
+        "https://security.debian.org/debian-security": (
+            f"{mirror}/debian-security"
+        ),
+    }
+    combined.update(source_overrides)
+    return combined
+
+
+def apt_source_map_content(source_overrides: dict[str, str]) -> str:
+    """Render the runtime map in longest-prefix order for the AWK helper."""
+    return "".join(
+        f"{origin}\t{replacement}\n"
+        for origin, replacement in ordered_source_overrides(source_overrides)
+    )
+
+
+def apt_source_map_secret_id(source_overrides: dict[str, str]) -> str:
+    digest = hashlib.sha256(
+        apt_source_map_content(source_overrides).encode()
+    ).hexdigest()
+    return f"{APT_SOURCE_MAP_SECRET_PREFIX}-{digest[:16]}"
+
+
+def apt_runtime_asset_digest() -> str:
+    """Hash runtime helpers for BuildKit cache invalidation only.
+
+    This digest must never feed task image identity. Identity must come only
+    from the original static task environment; violating that invariant is a
+    P0 bug.
+    """
+    digest = hashlib.sha256()
+    for name in APT_RUNTIME_ASSET_NAMES:
+        path = APT_RUNTIME_ASSET_DIR / name
+        try:
+            content = path.read_bytes()
+        except OSError as exc:
+            raise RuntimeError(
+                f"OpenSandbox APT runtime asset is unavailable: {path}"
+            ) from exc
+        digest.update(name.encode())
+        digest.update(b"\0")
+        digest.update(str(len(content)).encode())
+        digest.update(b"\0")
+        digest.update(content)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def apt_runtime_secret_ids() -> dict[str, str]:
+    """Return content-addressed IDs so secret changes invalidate RUN cache."""
+    suffix = apt_runtime_asset_digest()
+    return {
+        "wrapper": f"opensandbox-apt-wrapper-{suffix}",
+        "rewriter": f"opensandbox-apt-source-rewriter-{suffix}",
+        "runner": f"opensandbox-run-with-apt-path-{suffix}",
+    }
+
+
+def apt_runtime_mounts(source_overrides: dict[str, str]) -> str:
+    """Render content-addressed PATH-wrapper assets for shell-based RUNs."""
+    secret_ids = apt_runtime_secret_ids()
+    mounts = [
+        f"--mount=type=tmpfs,target={APT_RUNTIME_ROOT}/shadow",
+        (
+            f"--mount=type=secret,id={secret_ids['rewriter']},"
+            f"target={APT_RUNTIME_ROOT}/source-rewriter.awk,mode=0444,required=true"
+        ),
+        (
+            f"--mount=type=secret,id={apt_source_map_secret_id(source_overrides)},"
+            f"target={APT_RUNTIME_ROOT}/source-map,mode=0444,required=true"
+        ),
+        (
+            f"--mount=type=secret,id={secret_ids['runner']},"
+            f"target={APT_RUNTIME_ROOT}/run-with-apt-path,mode=0555,required=true"
+        ),
+    ]
+    mounts.extend(
+        f"--mount=type=secret,id={secret_ids['wrapper']},"
+        f"target={APT_RUNTIME_ROOT}/bin/{command},"
+        "mode=0555,required=true"
+        for command in ("apt", "apt-get")
+    )
+    return " ".join(mounts)
+
+
+def materialize_apt_runtime_assets(
+    destination: Path, source_overrides: dict[str, str]
+) -> dict[str, Path]:
+    """Write host-side BuildKit secrets; none are included in image layers."""
+    destination.mkdir(parents=True, exist_ok=True)
+    assets = {
+        name: APT_RUNTIME_ASSET_DIR / name for name in APT_RUNTIME_ASSET_NAMES
+    }
+    secret_ids = apt_runtime_secret_ids()
+    map_path = destination / "source-map.tsv"
+    map_path.write_text(apt_source_map_content(source_overrides), encoding="utf-8")
+    return {
+        secret_ids["wrapper"]: assets["apt-wrapper.sh"],
+        secret_ids["rewriter"]: assets["source-rewriter.awk"],
+        secret_ids["runner"]: assets["run-with-apt-path.sh"],
+        apt_source_map_secret_id(source_overrides): map_path,
+    }
 
 
 def package_source_build_args(
@@ -1227,6 +908,34 @@ def materialize_package_source_context(
     return destination, tuple(sorted(str(path) for path in rewritten))
 
 
+def inject_apt_runtime_into_run(source_line: str, mounts: str) -> str:
+    """Give one RUN the shared ephemeral wrapper PATH without inspecting it."""
+    if not mounts:
+        return source_line
+    if RUN_EXEC_FORM.match(source_line):
+        return source_line
+
+    run_prefix = RUN_SHELL_PREFIX.match(source_line)
+    if run_prefix is None:
+        return source_line
+    command = source_line[run_prefix.end() :]
+    if command.lstrip().startswith("<<"):
+        command = f"{APT_RUNTIME_ROOT}/run-with-apt-path {command}"
+    else:
+        command = f"export PATH={APT_RUNTIME_ROOT}/bin:$PATH; {command}"
+    return f"{source_line[:run_prefix.end()]}{mounts} {command}"
+
+
+def inject_run_mount(source_line: str, mount: str) -> str:
+    """Add one RUN option without changing shell- or exec-form command content."""
+    if not mount:
+        return source_line
+    run_prefix = RUN_SHELL_PREFIX.match(source_line)
+    if run_prefix is None:
+        return source_line
+    return f"{source_line[:run_prefix.end()]}{mount} {source_line[run_prefix.end():]}"
+
+
 def render_build_dockerfile(
     source: str,
     *,
@@ -1240,44 +949,40 @@ def render_build_dockerfile(
 ) -> str:
     package_build_args = package_build_args or {}
     apt_source_overrides = apt_source_overrides or {}
-    apt_stages = dockerfile_apt_stages(source)
+    runtime_source_overrides = apt_runtime_source_overrides(
+        apt_mirror, apt_source_overrides
+    )
+    apt_mounts = apt_runtime_mounts(runtime_source_overrides)
+    git_mount = ""
+    if github_mirror_config_mount_id:
+        git_mount = (
+            "--mount=type=secret,id="
+            f"{github_mirror_config_mount_id},target=/etc/gitconfig,"
+            "mode=0444,required=true"
+        )
+
+    def inject_run_runtime(instruction: str) -> str:
+        with_git_mount = inject_run_mount(instruction, git_mount)
+        return inject_apt_runtime_into_run(with_git_mount, apt_mounts)
+
     source = rewrite_dockerfile_run_source_overrides(
         source,
         apt_source_overrides,
-        apt_stages,
+        run_transform=inject_run_runtime,
     )
     output: list[str] = []
     aliases: set[str] = set()
-    stage_index = -1
-    stage_mirror_active = False
-    current_user_instruction: str | None = None
     active_instruction: str | None = None
-    active_apt_source_input = False
     heredocs: list[tuple[str, bool]] = []
     for source_line in source.splitlines():
         if heredocs:
-            if (
-                active_instruction in {"RUN", "COPY", "ADD"}
-                and APT_SOURCE_FILE_REFERENCE.search(source_line)
-            ):
-                active_apt_source_input = True
             delimiter, strip_tabs = heredocs[0]
             candidate = source_line.lstrip("\t") if strip_tabs else source_line
+            output.append(source_line)
             if candidate == delimiter:
-                output.append(source_line)
                 heredocs.pop(0)
                 if not heredocs:
-                    if active_apt_source_input and stage_mirror_active:
-                        append_apt_mirror_refresh(
-                            output,
-                            apt_mirror,
-                            current_user_instruction,
-                            apt_source_overrides,
-                        )
                     active_instruction = None
-                    active_apt_source_input = False
-            else:
-                output.append(source_line)
             continue
 
         instruction = None
@@ -1285,13 +990,6 @@ def render_build_dockerfile(
             instruction = DOCKERFILE_INSTRUCTION.match(source_line)
             if instruction:
                 active_instruction = instruction.group("name").upper()
-                active_apt_source_input = False
-
-        if (
-            active_instruction in {"RUN", "COPY", "ADD"}
-            and APT_SOURCE_FILE_REFERENCE.search(source_line)
-        ):
-            active_apt_source_input = True
 
         line = source_line
         line = rewrite_package_source_urls(
@@ -1299,29 +997,8 @@ def render_build_dockerfile(
             rustup_init_url=rustup_init_url,
             pytorch_index_url=pytorch_index_url,
         )
-        if active_instruction == "RUN" and github_mirror_config_mount_id:
-            line = re.sub(
-                r"^(\s*RUN\s+)",
-                (
-                    r"\1--mount=type=secret,id="
-                    f"{github_mirror_config_mount_id},target=/etc/gitconfig,mode=0444,required=true "
-                ),
-                line,
-                count=1,
-                flags=re.IGNORECASE,
-            )
         match = FROM_LINE.match(line)
         if match:
-            if stage_mirror_active:
-                append_apt_mirror_cleanup(
-                    output,
-                    apt_mirror,
-                    current_user_instruction,
-                    apt_source_overrides,
-                )
-            stage_index += 1
-            stage_mirror_active = False
-            current_user_instruction = None
             source_image = match.group("image")
             mirrored_image = mirror_image_ref(
                 source_image, dockerhub_mirror_prefix, aliases
@@ -1337,20 +1014,8 @@ def render_build_dockerfile(
             alias_match = AS_ALIAS.search(match.group("suffix"))
             if alias_match:
                 aliases.add(alias_match.group("alias"))
-            command = apt_mirror_command(
-                apt_mirror,
-                stage_uses_apt=(
-                    stage_index < len(apt_stages) and apt_stages[stage_index]
-                ),
-                source_overrides=apt_source_overrides,
-            )
-            if command:
-                output.append(command)
-                stage_mirror_active = True
         else:
             output.append(line)
-            if instruction and active_instruction == "USER":
-                current_user_instruction = line
 
         if active_instruction in {"RUN", "COPY", "ADD"}:
             heredocs.extend(
@@ -1358,22 +1023,7 @@ def render_build_dockerfile(
                 for item in HEREDOC_MARKER.finditer(source_line)
             )
         if not heredocs and not source_line.rstrip().endswith("\\"):
-            if active_apt_source_input and stage_mirror_active:
-                append_apt_mirror_refresh(
-                    output,
-                    apt_mirror,
-                    current_user_instruction,
-                    apt_source_overrides,
-                )
             active_instruction = None
-            active_apt_source_input = False
-    if stage_mirror_active:
-        append_apt_mirror_cleanup(
-            output,
-            apt_mirror,
-            current_user_instruction,
-            apt_source_overrides,
-        )
     return "\n".join(output) + "\n"
 
 
@@ -1904,21 +1554,16 @@ def atomic_write_json(path: Path, payload: dict) -> None:
 
 
 def image_identity(environment_dir: Path, *, docker_image: str | None = None) -> str:
-    """Return the Harbor benchmark framework's static environment identity."""
+    """Return identity derived only from the original static task environment.
+
+    Renderer output, runtime assets, mirrors, and every other build-time
+    mutation are forbidden identity inputs. Any such dependency is a P0 bug.
+    """
     return environment_content_hash(
         environment_dir,
         docker_image=docker_image,
         truncate=64,
     )
-
-
-def build_image_identity(environment_dir: Path) -> str:
-    """Namespace a task build hash by the generated-Dockerfile contract."""
-    task_identity = image_identity(environment_dir)
-    payload = (
-        f"opensandbox-build-renderer\0{BUILD_RENDERER_VERSION}\0{task_identity}"
-    ).encode()
-    return hashlib.sha256(payload).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -2310,9 +1955,9 @@ def _cached_bundle_matches_content(
         if not isinstance(image, dict):
             return False
         if service.build is not None:
-            expected_hash = "sha256:" + build_image_identity(
-                bundle.environment_dir
-            )
+            # P0 invariant: cache identity comes only from the original static
+            # task environment, never from rendered or runtime-mutated inputs.
+            expected_hash = "sha256:" + image_identity(bundle.environment_dir)
         else:
             expected_hash = "sha256:" + image_identity(
                 bundle.environment_dir,
@@ -2377,10 +2022,9 @@ def _service_image_inputs(
             **service.build.args,
             **explicit_build_args,
         }
-        # Dynamic build args and source/proxy values remain deployment
-        # adaptations, but a renderer contract change must never reuse an
-        # image produced before that contract existed.
-        identity = build_image_identity(bundle.environment_dir)
+        # P0 invariant: image identity comes only from the original static task
+        # environment. Including renderer/runtime/mirror mutations is a P0 bug.
+        identity = image_identity(bundle.environment_dir)
         return identity, declared_build_args, effective_build_args, None, None
     if not service.source_image:
         raise ValueError(f"service {service.name!r} has no build or source image")
@@ -2535,6 +2179,12 @@ def _prepare_service_image(
                     github_mirror_config_path.write_text(
                         github_mirror_config, encoding="utf-8"
                     )
+                apt_runtime_secrets = materialize_apt_runtime_assets(
+                    temporary / "apt-runtime",
+                    apt_runtime_source_overrides(
+                        args.apt_mirror, args.apt_source_overrides
+                    ),
+                )
                 rendered_dockerfile.write_text(
                     render_build_dockerfile(
                         dockerfile_source,
@@ -2568,11 +2218,18 @@ def _prepare_service_image(
                     target=target_stage,
                     no_cache=getattr(args, "no_cache", False),
                     build_network=getattr(args, "build_network", "default"),
-                    secret_files=(
-                        {GITHUB_MIRROR_CONFIG_MOUNT_ID: github_mirror_config_path}
-                        if github_mirror_config_path is not None
-                        else None
-                    ),
+                    secret_files={
+                        **apt_runtime_secrets,
+                        **(
+                            {
+                                GITHUB_MIRROR_CONFIG_MOUNT_ID: (
+                                    github_mirror_config_path
+                                )
+                            }
+                            if github_mirror_config_path is not None
+                            else {}
+                        ),
+                    },
                 )
                 local_image_config = oci_archive_image_config(archive_path)
                 log(f"publishing service={service.name}: {tag_ref}")

--- a/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
+++ b/Agents/utils/common/Harbor/tests/test_opensandbox_image_manager.py
@@ -2,6 +2,7 @@ import hashlib
 import io
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -16,7 +17,8 @@ HARBOR_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(HARBOR_DIR))
 
 from opensandbox_image_manager import (
-    APT_SOURCE_RESTORE_AWK,
+    APT_RUNTIME_ASSET_DIR,
+    APT_RUNTIME_ASSET_NAMES,
     DOCKER_CONFIG,
     DOCKER_LAYER_GZIP,
     DOCKER_MANIFEST,
@@ -25,12 +27,18 @@ from opensandbox_image_manager import (
     RegistryTarget,
     SkopeoPublisher,
     _compose_runtime,
+    _service_image_inputs,
     _service_manifest,
     apt_404_requires_cache_refresh,
-    build_image_identity,
+    apt_runtime_asset_digest,
+    apt_runtime_mounts,
+    apt_runtime_secret_ids,
+    apt_runtime_source_overrides,
+    apt_source_map_content,
     check_task_repository,
     environment_content_hash,
     github_mirror_config_content,
+    materialize_apt_runtime_assets,
     mirror_image_ref,
     normalize_oci_image_config,
     oci_archive_image_config,
@@ -44,7 +52,6 @@ from opensandbox_image_manager import (
     render_build_dockerfile,
     run_build,
     schema2_manifest,
-    source_override_sed,
     validate_github_mirror_url,
 )
 
@@ -57,17 +64,6 @@ def add_tar_bytes(archive: tarfile.TarFile, name: str, data: bytes) -> None:
     info = tarfile.TarInfo(name)
     info.size = len(data)
     archive.addfile(info, io.BytesIO(data))
-
-
-def injected_shell_runs(rendered: str) -> list[tuple[str, str]]:
-    result: list[tuple[str, str]] = []
-    for line in rendered.splitlines():
-        if not line.startswith("RUN ["):
-            continue
-        argv = json.loads(line.removeprefix("RUN "))
-        if argv[:2] == ["/bin/sh", "-c"]:
-            result.append((line, argv[2]))
-    return result
 
 
 class OpenSandboxImageManagerTest(unittest.TestCase):
@@ -251,17 +247,70 @@ class OpenSandboxImageManagerTest(unittest.TestCase):
             (environment / "payload.txt").write_text("changed", encoding="utf-8")
             self.assertNotEqual(first, environment_content_hash(environment))
 
-    def test_build_image_identity_includes_renderer_version(self) -> None:
+    def test_build_service_identity_excludes_renderer_and_runtime_assets(
+        self,
+    ) -> None:
+        # P0 regression guard: only the original static task environment may
+        # influence image identity; renderer/runtime mutations must not.
         with tempfile.TemporaryDirectory() as tmp:
-            environment = self.make_task(Path(tmp)) / "environment"
-            first = build_image_identity(environment)
-            with patch(
-                "opensandbox_image_manager.BUILD_RENDERER_VERSION",
-                "next-renderer-contract",
-            ):
-                second = build_image_identity(environment)
+            task = self.make_task(Path(tmp))
+            environment = task / "environment"
+            from compose_bundle import resolve_bundle_spec
 
-        self.assertNotEqual(first, second)
+            bundle = resolve_bundle_spec(task)
+            service = bundle.services["main"]
+            expected = environment_content_hash(environment, truncate=64)
+
+            def service_identity() -> str:
+                return _service_image_inputs(
+                    service,
+                    bundle=bundle,
+                    dockerhub_mirror_prefix="",
+                    package_build_args={},
+                    platform="linux/amd64",
+                    explicit_build_args={},
+                    dry_run=True,
+                )[0]
+
+            first = service_identity()
+            with patch(
+                "opensandbox_image_manager.apt_runtime_asset_digest",
+                return_value="changed-runtime-assets",
+            ):
+                second = service_identity()
+            with patch(
+                "opensandbox_image_manager.render_build_dockerfile",
+                return_value="different generated Dockerfile",
+            ):
+                third = service_identity()
+
+        self.assertEqual(first, expected)
+        self.assertEqual(first, second)
+        self.assertEqual(first, third)
+
+    def test_runtime_asset_content_changes_digest_mounts_and_secret_ids(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            asset_dir = Path(tmp)
+            for name in APT_RUNTIME_ASSET_NAMES:
+                (asset_dir / name).write_text(f"{name}:first\n", encoding="utf-8")
+            with patch(
+                "opensandbox_image_manager.APT_RUNTIME_ASSET_DIR", asset_dir
+            ):
+                first_digest = apt_runtime_asset_digest()
+                first_mounts = apt_runtime_mounts({})
+                first_secret_ids = apt_runtime_secret_ids()
+                (asset_dir / "apt-wrapper.sh").write_text(
+                    "apt-wrapper.sh:second\n", encoding="utf-8"
+                )
+                second_digest = apt_runtime_asset_digest()
+                second_mounts = apt_runtime_mounts({})
+                second_secret_ids = apt_runtime_secret_ids()
+
+        self.assertNotEqual(first_digest, second_digest)
+        self.assertNotEqual(first_mounts, second_mounts)
+        self.assertNotEqual(first_secret_ids, second_secret_ids)
 
     def test_oci_config_normalizes_process_ports_and_healthcheck(self) -> None:
         config = normalize_oci_image_config(
@@ -486,12 +535,11 @@ networks:
         )
         self.assertTrue(manifest["requirements"]["multi_service"])
 
-    def test_render_uses_domestic_sources_and_preserves_stage_alias(self) -> None:
+    def test_render_uses_runtime_path_and_preserves_stage_alias(self) -> None:
         rendered = render_build_dockerfile(
             (
                 "FROM ubuntu:24.04 AS builder\n"
-                "RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg "
-                "&& apt-get update\n"
+                "RUN apt-get update\n"
                 "FROM builder\n"
             ),
             dockerhub_mirror_prefix="m.daocloud.io/docker.io",
@@ -501,28 +549,22 @@ networks:
                 "PIP_INDEX_URL": "https://pypi.tuna.tsinghua.edu.cn/simple",
             },
         )
-        injected = injected_shell_runs(rendered)
 
         self.assertIn(
             "FROM m.daocloud.io/docker.io/library/ubuntu:24.04 AS builder",
             rendered,
         )
-        self.assertEqual(len(injected), 2)
-        self.assertIn("mirrors.tuna.tsinghua.edu.cn/ubuntu/", injected[0][1])
-        self.assertIn("original", injected[0][1])
-        self.assertIn("adapted", injected[0][1])
-        self.assertIn("archive.ubuntu.com/ubuntu/", injected[1][1])
+        self.assertIn(
+            "export PATH=/run/opensandbox-apt/bin:$PATH; apt-get update",
+            rendered,
+        )
+        self.assertIn("target=/run/opensandbox-apt/bin/apt-get", rendered)
+        self.assertNotIn("target=/usr/bin/apt-get", rendered)
+        self.assertNotIn("type=bind", rendered)
         self.assertIn("FROM builder\n", rendered)
         self.assertNotIn("docker.io/library/builder", rendered)
-        task_run = next(
-            line for line in rendered.splitlines() if line.startswith("RUN curl")
-        )
-        self.assertIn("https://download.docker.com/linux/ubuntu/gpg", task_run)
-        self.assertLess(
-            rendered.index(injected[1][0]), rendered.index("FROM builder")
-        )
-        self.assertIn("ARG NPM_CONFIG_REGISTRY", rendered)
-        self.assertIn("ARG PIP_INDEX_URL", rendered)
+        self.assertEqual(rendered.count("ARG NPM_CONFIG_REGISTRY"), 2)
+        self.assertEqual(rendered.count("ARG PIP_INDEX_URL"), 2)
 
     def test_http_pip_index_is_explicitly_trusted(self) -> None:
         http_args = package_source_build_args(
@@ -594,7 +636,7 @@ networks:
             ):
                 package_source_build_args(Namespace(**{field: value}), "host")
 
-    def test_github_mirror_uses_transient_secret_mount_for_submodules(self) -> None:
+    def test_github_mirror_mount_remains_on_shell_form_run(self) -> None:
         mirror = validate_github_mirror_url(
             "http://github-mirror.internal:8080/repos", "host"
         )
@@ -612,7 +654,52 @@ networks:
         self.assertEqual(
             rendered.count("id=opensandbox-github-mirror-gitconfig"), 1
         )
+        self.assertIn("target=/etc/gitconfig,mode=0444,required=true", rendered)
+        self.assertIn("target=/run/opensandbox-apt/bin/apt-get", rendered)
         self.assertNotIn(mirror, rendered)
+
+    def test_github_mirror_mount_preserves_exec_form_without_apt_runtime(
+        self,
+    ) -> None:
+        source = (
+            "FROM ubuntu:24.04\n"
+            'RUN ["git", "clone", "https://github.com/foo/bar.git"]\n'
+        )
+        rendered = render_build_dockerfile(
+            source,
+            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
+            apt_mirror="https://mirrors.tuna.tsinghua.edu.cn",
+            github_mirror_config_mount_id="opensandbox-github-mirror-gitconfig",
+        )
+
+        self.assertIn(
+            "RUN --mount=type=secret,"
+            "id=opensandbox-github-mirror-gitconfig,"
+            "target=/etc/gitconfig,mode=0444,required=true "
+            '["git", "clone", "https://github.com/foo/bar.git"]',
+            rendered,
+        )
+        self.assertNotIn("run-with-apt-path", rendered)
+        self.assertNotIn("/run/opensandbox-apt/bin/apt", rendered)
+        self.assertNotIn("target=/run/opensandbox-apt/shadow", rendered)
+
+    def test_exec_form_has_no_gitconfig_mount_when_mirror_is_unconfigured(
+        self,
+    ) -> None:
+        rendered = render_build_dockerfile(
+            (
+                "FROM ubuntu:24.04\n"
+                'RUN ["git", "clone", "https://github.com/foo/bar.git"]\n'
+            ),
+            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
+            apt_mirror="https://mirrors.tuna.tsinghua.edu.cn",
+        )
+
+        self.assertIn(
+            'RUN ["git", "clone", "https://github.com/foo/bar.git"]',
+            rendered,
+        )
+        self.assertNotIn("/etc/gitconfig", rendered)
 
     def test_dockerhub_mirror_matches_registry_component_exactly(self) -> None:
         mirror = "mirror.example/docker.io"
@@ -640,16 +727,45 @@ networks:
                 "https://user:password@mirror.example.internal/github", "host"
             )
 
-    def test_apt_source_overrides_accept_provider_neutral_url_mappings(self) -> None:
+    def rewrite_apt_source(
+        self, source: str, source_kind: str, overrides: dict[str, str]
+    ) -> tuple[str, str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / f"source.{source_kind}"
+            map_path = root / "map.tsv"
+            seen_path = root / "seen"
+            source_path.write_text(source, encoding="utf-8")
+            map_path.write_text(apt_source_map_content(overrides), encoding="utf-8")
+            seen_path.touch()
+            completed = subprocess.run(
+                [
+                    "awk",
+                    "-v",
+                    f"map_file={map_path}",
+                    "-v",
+                    f"seen_file={seen_path}",
+                    "-v",
+                    f"source_kind={source_kind}",
+                    "-v",
+                    "display_file=/etc/apt/sources.list.d/test",
+                    "-f",
+                    str(APT_RUNTIME_ASSET_DIR / "source-rewriter.awk"),
+                    str(source_path),
+                ],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+        return completed.stdout, completed.stderr
+
+    def test_apt_source_overrides_normalize_trailing_slashes(self) -> None:
         overrides = parse_apt_source_overrides(
             json.dumps(
                 {
                     "https://packages.example.com/repository/": (
-                        "http://sources.internal/apt/vendor-repository/"
-                    ),
-                    "https://packages.example.com/signing-key.gpg": (
-                        "http://sources.internal/objects/vendor-key.gpg"
-                    ),
+                        "http://sources.internal/apt/vendor/"
+                    )
                 }
             ),
             "host",
@@ -659,380 +775,403 @@ networks:
             overrides,
             {
                 "https://packages.example.com/repository": (
-                    "http://sources.internal/apt/vendor-repository"
-                ),
-                "https://packages.example.com/signing-key.gpg": (
-                    "http://sources.internal/objects/vendor-key.gpg"
-                ),
-            },
-        )
-
-    def test_apt_source_overrides_require_unique_reverse_mappings(self) -> None:
-        with self.assertRaisesRegex(ValueError, "must be unique"):
-            parse_apt_source_overrides(
-                json.dumps(
-                    {
-                        "https://one.example/repository": "http://mirror/apt/shared",
-                        "https://two.example/repository": "http://mirror/apt/shared",
-                    }
-                ),
-                "host",
-            )
-
-    def test_apt_source_overrides_reject_cross_prefix_cascades(self) -> None:
-        with self.assertRaisesRegex(ValueError, "must not overlap"):
-            parse_apt_source_overrides(
-                json.dumps(
-                    {
-                        "https://upstream.example/repository": (
-                            "https://mirror.example/vendor"
-                        ),
-                        "https://mirror.example/vendor/key": (
-                            "https://other.example/key"
-                        ),
-                    }
-                ),
-                "host",
-            )
-
-    def test_apt_source_override_sed_prefers_the_longest_prefix(self) -> None:
-        overrides = {
-            "https://packages.example.com/repository": (
-                "http://sources.internal/apt/vendor-repository"
-            ),
-            "https://packages.example.com/repository/signing-key.gpg": (
-                "http://sources.internal/objects/vendor-key.gpg"
-            ),
-        }
-        expression = source_override_sed(overrides)
-        source = (
-            "https://packages.example.com/repository/signing-key.gpg\n"
-            "https://packages.example.com/repository/dists/stable\n"
-            "https://packages.example.com/repository-v2\n"
-        )
-        completed = subprocess.run(
-            ["sed", "-E", expression],
-            input=source,
-            capture_output=True,
-            check=True,
-            text=True,
-        )
-
-        self.assertEqual(
-            completed.stdout,
-            "http://sources.internal/objects/vendor-key.gpg\n"
-            "http://sources.internal/apt/vendor-repository/dists/stable\n"
-            "https://packages.example.com/repository-v2\n",
-        )
-
-    def test_render_preserves_debian_security_repository_path(self) -> None:
-        rendered = render_build_dockerfile(
-            "FROM python:3.13-slim-bookworm\nRUN apt-get update\n",
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://mirrors.tuna.tsinghua.edu.cn",
-        )
-        injected = injected_shell_runs(rendered)
-
-        self.assertEqual(len(injected), 2)
-        self.assertIn("debian\\.org/debian-security", injected[0][1])
-        self.assertIn(
-            "mirrors.tuna.tsinghua.edu.cn/debian-security/", injected[0][1]
-        )
-        self.assertIn("security.debian.org/debian-security/", injected[1][1])
-        self.assertNotIn("debian/-security", injected[0][1])
-
-    def test_render_routes_apt_for_internal_overlay_alias_stage(self) -> None:
-        rendered = render_build_dockerfile(
-            (
-                "FROM registry.internal/rebench/c@sha256:abc AS base\n"
-                "FROM base AS task\n"
-                "RUN <<-BUILD\n"
-                "\tapt-get update -qq\n"
-                "BUILD\n"
-            ),
-            dockerhub_mirror_prefix="registry.internal/public-mirror",
-            apt_mirror="http://apt-mirror.internal/repos",
-        )
-        injected = injected_shell_runs(rendered)
-
-        self.assertEqual(len(injected), 2)
-        self.assertIn("apt-mirror.internal/repos/ubuntu/", injected[0][1])
-        self.assertIn("apt-mirror.internal/repos/debian/", injected[0][1])
-        self.assertLess(
-            rendered.index(injected[0][0]), rendered.index("RUN <<-BUILD")
-        )
-        self.assertGreater(
-            rendered.index(injected[1][0]), rendered.index("RUN <<-BUILD")
-        )
-
-    def test_render_detects_apt_on_a_run_continuation(self) -> None:
-        rendered = render_build_dockerfile(
-            (
-                "FROM registry.internal/rebench/c@sha256:abc\n"
-                "RUN set -eux; \\\n"
-                "    apt-get update\n"
-            ),
-            dockerhub_mirror_prefix="registry.internal/public-mirror",
-            apt_mirror="http://apt-mirror.internal/repos",
-        )
-
-        injected = injected_shell_runs(rendered)
-        self.assertEqual(len(injected), 2)
-        self.assertLess(rendered.index(injected[0][0]), rendered.index("RUN set"))
-        self.assertGreater(
-            rendered.index(injected[1][0]), rendered.index("apt-get update")
-        )
-
-    def test_render_detects_exec_form_apt_run(self) -> None:
-        rendered = render_build_dockerfile(
-            'FROM ubuntu:24.04\nRUN ["apt-get", "update"]\n',
-            dockerhub_mirror_prefix="registry.internal/public-mirror",
-            apt_mirror="http://apt-mirror.internal/repos",
-        )
-
-        injected = injected_shell_runs(rendered)
-        self.assertEqual(len(injected), 2)
-        task_run_offset = rendered.index('RUN ["apt-get"')
-        self.assertLess(rendered.index(injected[0][0]), task_run_offset)
-        self.assertGreater(rendered.index(injected[1][0]), task_run_offset)
-
-    def test_render_detects_shell_wrapped_apt_runs(self) -> None:
-        for task_run in (
-            "RUN sh -c 'apt-get update'",
-            'RUN ["/bin/bash", "-lc", "apt-get update"]',
-        ):
-            with self.subTest(task_run=task_run):
-                rendered = render_build_dockerfile(
-                    f"FROM ubuntu:24.04\n{task_run}\n",
-                    dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-                    apt_mirror="http://apt-mirror.internal/repos",
-                )
-
-                injected = injected_shell_runs(rendered)
-                self.assertEqual(len(injected), 2)
-                task_run_offset = rendered.index(task_run)
-                self.assertLess(rendered.index(injected[0][0]), task_run_offset)
-                self.assertGreater(rendered.index(injected[1][0]), task_run_offset)
-
-    def test_render_refreshes_apt_sources_copied_after_stage_setup(self) -> None:
-        rendered = render_build_dockerfile(
-            (
-                "FROM ubuntu:24.04\n"
-                "COPY vendor.list /etc/apt/sources.list.d/vendor.list\n"
-                "RUN apt-get update\n"
-            ),
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos",
-            apt_source_overrides={
-                "https://packages.example/repository": (
                     "http://sources.internal/apt/vendor"
                 )
             },
         )
 
-        injected = injected_shell_runs(rendered)
-        self.assertEqual(len(injected), 4)
-        refresh_cleanup_line, refresh_cleanup = injected[1]
-        refresh_setup_line, refresh_setup = injected[2]
-        self.assertIn(r"sources\.internal/apt/vendor", refresh_cleanup)
-        self.assertIn("packages.example/repository", refresh_cleanup)
-        self.assertIn("sources.internal/apt/vendor", refresh_setup)
-        self.assertIn(r"packages\.example/repository", refresh_setup)
-        refresh_cleanup_offset = rendered.index(refresh_cleanup_line)
-        refresh_setup_offset = rendered.index(
-            refresh_setup_line,
-            refresh_cleanup_offset + len(refresh_cleanup_line),
-        )
-        self.assertLess(
-            rendered.index("COPY vendor.list"),
-            refresh_cleanup_offset,
-        )
-        self.assertLess(refresh_cleanup_offset, refresh_setup_offset)
-        self.assertLess(refresh_setup_offset, rendered.index("RUN apt-get"))
-        for _line, command in injected:
-            subprocess.run(["/bin/sh", "-n", "-c", command], check=True)
-
-    def test_render_refreshes_apt_sources_changed_by_an_earlier_run(self) -> None:
-        rendered = render_build_dockerfile(
-            (
-                "FROM ubuntu:24.04\n"
-                "RUN cp /tmp/vendor.list "
-                "/etc/apt/sources.list.d/vendor.list\n"
-                "RUN apt-get update\n"
+    def test_runtime_list_mapping_uses_longest_boundary_safe_prefix(self) -> None:
+        overrides = {
+            "https://apt.postgresql.org/pub/repos/apt": (
+                "http://gateway/apt/postgresql"
             ),
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos",
-        )
-
-        injected = injected_shell_runs(rendered)
-        self.assertEqual(len(injected), 4)
-        refresh_cleanup_offset = rendered.index(injected[1][0])
-        refresh_setup_offset = rendered.index(
-            injected[2][0], refresh_cleanup_offset + len(injected[1][0])
-        )
-        self.assertLess(rendered.index("RUN cp"), refresh_cleanup_offset)
-        self.assertLess(refresh_setup_offset, rendered.index("RUN apt-get"))
-
-    def test_render_does_not_refresh_after_unrelated_copy(self) -> None:
-        rendered = render_build_dockerfile(
-            (
-                "FROM ubuntu:24.04\n"
-                "COPY app /usr/local/bin/app\n"
-                "RUN apt-get update\n"
+            "https://download.docker.com": "http://gateway/apt/docker",
+            "https://download.docker.com/linux": (
+                "http://gateway/apt/docker-linux"
             ),
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos",
+            "https://packages.example/repo": "http://gateway/apt/packages",
+        }
+        source = (
+            "deb https://apt.postgresql.org/pub/repos/apt stable main\n"
+            "deb [arch=amd64 signed-by=/keys/docker.gpg] "
+            "https://download.docker.com/linux/ubuntu noble stable\n"
+            "deb https://download.docker.com/repository-other stable main\n"
+            "deb https://packages.example/repository-other stable main\n"
+            "deb http://gateway/apt/docker/linux/debian stable main\n"
+            "deb https://unmapped.example/repo stable main\n"
+            "deb https://unmapped.example/repo stable main\n"
+            "deb https://download.docker.com.evil/linux stable main\n"
+            "deb https://download.docker.com:8443/linux stable main\n"
+            "deb file:/srv/packages stable main\n"
+            "deb cdrom:[Debian GNU/Linux] stable main\n"
+            "# deb https://commented.example/repo stable main\n"
         )
 
-        self.assertEqual(len(injected_shell_runs(rendered)), 2)
+        rewritten, warnings = self.rewrite_apt_source(source, "list", overrides)
 
-    def test_render_does_not_inject_apt_routing_into_scratch_stage(self) -> None:
-        rendered = render_build_dockerfile(
-            "FROM scratch\nCOPY app /app\n",
-            dockerhub_mirror_prefix="registry.internal/public-mirror",
-            apt_mirror="http://apt-mirror.internal/repos",
+        self.assertIn("deb http://gateway/apt/postgresql stable main", rewritten)
+        self.assertIn(
+            "[arch=amd64 signed-by=/keys/docker.gpg] "
+            "http://gateway/apt/docker-linux/ubuntu noble stable",
+            rewritten,
         )
-
-        self.assertEqual(injected_shell_runs(rendered), [])
-
-    def test_render_restores_task_user_after_apt_cleanup(self) -> None:
-        rendered = render_build_dockerfile(
-            (
-                "FROM ubuntu:24.04\n"
-                "RUN apt-get update\n"
-                "USER node\n"
-                "CMD [\"node\"]\n"
-            ),
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos",
+        self.assertIn("http://gateway/apt/docker/repository-other", rewritten)
+        self.assertIn("https://packages.example/repository-other", rewritten)
+        self.assertIn("https://download.docker.com.evil/linux", rewritten)
+        self.assertIn("https://download.docker.com:8443/linux", rewritten)
+        self.assertIn("http://gateway/apt/docker/linux/debian", rewritten)
+        self.assertEqual(warnings.count("source=https://unmapped.example/repo"), 1)
+        self.assertIn(
+            "source=https://packages.example/repository-other", warnings
         )
+        self.assertIn("file=/etc/apt/sources.list.d/test", warnings)
+        self.assertIn("source=https://download.docker.com.evil/linux", warnings)
+        self.assertIn("source=https://download.docker.com:8443/linux", warnings)
+        self.assertNotIn("commented.example", warnings)
+        self.assertNotIn("source=file:", warnings)
+        self.assertNotIn("source=cdrom:", warnings)
+        self.assertNotIn("source=http://gateway", warnings)
 
-        lines = rendered.splitlines()
-        self.assertEqual(lines[-1], "USER node")
-        self.assertEqual(lines[-3], "USER root")
-        self.assertIn("rm -rf", json.loads(lines[-2].removeprefix("RUN "))[2])
-
-    def test_rendered_apt_setup_and_cleanup_are_valid_posix_shell(self) -> None:
-        rendered = render_build_dockerfile(
-            "FROM ubuntu:24.04\nRUN apt-get update\n",
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos",
+    def test_runtime_deb822_maps_multiple_uris_and_skips_disabled_stanza(self) -> None:
+        source = (
+            "Types: deb\n"
+            "URIs: https://one.example/repo https://two.example/base/child "
+            "file:/srv/packages\n"
+            "Suites: noble noble-updates\n"
+            "Components: main universe\n"
+            "Signed-By: /keys/example.gpg\n"
+            "\n"
+            "Types: deb\n"
+            "URIs: https://disabled.example/repo\n"
+            "Enabled: no\n"
         )
-
-        for _line, command in injected_shell_runs(rendered):
-            subprocess.run(["/bin/sh", "-n", "-c", command], check=True)
-        cleanup = injected_shell_runs(rendered)[-1][1]
-        self.assertIn("apt-get indextargets", cleanup)
-        self.assertIn("target-moves", cleanup)
-
-    def test_apt_source_restore_preserves_original_endpoints_after_append(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            original = root / "original.sources"
-            adapted = root / "adapted.sources"
-            current = root / "current.sources"
-            original.write_text(
-                "deb https://archive.ubuntu.com/ubuntu noble main\n"
-                "deb https://security.ubuntu.com/ubuntu noble-security main\n",
-                encoding="utf-8",
-            )
-            adapted.write_text(
-                "deb http://mirror.internal/ubuntu noble main\n"
-                "deb http://mirror.internal/ubuntu noble-security main\n",
-                encoding="utf-8",
-            )
-            current.write_text(
-                "deb http://mirror.internal/ubuntu noble main universe\n"
-                "deb http://mirror.internal/ubuntu noble-security main\n"
-                + "URIs: https://packages.example/repository\n",
-                encoding="utf-8",
-            )
-            expected = (
-                "deb https://archive.ubuntu.com/ubuntu noble main universe\n"
-                "deb https://security.ubuntu.com/ubuntu noble-security main\n"
-                + "URIs: https://packages.example/repository\n"
-            )
-            completed = subprocess.run(
-                [
-                    "awk",
-                    APT_SOURCE_RESTORE_AWK,
-                    str(original),
-                    str(adapted),
-                    str(current),
-                ],
-                capture_output=True,
-                check=True,
-                text=True,
-            )
-
-        self.assertEqual(
-            completed.stdout,
-            expected,
-        )
-
-    def test_render_escapes_sed_replacement_characters_in_mirror_url(self) -> None:
-        rendered = render_build_dockerfile(
-            "FROM ubuntu:24.04\nRUN apt-get update\n",
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos/a&b",
-        )
-        injected = injected_shell_runs(rendered)
-
-        self.assertIn(r"apt-mirror.internal/repos/a\&b/ubuntu", injected[0][1])
-
-    def test_render_does_not_rewrite_configured_source_in_runtime_environment(
-        self,
-    ) -> None:
-        rendered = render_build_dockerfile(
-            (
-                "FROM ubuntu:24.04\n"
-                "ENV DOCKER_REPO=https://download.docker.com/linux/ubuntu\n"
-                "RUN apt-get update\n"
-            ),
-            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos",
-            apt_source_overrides={
-                "https://download.docker.com": "http://sources.internal/apt/docker"
+        rewritten, warnings = self.rewrite_apt_source(
+            source,
+            "sources",
+            {
+                "https://one.example/repo": "http://gateway/apt/one",
+                "https://two.example/base": "http://gateway/apt/two",
             },
         )
 
         self.assertIn(
-            "ENV DOCKER_REPO=https://download.docker.com/linux/ubuntu",
-            rendered,
+            "URIs: http://gateway/apt/one http://gateway/apt/two/child",
+            rewritten,
+        )
+        self.assertIn("Suites: noble noble-updates", rewritten)
+        self.assertIn("Signed-By: /keys/example.gpg", rewritten)
+        self.assertIn("file:/srv/packages", rewritten)
+        self.assertNotIn("source=file:", warnings)
+        self.assertIn("URIs: https://disabled.example/repo", rewritten)
+        self.assertNotIn("disabled.example", warnings)
+
+    def test_renderer_gives_shell_runs_the_same_path_runtime(self) -> None:
+        source = (
+            "FROM ubuntu:24.04\n"
+            "RUN apt-get update\n"
+            "RUN apt install -y curl\n"
+            "RUN sh -c 'apt-get install -y git'\n"
+            "RUN printf '#!/bin/sh\\napt-get update\\n' >/tmp/install.sh "
+            "&& sh /tmp/install.sh\n"
+            "RUN python3 -c 'import subprocess; "
+            "subprocess.run([\"apt-get\", \"update\"], check=True)'\n"
+            "RUN [\"apt-get\", \"update\"]\n"
+            "RUN [\"/usr/bin/apt-get\", \"update\"]\n"
+        )
+        rendered = render_build_dockerfile(
+            source,
+            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
+            apt_mirror="http://gateway/apt",
         )
 
-    def test_render_routes_and_restores_configured_third_party_sources(self) -> None:
+        self.assertEqual(rendered.count("target=/run/opensandbox-apt/bin/apt,"), 5)
+        self.assertEqual(
+            rendered.count("target=/run/opensandbox-apt/bin/apt-get,"), 5
+        )
+        self.assertEqual(
+            rendered.count("export PATH=/run/opensandbox-apt/bin:$PATH;"), 5
+        )
+        self.assertIn('RUN ["apt-get", "update"]', rendered)
+        self.assertIn('RUN ["/usr/bin/apt-get", "update"]', rendered)
+        self.assertNotIn("run-with-apt-path\", \"apt-get", rendered)
+        self.assertNotIn("target=/usr/bin/apt", rendered)
+        self.assertNotIn("type=bind", rendered)
+
+    def test_renderer_preserves_multiline_exec_run_as_bypass(self) -> None:
         rendered = render_build_dockerfile(
             (
                 "FROM ubuntu:24.04\n"
-                "RUN curl -fsSL https://packages.example.com/signing-key.gpg "
-                "-o /tmp/vendor.gpg && "
-                "echo 'deb https://packages.example.com/repository stable main' "
-                "> /etc/apt/sources.list.d/vendor.list && apt-get update\n"
+                'RUN ["apt-get", \\\n'
+                '     "update"]\n'
             ),
             dockerhub_mirror_prefix="m.daocloud.io/docker.io",
-            apt_mirror="http://apt-mirror.internal/repos",
+            apt_mirror="http://gateway/apt",
+        )
+
+        self.assertIn('RUN ["apt-get", \\\n     "update"]', rendered)
+        self.assertNotIn("target=/run/opensandbox-apt", rendered)
+        self.assertNotIn("run-with-apt-path", rendered)
+        self.assertNotIn("export PATH=", rendered)
+
+    def test_renderer_preserves_all_run_options_before_shell_runtime(self) -> None:
+        rendered = render_build_dockerfile(
+            (
+                "FROM ubuntu:24.04\n"
+                "RUN --mount=type=cache,target=/tmp/cache "
+                "--network=none --security=sandbox "
+                "--device=nvidia.com/gpu=all echo hello\n"
+            ),
+            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
+            apt_mirror="http://gateway/apt",
+            github_mirror_config_mount_id="opensandbox-github-mirror-gitconfig",
+        )
+        run_line = next(
+            line for line in rendered.splitlines() if line.startswith("RUN ")
+        )
+
+        for option in (
+            "--mount=type=cache,target=/tmp/cache",
+            "--network=none",
+            "--security=sandbox",
+            "--device=nvidia.com/gpu=all",
+            "target=/etc/gitconfig,mode=0444,required=true",
+            "target=/run/opensandbox-apt/shadow",
+        ):
+            self.assertLess(run_line.index(option), run_line.index("export PATH="))
+        self.assertIn(
+            "export PATH=/run/opensandbox-apt/bin:$PATH; echo hello", run_line
+        )
+        self.assertNotIn("; --device=", run_line)
+
+    def test_runtime_path_is_mechanical_not_apt_detection(self) -> None:
+        rendered = render_build_dockerfile(
+            (
+                "FROM alpine:3.20\n"
+                "RUN echo no-package-manager-use\n"
+            ),
+            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
+            apt_mirror="http://gateway/apt",
+        )
+
+        self.assertIn(
+            "export PATH=/run/opensandbox-apt/bin:$PATH; "
+            "echo no-package-manager-use",
+            rendered,
+        )
+
+    def test_runtime_wrapper_assets_are_standalone_and_use_current_rootfs_apt(
+        self,
+    ) -> None:
+        wrapper = (APT_RUNTIME_ASSET_DIR / "apt-wrapper.sh").read_text(
+            encoding="utf-8"
+        )
+        runner = (APT_RUNTIME_ASSET_DIR / "run-with-apt-path.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("real=/usr/bin/$command_name", wrapper)
+        self.assertIn("Dir::Etc::SourceList=$source_view/sources.list", wrapper)
+        self.assertIn("event=index-reconciliation-failed", wrapper)
+        self.assertIn("indextargets --no-release-info", wrapper)
+        self.assertIn("event=unmapped-source", (
+            APT_RUNTIME_ASSET_DIR / "source-rewriter.awk"
+        ).read_text(encoding="utf-8"))
+        self.assertIn('${APT_CONFIG:-}', wrapper)
+        self.assertIn("*Dir::Etc=*", wrapper)
+        self.assertIn("PATH=/run/opensandbox-apt/bin:$PATH", runner)
+        self.assertNotIn("base-root", wrapper)
+
+    def test_runtime_preserves_authored_source_and_absolute_path_limitation(
+        self,
+    ) -> None:
+        rendered = render_build_dockerfile(
+            (
+                "FROM ubuntu:24.04\n"
+                "RUN echo 'deb https://packages.example/repo stable main' "
+                "> /etc/apt/sources.list.d/vendor.list && apt-get update\n"
+                "RUN /usr/bin/apt-get --version\n"
+            ),
+            dockerhub_mirror_prefix="m.daocloud.io/docker.io",
+            apt_mirror="http://gateway/apt",
             apt_source_overrides={
-                "https://packages.example.com/repository": (
-                    "http://sources.internal/apt/vendor-repository"
-                ),
-                "https://packages.example.com/signing-key.gpg": (
-                    "http://sources.internal/objects/vendor-key.gpg"
-                ),
+                "https://packages.example/repo": "http://gateway/apt/vendor"
             },
         )
-        injected = injected_shell_runs(rendered)
 
-        task_run = next(
-            line for line in rendered.splitlines() if "vendor.list" in line
+        self.assertIn(
+            "deb https://packages.example/repo stable main", rendered
         )
-        self.assertIn("sources.internal/apt/vendor-repository", task_run)
-        self.assertIn("sources.internal/objects/vendor-key.gpg", task_run)
-        self.assertNotIn("packages.example.com", task_run)
-        self.assertIn("packages.example.com/repository", injected[-1][1])
-        self.assertIn("packages.example.com/signing-key.gpg", injected[-1][1])
+        self.assertIn(
+            "export PATH=/run/opensandbox-apt/bin:$PATH; "
+            "/usr/bin/apt-get --version",
+            rendered,
+        )
+        self.assertNotIn(
+            "deb http://gateway/apt/vendor stable main", rendered
+        )
+
+    @unittest.skipUnless(
+        os.environ.get("RUN_OPENSANDBOX_APT_BUILD_TEST") == "1"
+        and shutil.which("docker"),
+        "set RUN_OPENSANDBOX_APT_BUILD_TEST=1 for the real BuildKit integration",
+    )
+    def test_runtime_path_wrapper_real_build(self) -> None:
+        base_image = os.environ.get(
+            "OPENSANDBOX_APT_TEST_BASE_IMAGE",
+            "harbor-sandbox.lg.shzhisuan.com/public-mirror/library/python:3.11-slim",
+        )
+        source = fr'''FROM {base_image}
+RUN cat <<'FAKE_APT' > /tmp/fake-apt
+#!/bin/sh
+shadow=
+parts=
+for argument in "$@"; do
+    case "$argument" in
+        Dir::Etc::SourceList=*) shadow=${{argument#*=}} ;;
+        Dir::Etc::SourceParts=*) parts=${{argument#*=}} ;;
+    esac
+done
+if [ -n "$parts" ] && grep -q 'deb http://cache.test/apt/vendor stable main' "$parts/runtime.list"; then
+    state=shadow-cache
+    index_path=/var/lib/apt/lists/cache.test_apt_vendor_dists_stable_main_binary-amd64_Packages
+    release_path=/var/lib/apt/lists/cache.test_apt_vendor_dists_stable
+else
+    state=no-shadow
+    index_path=/var/lib/apt/lists/example.test_repo_dists_stable_main_binary-amd64_Packages
+    release_path=/var/lib/apt/lists/example.test_repo_dists_stable
+fi
+case " $* " in
+    *" indextargets "*)
+        key="$parts/runtime.list:1~Packages~stable~main~amd64~Packages~main/binary-amd64/Packages"
+        printf '%s|main|%s\n' "$key" "$index_path"
+        exit 0
+        ;;
+    *" update "*)
+        mkdir -p /var/lib/apt/lists
+        printf 'package-index\n' > "$index_path.lz4"
+        for release_file in InRelease Release Release.gpg; do
+            printf '%s\n' "$release_file" > "${{release_path}}_${{release_file}}"
+        done
+        ;;
+esac
+if [ -n "$parts" ]; then cat "$parts/runtime.list" >> /tmp/apt-shadow-observed; fi
+printf '%s %s args=%s\n' "${{0##*/}}" "$state" "$*" >> /tmp/apt-calls
+FAKE_APT
+RUN chmod +x /tmp/fake-apt && cp /tmp/fake-apt /usr/bin/apt-get && cp /tmp/fake-apt /usr/bin/apt
+RUN printf '%s\n' 'deb https://example.test/repo stable main' > /etc/apt/sources.list.d/runtime.list && apt-get update
+RUN apt update
+RUN apt install package
+RUN sh -c 'apt-get install package'
+RUN printf '#!/bin/sh\napt-get update\n' > /tmp/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh
+RUN python3 -c 'import subprocess; subprocess.run(["apt-get", "update"], check=True)'
+RUN APT_CONFIG=/tmp/custom-apt.conf apt-get env-config-bypass
+RUN apt-get -o Dir::Etc=/tmp/custom-apt cli-layout-bypass
+RUN ["apt-get", "exec-form-bypass"]
+RUN /usr/bin/apt-get absolute-path
+RUN cat /tmp/apt-calls && cat /tmp/apt-shadow-observed && test "$(grep -c 'shadow-cache' /tmp/apt-calls)" -eq 6 && test "$(grep -c 'no-shadow' /tmp/apt-calls)" -eq 4 && grep -q 'args=env-config-bypass' /tmp/apt-calls && grep -q 'args=-o Dir::Etc=/tmp/custom-apt cli-layout-bypass' /tmp/apt-calls && grep -q 'args=exec-form-bypass' /tmp/apt-calls && grep -q 'args=absolute-path' /tmp/apt-calls && grep -q 'deb https://example.test/repo stable main' /etc/apt/sources.list.d/runtime.list && test -f /var/lib/apt/lists/example.test_repo_dists_stable_main_binary-amd64_Packages.lz4 && test -f /var/lib/apt/lists/example.test_repo_dists_stable_InRelease && test -f /var/lib/apt/lists/example.test_repo_dists_stable_Release && test -f /var/lib/apt/lists/example.test_repo_dists_stable_Release.gpg
+'''
+        rendered = render_build_dockerfile(
+            source,
+            dockerhub_mirror_prefix="",
+            apt_mirror="http://cache.test/apt",
+            apt_source_overrides={
+                "https://example.test/repo": "http://cache.test/apt/vendor"
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dockerfile = root / "Dockerfile"
+            dockerfile.write_text(rendered, encoding="utf-8")
+            runtime_overrides = apt_runtime_source_overrides(
+                "http://cache.test/apt",
+                {
+                    "https://example.test/repo": (
+                        "http://cache.test/apt/vendor"
+                    )
+                },
+            )
+            log_path = root / "build.log"
+            try:
+                run_build(
+                    environment_dir=root,
+                    dockerfile=dockerfile,
+                    archive_path=root / "image.oci.tar",
+                    log_path=log_path,
+                    platform="linux/amd64",
+                    timeout_sec=180,
+                    build_args={},
+                    secret_files=materialize_apt_runtime_assets(
+                        root / "apt-runtime", runtime_overrides
+                    ),
+                )
+            except RuntimeError as exc:
+                self.fail(f"{exc}\n{log_path.read_text(encoding='utf-8')}")
+
+            with tarfile.open(root / "image.oci.tar", "r") as archive:
+                _manifest, descriptors = schema2_manifest(archive)
+                for descriptor in descriptors[1:]:
+                    digest = str(descriptor["digest"]).split(":", 1)[1]
+                    layer = archive.extractfile(f"blobs/sha256/{digest}")
+                    self.assertIsNotNone(layer)
+                    with tarfile.open(fileobj=layer, mode="r|*") as layer_archive:
+                        self.assertFalse(
+                            any(
+                                member.name.lstrip("./").startswith(
+                                    "run/opensandbox-apt"
+                                )
+                                for member in layer_archive
+                            )
+                        )
+
+    @unittest.skipUnless(
+        os.environ.get("RUN_OPENSANDBOX_APT_BUILD_TEST") == "1"
+        and shutil.which("docker"),
+        "set RUN_OPENSANDBOX_APT_BUILD_TEST=1 for the real BuildKit integration",
+    )
+    def test_runtime_update_indexes_work_with_original_sources(self) -> None:
+        base_image = os.environ.get(
+            "OPENSANDBOX_APT_TEST_BASE_IMAGE",
+            "harbor-sandbox.lg.shzhisuan.com/public-mirror/library/python:3.11-slim",
+        )
+        original_repo = "http://original.invalid:18765/repo"
+        runtime_repo = "http://127.0.0.1:18765/repo"
+        source = f"FROM {base_image}\n" + r'''RUN rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources && printf '%s\n' 'deb [trusted=yes] http://original.invalid:18765/repo ./' > /etc/apt/sources.list.d/probe.list
+RUN mkdir -p /tmp/apt-repo/repo && printf 'Package: opensandbox-index-probe\nVersion: 1.0\nArchitecture: all\nMaintainer: OpenSandbox Test <noreply@example.invalid>\nFilename: pool/probe.deb\nSize: 0\nMD5sum: d41d8cd98f00b204e9800998ecf8427e\nSHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nDescription: index reconciliation probe\n\n' > /tmp/apt-repo/repo/Packages; python3 -m http.server 18765 --bind 127.0.0.1 --directory /tmp/apt-repo >/tmp/apt-http.log 2>&1 & server=$!; trap 'kill "$server" 2>/dev/null || :' EXIT; ready=0; for attempt in 1 2 3 4 5 6 7 8 9 10; do if python3 -c 'import socket; socket.create_connection(("127.0.0.1", 18765), 0.2).close()'; then ready=1; break; fi; sleep 0.2; done; test "$ready" -eq 1; apt-get update
+RUN ["/bin/sh", "-c", "grep -F 'deb [trusted=yes] http://original.invalid:18765/repo ./' /etc/apt/sources.list.d/probe.list && test ! -e /run/opensandbox-apt/bin/apt-get && apt-cache policy opensandbox-index-probe | grep -F '1.0'"]
+'''
+        rendered = render_build_dockerfile(
+            source,
+            dockerhub_mirror_prefix="",
+            apt_mirror="http://cache.test/apt",
+            apt_source_overrides={original_repo: runtime_repo},
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dockerfile = root / "Dockerfile"
+            dockerfile.write_text(rendered, encoding="utf-8")
+            log_path = root / "build.log"
+            try:
+                run_build(
+                    environment_dir=root,
+                    dockerfile=dockerfile,
+                    archive_path=root / "image.oci.tar",
+                    log_path=log_path,
+                    platform="linux/amd64",
+                    timeout_sec=180,
+                    build_args={},
+                    secret_files=materialize_apt_runtime_assets(
+                        root / "apt-runtime",
+                        apt_runtime_source_overrides(
+                            "http://cache.test/apt",
+                            {original_repo: runtime_repo},
+                        ),
+                    ),
+                )
+            except RuntimeError as exc:
+                self.fail(f"{exc}\n{log_path.read_text(encoding='utf-8')}")
+
 
     def test_render_does_not_guess_unconfigured_third_party_sources(self) -> None:
         rendered = render_build_dockerfile(
@@ -1046,7 +1185,7 @@ networks:
 
         self.assertIn("https://packages.example.com/key.gpg", rendered)
 
-    def test_render_routes_override_only_opaque_stage_without_apt_setup(
+    def test_render_rewrites_object_fetch_in_opaque_stage(
         self,
     ) -> None:
         rendered = render_build_dockerfile(
@@ -1062,9 +1201,6 @@ networks:
                 )
             },
         )
-        injected = injected_shell_runs(rendered)
-
-        self.assertEqual(injected, [])
         self.assertIn("sources.internal/objects/vendor-setup.sh", rendered)
 
     def test_render_does_not_rewrite_url_persisted_outside_apt(self) -> None:
@@ -1085,9 +1221,7 @@ networks:
             },
         )
 
-        task_run = next(
-            line for line in rendered.splitlines() if line.startswith("RUN curl")
-        )
+        task_run = next(line for line in rendered.splitlines() if "curl" in line)
         self.assertIn(
             "curl -fsSL http://sources.internal/apt/vendor", task_run
         )
@@ -1097,7 +1231,6 @@ networks:
         self.assertNotIn(
             "printf %s http://sources.internal/apt/vendor", task_run
         )
-        self.assertEqual(injected_shell_runs(rendered), [])
 
     def test_render_rewrites_exec_form_fetch_source_override(self) -> None:
         rendered = render_build_dockerfile(
@@ -1117,7 +1250,6 @@ networks:
 
         self.assertIn("http://sources.internal/objects/key", rendered)
         self.assertNotIn("https://packages.example/key", rendered)
-        self.assertEqual(injected_shell_runs(rendered), [])
 
     def test_render_preserves_exec_form_non_fetch_url_data(self) -> None:
         rendered = render_build_dockerfile(
@@ -1138,7 +1270,7 @@ networks:
         self.assertIn("https://packages.example/repository", rendered)
         self.assertNotIn("http://sources.internal/apt/vendor", rendered)
 
-    def test_render_does_not_rewrite_apt_source_without_apt_run(self) -> None:
+    def test_render_never_rewrites_authored_apt_source(self) -> None:
         rendered = render_build_dockerfile(
             (
                 "FROM ubuntu:24.04\n"
@@ -1156,9 +1288,8 @@ networks:
 
         self.assertIn("https://packages.example/repository", rendered)
         self.assertNotIn("http://sources.internal/apt/vendor", rendered)
-        self.assertEqual(injected_shell_runs(rendered), [])
 
-    def test_render_does_not_treat_other_apt_paths_as_restorable_sources(
+    def test_render_does_not_rewrite_non_source_apt_files(
         self,
     ) -> None:
         rendered = render_build_dockerfile(
@@ -1229,22 +1360,17 @@ networks:
                 ),
             },
         )
-        injected = injected_shell_runs(rendered)
-
         self.assertIn(
             "curl -fsSL http://sources.internal/objects/bazel-key.gpg",
             rendered,
         )
         self.assertIn(
-            "deb http://sources.internal/apt/bazel stable main", rendered
+            "deb https://packages.example/bazel stable main", rendered
         )
         self.assertIn("DOCKER_RUN_EOF\n", rendered)
-        self.assertIn(
-            "https://bazel.example/signing-key.gpg", injected[-1][1]
-        )
-        self.assertIn("https://packages.example/bazel", injected[-1][1])
+        self.assertNotIn("target=/usr/bin/apt", rendered)
 
-    def test_render_routes_override_only_run_heredoc_without_apt_setup(
+    def test_render_rewrites_object_fetch_in_command_heredoc(
         self,
     ) -> None:
         rendered = render_build_dockerfile(
@@ -1267,7 +1393,6 @@ networks:
             "curl -fsSL http://sources.internal/objects/setup.sh | sh",
             rendered,
         )
-        self.assertEqual(injected_shell_runs(rendered), [])
 
     def test_render_preserves_source_override_in_persisted_run_heredoc(
         self,
@@ -1293,7 +1418,6 @@ networks:
             "curl -fsSL https://packages.example/setup.sh | sh", rendered
         )
         self.assertNotIn("sources.internal/objects/setup.sh", rendered)
-        self.assertEqual(injected_shell_runs(rendered), [])
 
     def test_render_rewrites_source_override_in_shell_command_heredoc(
         self,
@@ -1320,7 +1444,7 @@ networks:
         )
         self.assertNotIn("https://packages.example/setup.sh", rendered)
 
-    def test_render_rewrites_apt_source_data_heredoc_for_build_only(
+    def test_render_preserves_apt_source_data_heredoc(
         self,
     ) -> None:
         rendered = render_build_dockerfile(
@@ -1341,16 +1465,12 @@ networks:
         )
 
         task_heredoc = rendered[
-            rendered.index("RUN cat <<'EOF'") : rendered.index("EOF\n")
+            rendered.index("cat <<'EOF'") : rendered.index("EOF\n")
         ]
-        self.assertIn("sources.internal/apt/vendor", task_heredoc)
-        self.assertNotIn("packages.example/repository", task_heredoc)
-        self.assertIn(
-            "https://packages.example/repository",
-            injected_shell_runs(rendered)[-1][1],
-        )
+        self.assertIn("packages.example/repository", task_heredoc)
+        self.assertNotIn("sources.internal/apt/vendor", task_heredoc)
 
-    def test_persisted_run_heredoc_does_not_mark_stage_as_apt(self) -> None:
+    def test_persisted_script_content_is_not_statically_inspected(self) -> None:
         rendered = render_build_dockerfile(
             (
                 "FROM registry.internal/opaque:latest\n"
@@ -1363,7 +1483,8 @@ networks:
             apt_mirror="http://apt-mirror.internal/repos",
         )
 
-        self.assertEqual(injected_shell_runs(rendered), [])
+        self.assertIn("apt-get update", rendered)
+        self.assertIn("export PATH=/run/opensandbox-apt/bin:$PATH;", rendered)
 
     def test_render_does_not_rewrite_configured_source_inside_copy_heredoc(
         self,


### PR DESCRIPTION
## 1. Why the change?

Static Dockerfile analysis cannot reliably detect APT usage in nested shells, downloaded scripts, or subprocesses, and requires complex source mutation tracking and cleanup.

## 2. Summary of the change

- Replaced static APT analysis with build-time PATH wrappers for shell-form `RUN`.
- Rewrites invocation-time sources in an ephemeral shadow tree without modifying `/etc/apt`.
- Reconciles successful APT updates back to the original source identity.
- Preserves RUN options such as `--device` and keeps Git mirror mounts independent.
- Fixed image identity to use only the static task environment hash. Renderer/runtime mutations are documented as forbidden identity inputs and P0 bugs.

## 3. Other details

JSON exec-form APT calls, absolute `/usr/bin/apt*` paths, and custom libapt frontends intentionally bypass interception. Runtime assets are BuildKit-only and do not enter the final image.