### PR TITLE
Fix SWE-rebench-v2 builds for migrated upstream repositories

### DIFF
--- a/Tasks/SWE-rebench-v2/src/swe_rebench_v2/environment.py
+++ b/Tasks/SWE-rebench-v2/src/swe_rebench_v2/environment.py
@@ -18,6 +18,78 @@ CLONE_REPOSITORY_OVERRIDES = {
         "absmach/supermq",
         "1c0400d3a58409d4148d2f3cd7befd279dd97a42",
     ): "absmach/magistrala",
+    # GitHub no longer redirects the deleted petermattis/pebble path. The
+    # migrated CockroachDB repository retains these exact dataset commits.
+    (
+        "petermattis/pebble",
+        "b9be2e7eb20c3b1c04ae5760527dde2a44b3b096",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "4d7ef68ab4c9a0154948e449a185c651fc66ab9c",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "8706ee31debea13e12a82d76bae045aa863447a1",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "2d51c6eb4acc92c40b5a9dc1e518b1035ecd73ef",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "48370d7d34df112c1c8baab25299028f799257c2",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "a7ffd710039b20ac758accaf6e1d2038fe0459ab",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "965163f446adf7122c4a0a129f4d4a19cbd93c94",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "2451b8431268ebfaa39a7d6328e3ec8ae979a072",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "4aeaa2d922ed9243f500bdacec32ff4ca0b2f8ed",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "4c511ec1d202805a4c9727010a543cd763a96a3c",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "0c1c913d7f4719701317fd793861c4660562bb0f",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "fcb9ed13025a2407eb66dd0bc6b370868b52cc17",
+    ): "cockroachdb/pebble",
+    (
+        "petermattis/pebble",
+        "53f7531cb726299eb33b5849ae6935501f357442",
+    ): "cockroachdb/pebble",
+    # The deleted rickbergfalk/sqlpad path likewise has no GitHub redirect;
+    # sqlpad/sqlpad retains each exact commit used by the dataset.
+    (
+        "rickbergfalk/sqlpad",
+        "ba30b4e247a91327568b93dfb84bc0a7af2c8fc9",
+    ): "sqlpad/sqlpad",
+    (
+        "rickbergfalk/sqlpad",
+        "ff34735a1b681743a6a74b5598bfa4607666f46c",
+    ): "sqlpad/sqlpad",
+    (
+        "rickbergfalk/sqlpad",
+        "b6e793cff3d4c2f7b7458ba5a5b312b3204a062d",
+    ): "sqlpad/sqlpad",
+    (
+        "rickbergfalk/sqlpad",
+        "edd6efb03a3745dbf80e226ee7fc050c4f2c2d29",
+    ): "sqlpad/sqlpad",
 }
 
 # The published dataset names this base ``php:8.3.16``, which selects the

--- a/Tasks/SWE-rebench-v2/tests/test_adapter.py
+++ b/Tasks/SWE-rebench-v2/tests/test_adapter.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 import tomllib
 from swe_rebench_v2.adapter import SWERebenchV2Adapter
+from swe_rebench_v2.environment import CLONE_REPOSITORY_OVERRIDES
 from swe_rebench_v2.loader import LocalDatasetLoader
 
 
@@ -231,12 +232,24 @@ def test_archived_supermq_repository_clones_merged_magistrala_history(
     assert metadata["base_commit"] == record["base_commit"]
 
 
-def test_repository_override_is_limited_to_verified_commit(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("source_repo", "base_commit", "clone_repo"),
+    [(*key, clone_repo) for key, clone_repo in CLONE_REPOSITORY_OVERRIDES.items()],
+    ids=lambda value: value[:12] if len(value) == 40 else value,
+)
+def test_repository_overrides_preserve_task_identity_and_verified_commit(
+    tmp_path: Path,
+    source_repo: str,
+    base_commit: str,
+    clone_repo: str,
+) -> None:
+    project = source_repo.rsplit("/", 1)[-1]
     record = _record()
     record.update(
         {
-            "instance_id": "absmach__supermq-other",
-            "repo": "absmach/supermq",
+            "instance_id": f"{source_repo.replace('/', '__')}-verified",
+            "repo": source_repo,
+            "base_commit": base_commit,
         }
     )
     adapter = SWERebenchV2Adapter(tmp_path, source="sample.json")
@@ -244,8 +257,48 @@ def test_repository_override_is_limited_to_verified_commit(tmp_path: Path) -> No
     task_dir, _ = adapter.generate_task(record)
 
     dockerfile = (task_dir / "environment" / "Dockerfile").read_text()
-    assert "https://github.com/absmach/supermq /supermq;" in dockerfile
-    assert "https://github.com/absmach/magistrala" not in dockerfile
+    expected_clone = (
+        f"git clone -o origin https://github.com/{clone_repo} /{project};"
+    )
+    assert expected_clone in dockerfile
+    assert f"git cat-file -e '{base_commit}^{{commit}}'" in dockerfile
+    assert f"git fetch --no-tags origin '{base_commit}';" in dockerfile
+    assert f"git reset --hard {base_commit};" in dockerfile
+    assert dockerfile.endswith(f"WORKDIR /{project}\n")
+
+    metadata = json.loads((task_dir / "tests" / "config.json").read_text())
+    assert metadata["repo"] == source_repo
+    assert metadata["base_commit"] == base_commit
+
+
+@pytest.mark.parametrize(
+    ("source_repo", "clone_repo"),
+    [
+        ("absmach/supermq", "absmach/magistrala"),
+        ("petermattis/pebble", "cockroachdb/pebble"),
+        ("rickbergfalk/sqlpad", "sqlpad/sqlpad"),
+    ],
+)
+def test_repository_override_is_limited_to_verified_commit(
+    tmp_path: Path,
+    source_repo: str,
+    clone_repo: str,
+) -> None:
+    project = source_repo.rsplit("/", 1)[-1]
+    record = _record()
+    record.update(
+        {
+            "instance_id": f"{source_repo.replace('/', '__')}-other",
+            "repo": source_repo,
+        }
+    )
+    adapter = SWERebenchV2Adapter(tmp_path, source="sample.json")
+
+    task_dir, _ = adapter.generate_task(record)
+
+    dockerfile = (task_dir / "environment" / "Dockerfile").read_text()
+    assert f"https://github.com/{source_repo} /{project};" in dockerfile
+    assert f"https://github.com/{clone_repo}" not in dockerfile
 
 
 def test_task_config_matches_current_harbor_schema(tmp_path: Path) -> None:


### PR DESCRIPTION
## 1. Why the change?

  Several SWE-rebench-v2 tasks reference GitHub repositories that have moved without redirects. Their original repository URLs now return 404, causing environment builds to fail before task setup begins.

  The canonical Pebble and SQLPad repositories retain the exact commits required by the dataset, so these tasks can be recovered without changing their baseline or evaluation semantics.

  ## 2. Summary of the change

  - Adds commit-scoped repository overrides:
      - petermattis/pebble → cockroachdb/pebble
      - rickbergfalk/sqlpad → sqlpad/sqlpad

  - Applies an override only to dataset commits verified to exist in the canonical repository.
  - Preserves the original repository name, commit, checkout directory, and task metadata.